### PR TITLE
修复zlm推流FMS,修正zlm的RTMP协议

### DIFF
--- a/src/Rtmp/Rtmp.h
+++ b/src/Rtmp/Rtmp.h
@@ -61,7 +61,8 @@ using namespace toolkit;
 #define STREAM_CONTROL				0
 #define STREAM_MEDIA				1
 
-#define CHUNK_SERVER_REQUEST			2 /*服务器像客户端发出请求时的chunkID*/
+#define CHUNK_NETWORK                   2 /*网络相关的消息(参见 Protocol Control Messages)*/
+#define CHUNK_SYSTEM                    3 /*向服务器发送控制消息(反之亦可)*/
 #define CHUNK_CLIENT_REQUEST_BEFORE		3 /*客户端在createStream前,向服务器发出请求的chunkID*/
 #define CHUNK_CLIENT_REQUEST_AFTER		4 /*客户端在createStream后,向服务器发出请求的chunkID*/
 #define CHUNK_AUDIO						6 /*音频chunkID*/

--- a/src/Rtmp/RtmpProtocol.cpp
+++ b/src/Rtmp/RtmpProtocol.cpp
@@ -165,11 +165,11 @@ void RtmpProtocol::sendInvoke(const string &cmd, const AMFValue &val) {
 }
 
 void RtmpProtocol::sendRequest(int cmd, const string& str) {
-    // 若 cmd 属于 Protocol Control Messages ，则应使用 chunk id 2 发送
     if (cmd <= MSG_SET_PEER_BW) {
+        // 若 cmd 属于 Protocol Control Messages ，则应使用 chunk id 2 发送
         sendRtmp(cmd, _stream_index, str, 0, CHUNK_NETWORK);
-        // 否则使用 chunk id 发送(任意值3-128，参见 obs 及 ffmpeg 选取 3)
     } else {
+        // 否则使用 chunk id 发送(任意值3-128，参见 obs 及 ffmpeg 选取 3)
         sendRtmp(cmd, _stream_index, str, 0, CHUNK_SYSTEM);
     }
 }

--- a/src/Rtmp/RtmpProtocol.cpp
+++ b/src/Rtmp/RtmpProtocol.cpp
@@ -165,7 +165,13 @@ void RtmpProtocol::sendInvoke(const string &cmd, const AMFValue &val) {
 }
 
 void RtmpProtocol::sendRequest(int cmd, const string& str) {
-    sendRtmp(cmd, _stream_index, str, 0, CHUNK_SERVER_REQUEST);
+    // 若 cmd 属于 Protocol Control Messages ，则应使用 chunk id 2 发送
+    if(cmd <= MSG_SET_PEER_BW){
+        sendRtmp(cmd, _stream_index, str, 0, CHUNK_NETWORK);
+    // 否则使用 chunk id 发送(任意值3-128，参见 obs 及 ffmpeg 选取 3)
+    }else{
+        sendRtmp(cmd, _stream_index, str, 0, CHUNK_SYSTEM);
+    }
 }
 
 class BufferPartial : public Buffer {

--- a/src/Rtmp/RtmpProtocol.cpp
+++ b/src/Rtmp/RtmpProtocol.cpp
@@ -166,10 +166,10 @@ void RtmpProtocol::sendInvoke(const string &cmd, const AMFValue &val) {
 
 void RtmpProtocol::sendRequest(int cmd, const string& str) {
     // 若 cmd 属于 Protocol Control Messages ，则应使用 chunk id 2 发送
-    if(cmd <= MSG_SET_PEER_BW){
+    if (cmd <= MSG_SET_PEER_BW) {
         sendRtmp(cmd, _stream_index, str, 0, CHUNK_NETWORK);
-    // 否则使用 chunk id 发送(任意值3-128，参见 obs 及 ffmpeg 选取 3)
-    }else{
+        // 否则使用 chunk id 发送(任意值3-128，参见 obs 及 ffmpeg 选取 3)
+    } else {
         sendRtmp(cmd, _stream_index, str, 0, CHUNK_SYSTEM);
     }
 }


### PR DESCRIPTION
针对 issue #1135。

修复原因在 issue 里，FMS推流失败的原因是 chunk id 的错误使用。