### PR TITLE
修正连 node ws 服务端失败问题

### DIFF
--- a/src/Http/WebSocketClient.h
+++ b/src/Http/WebSocketClient.h
@@ -73,7 +73,7 @@ public:
     typedef shared_ptr<HttpWsClient> Ptr;
 
     HttpWsClient(ClientTypeImp<ClientType,DataType> &delegate) : _delegate(delegate){
-        _Sec_WebSocket_Key = encodeBase64(SHA1::encode_bin(makeRandStr(16, false)));
+        _Sec_WebSocket_Key = encodeBase64(makeRandStr(16, false));
         setPoller(delegate.getPoller());
     }
     ~HttpWsClient(){}


### PR DESCRIPTION
Fix #1251

参考: https://datatracker.ietf.org/doc/html/rfc6455#section-4.2.1
Sec-WebSocket-Key base64 解码后长度应该是 16 字节.