### PR TITLE
修改写录像方式，增加立即刷新录像文件接口

### DIFF
--- a/postman/ZLMediaKit.postman_collection.json
+++ b/postman/ZLMediaKit.postman_collection.json
@@ -983,7 +983,7 @@
 						{
 							"key": "speed",
 							"value": 2.0,
-							"description": "要设置的录像倍速",
+							"description": "要设置的录像倍速"
 						}
 					]
 				}
@@ -1029,7 +1029,7 @@
 						{
 							"key": "stamp",
 							"value": 1000,
-							"description": "要设置的录像播放位置",
+							"description": "要设置的录像播放位置"
 						}
 					]
 				}
@@ -1076,6 +1076,64 @@
 							"key": "stream",
 							"value": "obs",
 							"description": "流id，例如 obs"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "刷新录制(refreshRecord)",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{ZLMediaKit_URL}}/index/api/refreshRecord?secret={{ZLMediaKit_secret}}&type=1&vhost={{defaultVhost}}&app=live&stream=obs",
+					"host": [
+						"{{ZLMediaKit_URL}}"
+					],
+					"path": [
+						"index",
+						"api",
+						"startRecord"
+					],
+					"query": [
+						{
+							"key": "secret",
+							"value": "{{ZLMediaKit_secret}}",
+							"description": "api操作密钥(配置文件配置)，如果操作ip是127.0.0.1，则不需要此参数"
+						},
+						{
+							"key": "type",
+							"value": "1",
+							"description": "0为hls，1为mp4"
+						},
+						{
+							"key": "vhost",
+							"value": "{{defaultVhost}}",
+							"description": "虚拟主机，例如__defaultVhost__"
+						},
+						{
+							"key": "app",
+							"value": "live",
+							"description": "应用名，例如 live"
+						},
+						{
+							"key": "stream",
+							"value": "obs",
+							"description": "流id，例如 obs"
+						},
+						{
+							"key": "customized_path",
+							"value": null,
+							"description": "录像文件保存自定义根目录，为空则采用配置文件设置",
+							"disabled": true
+						},
+						{
+							"key": "max_second",
+							"value": "1000",
+							"description": "MP4录制的切片时间大小，单位秒",
+							"disabled": true
 						}
 					]
 				}

--- a/server/WebApi.cpp
+++ b/server/WebApi.cpp
@@ -1090,6 +1090,27 @@ void installWebApi() {
         val["msg"] = result ? "success" :  "stop record failed";
     });
 
+    // 刷新录制mp4
+    api_regist("/index/api/refreshRecord", [](API_ARGS_MAP) {
+        CHECK_SECRET();
+        CHECK_ARGS("type", "vhost", "app", "stream");
+        auto src = MediaSource::find(allArgs["schema"],
+            allArgs["vhost"],
+            allArgs["app"],
+            allArgs["stream"]);
+        if (src) {
+            bool flag = src->refreshRecord((Recorder::type) allArgs["type"].as<int>());
+            val["result"] = flag ? 0 : -1;
+            val["msg"] = flag ? "success" : "refresh failed";
+            val["code"] = flag ? API::Success : API::OtherFailed;
+        }
+        else {
+            val["result"] = -2;
+            val["msg"] = "can not find the stream";
+            val["code"] = API::OtherFailed;
+        }
+        });
+
     // 获取hls或MP4录制状态
     api_regist("/index/api/isRecording",[](API_ARGS_MAP){
         CHECK_SECRET();

--- a/src/Common/MediaSink.h
+++ b/src/Common/MediaSink.h
@@ -49,6 +49,8 @@ class MediaSinkInterface : public FrameWriterInterface, public TrackListener {
 public:
     typedef std::shared_ptr<MediaSinkInterface> Ptr;
 
+    virtual bool refreshRecord() { return false; };
+
     MediaSinkInterface() = default;
     ~MediaSinkInterface() override = default;
 };

--- a/src/Common/MediaSource.cpp
+++ b/src/Common/MediaSource.cpp
@@ -212,6 +212,15 @@ bool MediaSource::setupRecord(Recorder::type type, bool start, const string &cus
     return listener->setupRecord(*this, type, start, custom_path, max_second);
 }
 
+bool MediaSource::refreshRecord(Recorder::type type) {
+    auto listener = _listener.lock();
+    if (!listener) {
+        WarnL << "未设置MediaSource的事件监听者，setupRecord失败:" << getSchema() << "/" << getVhost() << "/" << getApp() << "/" << getId();
+        return false;
+    }
+    return listener->refreshRecord(*this, type);
+}
+
 bool MediaSource::isRecording(Recorder::type type){
     auto listener = _listener.lock();
     if(!listener){
@@ -676,6 +685,14 @@ bool MediaSourceEventInterceptor::setupRecord(MediaSource &sender, Recorder::typ
         return false;
     }
     return listener->setupRecord(sender, type, start, custom_path, max_second);
+}
+
+bool MediaSourceEventInterceptor::refreshRecord(MediaSource& sender, Recorder::type type) {
+    auto listener = _listener.lock();
+    if (!listener) {
+        return false;
+    }
+    return listener->refreshRecord(sender, type);
 }
 
 bool MediaSourceEventInterceptor::isRecording(MediaSource &sender, Recorder::type type) {

--- a/src/Common/MediaSource.h
+++ b/src/Common/MediaSource.h
@@ -85,6 +85,8 @@ public:
     virtual bool setupRecord(MediaSource &sender, Recorder::type type, bool start, const string &custom_path, size_t max_second) { return false; };
     // 获取录制状态
     virtual bool isRecording(MediaSource &sender, Recorder::type type) { return false; };
+    // 刷新录像
+    virtual bool refreshRecord(MediaSource& sender, Recorder::type type) { return false; };
     // 获取所有track相关信息
     virtual vector<Track::Ptr> getMediaTracks(MediaSource &sender, bool trackReady = true) const { return vector<Track::Ptr>(); };
     // 开始发送ps-rtp
@@ -117,6 +119,7 @@ public:
     void onReaderChanged(MediaSource &sender, int size) override;
     void onRegist(MediaSource &sender, bool regist) override;
     bool setupRecord(MediaSource &sender, Recorder::type type, bool start, const string &custom_path, size_t max_second) override;
+    bool refreshRecord(MediaSource& sender, Recorder::type type) override;
     bool isRecording(MediaSource &sender, Recorder::type type) override;
     vector<Track::Ptr> getMediaTracks(MediaSource &sender, bool trackReady = true) const override;
     void startSendRtp(MediaSource &sender, const string &dst_url, uint16_t dst_port, const string &ssrc, bool is_udp, uint16_t src_port, const function<void(uint16_t local_port, const SockException &ex)> &cb) override;
@@ -267,6 +270,8 @@ public:
     bool setupRecord(Recorder::type type, bool start, const string &custom_path, size_t max_second);
     // 获取录制状态
     bool isRecording(Recorder::type type);
+    // 刷新录像
+    bool refreshRecord(Recorder::type type);
     // 开始发送ps-rtp
     void startSendRtp(const string &dst_url, uint16_t dst_port, const string &ssrc, bool is_udp, uint16_t src_port, const function<void(uint16_t local_port, const SockException &ex)> &cb);
     // 停止发送ps-rtp

--- a/src/Common/MultiMediaSourceMuxer.cpp
+++ b/src/Common/MultiMediaSourceMuxer.cpp
@@ -183,6 +183,18 @@ bool MultiMediaSourceMuxer::setupRecord(MediaSource &sender, Recorder::type type
     }
 }
 
+bool MultiMediaSourceMuxer::refreshRecord(MediaSource& sender, Recorder::type type) {
+    switch (type)
+    {
+    case Recorder::type_hls:
+        return false;
+    case Recorder::type_mp4:
+        _mp4->refreshRecord();
+    default:
+        break;
+    }
+}
+
 //此函数可能跨线程调用
 bool MultiMediaSourceMuxer::isRecording(MediaSource &sender, Recorder::type type) {
     switch (type){

--- a/src/Common/MultiMediaSourceMuxer.h
+++ b/src/Common/MultiMediaSourceMuxer.h
@@ -88,6 +88,12 @@ public:
      * @return 是否设置成功
      */
     bool setupRecord(MediaSource &sender, Recorder::type type, bool start, const string &custom_path, size_t max_second) override;
+    
+    /**
+    * 刷新注册
+    * @param type 录制类型
+    */
+    bool refreshRecord(MediaSource& sender, Recorder::type type) override;
 
     /**
      * 获取录制状态


### PR DESCRIPTION
增加立即刷新录像的接口，以便用户可以立即查看数秒前的录像而不需要等待切片时间到或者终止录像。
修改写录像文件的方式，改为先缓存一个i帧与数个p、b帧，接收到下一个i帧时才写入文件，这样可以允许用户立即查看当前录像的同时保证每个录像切片都是连续的