### PR TITLE
去除非第三方库的编译告警

### DIFF
--- a/api/include/mk_media.h
+++ b/api/include/mk_media.h
@@ -75,7 +75,7 @@ API_EXPORT void API_CALL mk_media_init_complete(mk_media ctx);
  * @param dts 解码时间戳，单位毫秒
  * @param pts 播放时间戳，单位毫秒
  */
-API_EXPORT void API_CALL mk_media_input_h264(mk_media ctx, void *data, int len, uint32_t dts, uint32_t pts);
+API_EXPORT void API_CALL mk_media_input_h264(mk_media ctx, const void *data, int len, uint32_t dts, uint32_t pts);
 
 /**
  * 输入单帧H265视频，帧起始字节00 00 01,00 00 00 01均可
@@ -85,7 +85,7 @@ API_EXPORT void API_CALL mk_media_input_h264(mk_media ctx, void *data, int len, 
  * @param dts 解码时间戳，单位毫秒
  * @param pts 播放时间戳，单位毫秒
  */
-API_EXPORT void API_CALL mk_media_input_h265(mk_media ctx, void *data, int len, uint32_t dts, uint32_t pts);
+API_EXPORT void API_CALL mk_media_input_h265(mk_media ctx, const void *data, int len, uint32_t dts, uint32_t pts);
 
 /**
  * 输入单帧AAC音频(单独指定adts头)
@@ -95,7 +95,7 @@ API_EXPORT void API_CALL mk_media_input_h265(mk_media ctx, void *data, int len, 
  * @param dts 时间戳，毫秒
  * @param adts adts头，可以为null
  */
-API_EXPORT void API_CALL mk_media_input_aac(mk_media ctx, void *data, int len, uint32_t dts, void *adts);
+API_EXPORT void API_CALL mk_media_input_aac(mk_media ctx, const void *data, int len, uint32_t dts, void *adts);
 
 /**
  * 输入单帧PCM音频,启用ENABLE_FAAC编译时，该函数才有效
@@ -113,7 +113,7 @@ API_EXPORT void API_CALL mk_media_input_pcm(mk_media ctx, void *data, int len, u
  * @param len  单帧音频数据字节数
  * @param dts 时间戳，毫秒
  */
-API_EXPORT void API_CALL mk_media_input_audio(mk_media ctx, void* data, int len, uint32_t dts);
+API_EXPORT void API_CALL mk_media_input_audio(mk_media ctx, const void* data, int len, uint32_t dts);
 
 /**
  * MediaSource.close()回调事件

--- a/api/source/mk_media.cpp
+++ b/api/source/mk_media.cpp
@@ -202,22 +202,22 @@ API_EXPORT void API_CALL mk_media_init_complete(mk_media ctx){
     (*obj)->getChannel()->addTrackCompleted();
 }
 
-API_EXPORT void API_CALL mk_media_input_h264(mk_media ctx, void *data, int len, uint32_t dts, uint32_t pts) {
+API_EXPORT void API_CALL mk_media_input_h264(mk_media ctx, const void *data, int len, uint32_t dts, uint32_t pts) {
     assert(ctx && data && len > 0);
     MediaHelper::Ptr *obj = (MediaHelper::Ptr *) ctx;
-    (*obj)->getChannel()->inputH264((char *) data, len, dts, pts);
+    (*obj)->getChannel()->inputH264((const char *) data, len, dts, pts);
 }
 
-API_EXPORT void API_CALL mk_media_input_h265(mk_media ctx, void *data, int len, uint32_t dts, uint32_t pts) {
+API_EXPORT void API_CALL mk_media_input_h265(mk_media ctx, const void *data, int len, uint32_t dts, uint32_t pts) {
     assert(ctx && data && len > 0);
     MediaHelper::Ptr *obj = (MediaHelper::Ptr *) ctx;
-    (*obj)->getChannel()->inputH265((char *) data, len, dts, pts);
+    (*obj)->getChannel()->inputH265((const char *) data, len, dts, pts);
 }
 
-API_EXPORT void API_CALL mk_media_input_aac(mk_media ctx, void *data, int len, uint32_t dts, void *adts) {
+API_EXPORT void API_CALL mk_media_input_aac(mk_media ctx, const void *data, int len, uint32_t dts, void *adts) {
     assert(ctx && data && len > 0 && adts);
     MediaHelper::Ptr *obj = (MediaHelper::Ptr *) ctx;
-    (*obj)->getChannel()->inputAAC((char *) data, len, dts, (char *) adts);
+    (*obj)->getChannel()->inputAAC((const char *) data, len, dts, (char *) adts);
 }
 
 API_EXPORT void API_CALL mk_media_input_pcm(mk_media ctx, void *data , int len, uint32_t pts){
@@ -226,10 +226,10 @@ API_EXPORT void API_CALL mk_media_input_pcm(mk_media ctx, void *data , int len, 
 	(*obj)->getChannel()->inputPCM((char*)data, len, pts);
 }
 
-API_EXPORT void API_CALL mk_media_input_audio(mk_media ctx, void* data, int len, uint32_t dts){
+API_EXPORT void API_CALL mk_media_input_audio(mk_media ctx, const void* data, int len, uint32_t dts){
     assert(ctx && data && len > 0);
     MediaHelper::Ptr* obj = (MediaHelper::Ptr*) ctx;
-    (*obj)->getChannel()->inputAudio((char*)data, len, dts);
+    (*obj)->getChannel()->inputAudio((const char*)data, len, dts);
 }
 
 API_EXPORT void API_CALL mk_media_start_send_rtp(mk_media ctx, const char *dst_url, uint16_t dst_port, const char *ssrc, int is_udp, on_mk_media_send_rtp_result cb, void *user_data){

--- a/player/AudioSRC.cpp
+++ b/player/AudioSRC.cpp
@@ -83,7 +83,7 @@ int AudioSRC::getPCMData(char *buf, int size) {
     if (_audio_cvt.len_cvt) {
         _target_buf.append(_buf.get(), _audio_cvt.len_cvt);
     }
-    if (_target_buf.size() < size) {
+    if (_target_buf.size() < (size_t)size) {
         return 0;
     }
     memcpy(buf, _target_buf.data(), size);
@@ -122,7 +122,7 @@ int AudioPlayer::getPCMChannel() {
 
 int AudioPlayer::getPCMData(char *buf, int size) {
     lock_guard<mutex> lck(_mtx);
-    if (_buffer.size() < size) {
+    if (_buffer.size() < (size_t)size) {
         return 0;
     }
     memcpy(buf, _buffer.data(), size);

--- a/player/FFMpegDecoder.cpp
+++ b/player/FFMpegDecoder.cpp
@@ -102,7 +102,7 @@ FFmpegSwr::~FFmpegSwr() {
 FFmpegFrame::Ptr FFmpegSwr::inputFrame(const FFmpegFrame::Ptr &frame) {
     if (frame->get()->format == _target_format &&
     frame->get()->channels == _target_channels &&
-    frame->get()->channel_layout == _target_channel_layout &&
+    frame->get()->channel_layout == (uint64_t)_target_channel_layout &&
     frame->get()->sample_rate == _target_samplerate) {
         //不转格式
         return frame;

--- a/src/Extension/SPSParser.c
+++ b/src/Extension/SPSParser.c
@@ -712,7 +712,6 @@ static inline int decodeVuiParameters(void *pvBuf, T_SPS *ptSps)
 {
     int iAspectRatioInfoPresentFlag;
     unsigned int uiAspectRatioIdc;
-    int iChromaSampleLocation;
 
     iAspectRatioInfoPresentFlag = getOneBit(pvBuf);
 
@@ -759,8 +758,7 @@ static inline int decodeVuiParameters(void *pvBuf, T_SPS *ptSps)
     /* chroma_location_info_present_flag */
     if (getOneBit(pvBuf))
     {
-        /* chroma_sample_location_type_top_field */
-        iChromaSampleLocation = parseUe(pvBuf);
+        parseUe(pvBuf);  /* chroma_sample_location_type_top_field */
         parseUe(pvBuf);  /* chroma_sample_location_type_bottom_field */
     }
     if(getBitsLeft(pvBuf) < 10)


### PR DESCRIPTION
SPSParser.c:715:9: warning: variable ‘iChromaSampleLocation’ set but not used
AudioSRC.cpp:86:28: warning: comparison of integer expressions of different signedness: ‘size_t’
AudioSRC.cpp:125:24: warning: comparison of integer expressions of different signedness: ‘size_t’
FFMpegDecoder.cpp:105:34: warning: comparison of integer expressions of different signedness: ‘uint64_t’
h264_media_server.c:32:32: warning: passing argument 2 of ‘mk_media_input_h264’ discards ‘const’ qualifier from pointer