### PR TITLE
修复某些TS流粘帧问题

### DIFF
--- a/src/Common/MediaSink.h
+++ b/src/Common/MediaSink.h
@@ -87,6 +87,19 @@ public:
      * 重置track
      */
     void resetTracks() override;
+    /**
+    * 返回是否track已经准备完成
+    */
+    bool isTrackReady(TrackType type){
+        if(_all_track_ready){
+            return true;
+        }
+        auto it = _track_map.find(type);
+        if (it == _track_map.end()) {
+            return false;
+        }
+        return it->second->ready();
+    }
 
     /**
      * 获取所有Track

--- a/src/Extension/Frame.cpp
+++ b/src/Extension/Frame.cpp
@@ -276,6 +276,10 @@ bool FrameMerger::shouldDrop(const Frame::Ptr &frame) const{
 bool FrameMerger::frameCacheHasVCL(List<Frame::Ptr> &frameCached) const {
     bool hasVCL = false;
     bool isH264OrH265 = false;
+    if(_type == none){
+        // 因为可能存在粘帧, 所以等待后续split
+        return true;
+    }
     frameCached.for_each([&hasVCL, &isH264OrH265](const Frame::Ptr &frame) {
         switch (frame->getCodecId()) {
             case CodecH264: {

--- a/src/Extension/H264.cpp
+++ b/src/Extension/H264.cpp
@@ -181,6 +181,7 @@ void H264Track::inputFrame_l(const Frame::Ptr &frame){
             _pps = string(frame->data() + frame->prefixSize(), frame->size() - frame->prefixSize());
             break;
         }
+        case H264Frame::NAL_SEI:
         case H264Frame::NAL_AUD: {
             //忽略AUD帧;
             break;

--- a/src/Http/HlsPlayer.cpp
+++ b/src/Http/HlsPlayer.cpp
@@ -119,6 +119,10 @@ void HlsPlayer::onParsed(bool is_m3u8_inner,int64_t sequence,const map<int,ts_se
             return;
         }
         _last_sequence = sequence;
+//        if(!ts_map.empty()&& _ts_url_sort.empty() && _ts_list.empty() && !_ts_url_cache.empty()){
+//            _ts_url_cache.clear();
+//            _ts_url_sort.clear();
+//        }
         for (auto &pr : ts_map) {
             auto &ts = pr.second;
             if (_ts_url_cache.emplace(ts.url).second) {
@@ -302,7 +306,11 @@ void HlsPlayerImp::inputFrame(const Frame::Ptr &frame) {
     _stamp[frame->getTrackType()].revise(frame->dts(), frame->pts(), dts, pts);
     //根据时间戳缓存frame
     _frame_cache.emplace(dts, Frame::getCacheAbleFrame(frame));
-
+    if(!MediaSink::isTrackReady(frame->getTrackType())){
+        MediaSink::inputFrame(Frame::getCacheAbleFrame(frame));
+        return;
+    }
+//    WarnL << "缓存时间[" << getBufferMS() << "]";
     if (getBufferMS() > 30 * 1000) {
         //缓存超过30秒，强制消费至15秒(减少延时或内存占用)
         while (getBufferMS() > 15 * 1000) {

--- a/src/Rtp/Decoder.cpp
+++ b/src/Rtp/Decoder.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2016 The ZLMediaKit project authors. All Rights Reserved.
  *
  * This file is part of ZLMediaKit(https://github.com/xia-chu/ZLMediaKit).
@@ -146,16 +146,31 @@ void DecoderImp::onStream(int stream, int codecid, const void *extra, size_t byt
 void DecoderImp::onDecode(int stream,int codecid,int flags,int64_t pts,int64_t dts,const void *data,size_t bytes) {
     pts /= 90;
     dts /= 90;
-
+    using H264FrameInternal = FrameInternal<H264FrameNoCacheAble>;
     switch (codecid) {
         case PSI_STREAM_H264: {
             if (!_tracks[TrackVideo]) {
                 onTrack(std::make_shared<H264Track>());
             }
             auto frame = std::make_shared<H264FrameNoCacheAble>((char *) data, bytes, (uint32_t)dts, (uint32_t)pts, prefixSize((char *) data, bytes));
-            _merger.inputFrame(frame,[this](uint32_t dts, uint32_t pts, const Buffer::Ptr &buffer, bool) {
-                onFrame(std::make_shared<FrameWrapper<H264FrameNoCacheAble> >(buffer, dts, pts, prefixSize(buffer->data(), buffer->size()), 0));
-            });
+            int type = H264_TYPE(*((uint8_t *) frame->data() + frame->prefixSize()));
+            if (type == H264Frame::NAL_SEI || type == H264Frame::NAL_AUD) {
+                //非I/B/P帧情况下，split一下，防止多个帧粘合在一起
+                splitH264(frame->data(), frame->size(), frame->prefixSize(), [&](const char *ptr, size_t len, size_t prefix) {
+//                    auto sub_frame = std::make_shared<H264FrameNoCacheAble>((char *) ptr, len, (uint32_t)dts, (uint32_t)pts, prefix);
+                    H264FrameInternal::Ptr sub_frame = std::make_shared<H264FrameInternal>(frame, (char *) ptr, len, prefix);
+                    _merger.inputFrame(sub_frame,[this](uint32_t dts, uint32_t pts, const Buffer::Ptr &buffer, bool) {
+                        onFrame(std::make_shared<FrameWrapper<H264FrameNoCacheAble> >(buffer, dts, pts, prefixSize(buffer->data(), buffer->size()), 0));
+                    });
+                });
+            } else {
+                _merger.inputFrame(frame,[this](uint32_t dts, uint32_t pts, const Buffer::Ptr &buffer, bool) {
+                    onFrame(std::make_shared<FrameWrapper<H264FrameNoCacheAble> >(buffer, dts, pts, prefixSize(buffer->data(), buffer->size()), 0));
+                });
+            }
+//            _merger.inputFrame(frame,[this](uint32_t dts, uint32_t pts, const Buffer::Ptr &buffer, bool) {
+//                onFrame(std::make_shared<FrameWrapper<H264FrameNoCacheAble> >(buffer, dts, pts, prefixSize(buffer->data(), buffer->size()), 0));
+//            });
             break;
         }
 

--- a/src/Rtp/Decoder.cpp
+++ b/src/Rtp/Decoder.cpp
@@ -146,31 +146,15 @@ void DecoderImp::onStream(int stream, int codecid, const void *extra, size_t byt
 void DecoderImp::onDecode(int stream,int codecid,int flags,int64_t pts,int64_t dts,const void *data,size_t bytes) {
     pts /= 90;
     dts /= 90;
-    using H264FrameInternal = FrameInternal<H264FrameNoCacheAble>;
     switch (codecid) {
         case PSI_STREAM_H264: {
             if (!_tracks[TrackVideo]) {
                 onTrack(std::make_shared<H264Track>());
             }
             auto frame = std::make_shared<H264FrameNoCacheAble>((char *) data, bytes, (uint32_t)dts, (uint32_t)pts, prefixSize((char *) data, bytes));
-            int type = H264_TYPE(*((uint8_t *) frame->data() + frame->prefixSize()));
-            if (type == H264Frame::NAL_SEI || type == H264Frame::NAL_AUD) {
-                //非I/B/P帧情况下，split一下，防止多个帧粘合在一起
-                splitH264(frame->data(), frame->size(), frame->prefixSize(), [&](const char *ptr, size_t len, size_t prefix) {
-//                    auto sub_frame = std::make_shared<H264FrameNoCacheAble>((char *) ptr, len, (uint32_t)dts, (uint32_t)pts, prefix);
-                    H264FrameInternal::Ptr sub_frame = std::make_shared<H264FrameInternal>(frame, (char *) ptr, len, prefix);
-                    _merger.inputFrame(sub_frame,[this](uint32_t dts, uint32_t pts, const Buffer::Ptr &buffer, bool) {
-                        onFrame(std::make_shared<FrameWrapper<H264FrameNoCacheAble> >(buffer, dts, pts, prefixSize(buffer->data(), buffer->size()), 0));
-                    });
-                });
-            } else {
-                _merger.inputFrame(frame,[this](uint32_t dts, uint32_t pts, const Buffer::Ptr &buffer, bool) {
-                    onFrame(std::make_shared<FrameWrapper<H264FrameNoCacheAble> >(buffer, dts, pts, prefixSize(buffer->data(), buffer->size()), 0));
-                });
-            }
-//            _merger.inputFrame(frame,[this](uint32_t dts, uint32_t pts, const Buffer::Ptr &buffer, bool) {
-//                onFrame(std::make_shared<FrameWrapper<H264FrameNoCacheAble> >(buffer, dts, pts, prefixSize(buffer->data(), buffer->size()), 0));
-//            });
+            _merger.inputFrame(frame,[this](uint32_t dts, uint32_t pts, const Buffer::Ptr &buffer, bool) {
+                onFrame(std::make_shared<FrameWrapper<H264FrameNoCacheAble> >(buffer, dts, pts, prefixSize(buffer->data(), buffer->size()), 0));
+            });
             break;
         }
 


### PR DESCRIPTION
有些TS流会粘帧, 需要先进行split处理, 否则多个NAL单元粘在一起时, 很有可能第一个NAL单元是NAL_SEI或者NAL_AUD, 从而导致直接丢掉多个帧.

#954 