### PR TITLE
解决win32下大文件点播不了问题

### DIFF
--- a/src/Record/MP4.cpp
+++ b/src/Record/MP4.cpp
@@ -200,11 +200,11 @@ int MP4FileDisk::onWrite(const void *data, size_t bytes) {
     return bytes == fwrite(data, 1, bytes, _file.get()) ? 0 : ferror(_file.get());
 }
 
-int MP4FileDisk::onSeek(size_t offset) {
+int MP4FileDisk::onSeek(uint64_t offset) {
     return fseek64(_file.get(), offset, SEEK_SET);
 }
 
-size_t MP4FileDisk::onTell() {
+uint64_t MP4FileDisk::onTell() {
     return ftell64(_file.get());
 }
 
@@ -221,11 +221,11 @@ size_t MP4FileMemory::fileSize() const{
     return _memory.size();
 }
 
-size_t MP4FileMemory::onTell(){
+uint64_t MP4FileMemory::onTell(){
     return _offset;
 }
 
-int MP4FileMemory::onSeek(size_t offset){
+int MP4FileMemory::onSeek(uint64_t offset){
     if (offset > _memory.size()) {
         return -1;
     }

--- a/src/Record/MP4.h
+++ b/src/Record/MP4.h
@@ -62,14 +62,14 @@ public:
     /**
      * 获取文件读写位置
      */
-    virtual size_t onTell() = 0;
+    virtual uint64_t onTell() = 0;
 
     /**
      * seek至文件某处
      * @param offset 文件偏移量
      * @return 是否成功(0成功)
      */
-    virtual int onSeek(size_t offset) = 0;
+    virtual int onSeek(uint64_t offset) = 0;
 
     /**
      * 从文件读取一定数据
@@ -108,8 +108,8 @@ public:
     void closeFile();
 
 protected:
-    size_t onTell() override;
-    int onSeek(size_t offset) override;
+    uint64_t onTell() override;
+    int onSeek(uint64_t offset) override;
     int onRead(void *data, size_t bytes) override;
     int onWrite(const void *data, size_t bytes) override;
 
@@ -134,13 +134,13 @@ public:
     string getAndClearMemory();
 
 protected:
-    size_t onTell() override;
-    int onSeek(size_t offset) override;
+    uint64_t onTell() override;
+    int onSeek(uint64_t offset) override;
     int onRead(void *data, size_t bytes) override;
     int onWrite(const void *data, size_t bytes) override;
 
 private:
-    size_t _offset = 0;
+    uint64_t _offset = 0;
     string _memory;
 };
 


### PR DESCRIPTION
大文件mp4点播  去找mdat时，需要去seek一个很大的数。uint64转size_t  如果超过 win32下的size_t （2的32次方） 就会溢出，导致失败。64位没有这个问题。 #1036 