### PR TITLE
fix publish type

### DIFF
--- a/src/Rtmp/RtmpPusher.cpp
+++ b/src/Rtmp/RtmpPusher.cpp
@@ -173,9 +173,10 @@ inline void RtmpPusher::send_createStream() {
     });
 }
 
+#define RTMP_STREAM_LIVE    "live"
 inline void RtmpPusher::send_publish() {
     AMFEncoder enc;
-    enc << "publish" << ++_send_req_id << nullptr << _stream_id << _app;
+    enc << "publish" << ++_send_req_id << nullptr << _stream_id << RTMP_STREAM_LIVE;
     sendRequest(MSG_CMD, enc.data());
 
     addOnStatusCB([this](AMFValue &val) {


### PR DESCRIPTION
rtmp publish 最后一个字段应该为publishType,而不是 appname. 实测rtmp://a.rtmp.youtube.com/live2/xxxx-xxxx-xxxx-xxxx-xxxx类型的url,推流相关publishType字段会变为live2.
参考url:[publish推流](https://blog.csdn.net/mlfcjob/article/details/106221645)
