### PR TITLE
修正Release 和 Debug编译选项

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(CCACHE_FOUND)
 endif(CCACHE_FOUND)
 
 #set(CMAKE_BUILD_TYPE "Release")
-if (${CMAKE_BUILD_TYPE} MATCHES "")
+if ("${CMAKE_BUILD_TYPE}" STREQUAL "")
     set(CMAKE_BUILD_TYPE "Debug")
 endif ()
 


### PR DESCRIPTION
根据传入的 -DCMAKE_BUILD_TYPE=Release 或者Debug， 或者不写（默认是Debug） 来决定生成何种编译文件。