### PR TITLE
增加 libsrtp 2.3.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "3rdpart/media-server"]
 	path = 3rdpart/media-server
 	url = https://gitee.com/ireader/media-server
+[submodule "3rdpart/libsrtp"]
+	path = 3rdpart/libsrtp
+	url = https://github.com/cisco/libsrtp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,11 @@ else ()
     message(WARNING "openssl未找到，rtmp将不支持flash播放器，https/wss/rtsps/rtmps也将失效")
 endif ()
 
+# 添加srtp
+set(TEST_APPS OFF CACHE INTERNAL "")
+add_subdirectory(3rdpart/libsrtp)
+unset(TEST_APPS)
+
 #查找mysql是否安装
 find_package(MYSQL QUIET)
 if (MYSQL_FOUND AND ENABLE_MYSQL)
@@ -292,23 +297,12 @@ if (ENABLE_API)
 endif ()
 
 if (ENABLE_WEBRTC)
-    #查找srtp是否安装
-    find_package(SRTP QUIET)
-    if (SRTP_FOUND)
-        message(STATUS "found library:${SRTP_LIBRARIES}")
-        include_directories(${SRTP_INCLUDE_DIRS})
-        list(APPEND LINK_LIB_LIST ${SRTP_LIBRARIES})
-
-        add_definitions(-DENABLE_WEBRTC)
-        include_directories(./webrtc)
-        file(GLOB SRC_WEBRTC_LIST ./webrtc/*.cpp ./webrtc/*.h ./webrtc/*.hpp)
-        add_library(webrtc ${SRC_WEBRTC_LIST})
-        list(APPEND LINK_LIB_LIST webrtc)
-        message(STATUS "webrtc功能已开启")
-    else ()
-        set(ENABLE_WEBRTC off)
-        message(WARNING "srtp未找到, webrtc相关功能打开失败")
-    endif ()
+  add_definitions(-DENABLE_WEBRTC)
+  include_directories(./webrtc 3rdpart/libsrtp/include)
+  file(GLOB SRC_WEBRTC_LIST ./webrtc/*.cpp ./webrtc/*.h ./webrtc/*.hpp)
+  add_library(webrtc ${SRC_WEBRTC_LIST})
+  list(APPEND LINK_LIB_LIST webrtc srtp2)
+  message(STATUS "webrtc功能已开启")
 endif ()
 
 #ios不编译可执行程序

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,7 @@ if (OPENSSL_FOUND AND ENABLE_OPENSSL)
     add_subdirectory(3rdpart/libsrtp)
     unset(TEST_APPS)
 else ()
-    message(WARNING "openssl未找到，rtmp将不支持flash播放器，https/wss/rtsps/rtmps也将失效, webrtc功能也将没有")
+    message(WARNING "openssl未找到，rtmp将不支持flash播放器，https/wss/rtsps/rtmps也将失效, webrtc功能也将关闭")
 endif ()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,14 +151,15 @@ if (OPENSSL_FOUND AND ENABLE_OPENSSL)
     if (CMAKE_SYSTEM_NAME MATCHES "Linux" AND OPENSSL_USE_STATIC_LIBS)
         list(APPEND LINK_LIB_LIST dl)
     endif ()
+
+    # 添加srtp
+    set(TEST_APPS OFF CACHE INTERNAL "")
+    add_subdirectory(3rdpart/libsrtp)
+    unset(TEST_APPS)
 else ()
-    message(WARNING "openssl未找到，rtmp将不支持flash播放器，https/wss/rtsps/rtmps也将失效")
+    message(WARNING "openssl未找到，rtmp将不支持flash播放器，https/wss/rtsps/rtmps也将失效, webrtc功能也将没有")
 endif ()
 
-# 添加srtp
-set(TEST_APPS OFF CACHE INTERNAL "")
-add_subdirectory(3rdpart/libsrtp)
-unset(TEST_APPS)
 
 #查找mysql是否安装
 find_package(MYSQL QUIET)
@@ -296,7 +297,7 @@ if (ENABLE_API)
     add_subdirectory(api)
 endif ()
 
-if (ENABLE_WEBRTC)
+if (OPENSSL_FOUND AND ENABLE_WEBRTC)
   add_definitions(-DENABLE_WEBRTC)
   include_directories(./webrtc 3rdpart/libsrtp/include)
   file(GLOB SRC_WEBRTC_LIST ./webrtc/*.cpp ./webrtc/*.h ./webrtc/*.hpp)

--- a/webrtc/DtlsTransport.cpp
+++ b/webrtc/DtlsTransport.cpp
@@ -595,8 +595,11 @@ namespace RTC
 		SSL_set_mtu(this->ssl, DtlsMtu);
 		DTLS_set_link_mtu(this->ssl, DtlsMtu);
 
+#if OPENSSL_VERSION_NUMBER >= 0x10010100L
+		// The DTLS_set_timer_cb() function was added in OpenSSL 1.1.1.
 		// Set callback handler for setting DTLS timer interval.
 		DTLS_set_timer_cb(this->ssl, onSslDtlsTimer);
+#endif
 
 		return;
 

--- a/webrtc/SrtpSession.hpp
+++ b/webrtc/SrtpSession.hpp
@@ -20,7 +20,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #define MS_RTC_SRTP_SESSION_HPP
 
 #include "Utils.hpp"
-#include <srtp2/srtp.h>
+#include <srtp.h>
 #include <vector>
 #include <memory>
 


### PR DESCRIPTION
默认需要在源码外部安装srtp库，才能启用webrtc，
这挺麻烦的，这个提交直接在代码内部包含srtp库，并用cmake引用
并修改了比较早的openssl版本没DTLS_set_timer_cb方法bug