### PR TITLE
修复rtsp tcp 推送到 rtsp-simple-server 失败的问题，

### DIFF
--- a/src/Rtsp/RtspPusher.cpp
+++ b/src/Rtsp/RtspPusher.cpp
@@ -45,7 +45,6 @@ void RtspPusher::teardown() {
     _track_vec.clear();
     _session_id.clear();
     _content_base.clear();
-    _session_id.clear();
     _cseq = 1;
     _publish_timer.reset();
     _beat_timer.reset();
@@ -265,14 +264,14 @@ void RtspPusher::sendSetup(unsigned int track_idx) {
         case Rtsp::RTP_TCP: {
             sendRtspRequest("SETUP", control_url, {"Transport",
                                                    StrPrinter << "RTP/AVP/TCP;unicast;interleaved=" << track->_type * 2
-                                                           << "-" << track->_type * 2 + 1<<";mode=record"});
+                                                           << "-" << track->_type * 2 + 1 << ";mode=record"});
         }
             break;
         case Rtsp::RTP_UDP: {
             createUdpSockIfNecessary(track_idx);
             int port = _rtp_sock[track_idx]->get_local_port();
             sendRtspRequest("SETUP", control_url,
-                            {"Transport", StrPrinter << "RTP/AVP;unicast;client_port=" << port << "-" << port + 1<<";mode=record"});
+                            {"Transport", StrPrinter << "RTP/AVP;unicast;client_port=" << port << "-" << port + 1 << ";mode=record"});
         }
             break;
         default:

--- a/src/Rtsp/RtspPusher.cpp
+++ b/src/Rtsp/RtspPusher.cpp
@@ -272,7 +272,7 @@ void RtspPusher::sendSetup(unsigned int track_idx) {
             createUdpSockIfNecessary(track_idx);
             int port = _rtp_sock[track_idx]->get_local_port();
             sendRtspRequest("SETUP", control_url,
-                            {"Transport", StrPrinter << "RTP/AVP;unicast;client_port=" << port << "-" << port + 1});
+                            {"Transport", StrPrinter << "RTP/AVP;unicast;client_port=" << port << "-" << port + 1<<";mode=record"});
         }
             break;
         default:

--- a/src/Rtsp/RtspPusher.cpp
+++ b/src/Rtsp/RtspPusher.cpp
@@ -207,6 +207,8 @@ void RtspPusher::handleResAnnounce(const Parser &parser) {
     if (_content_base.back() == '/') {
         _content_base.pop_back();
     }
+    
+    _session_id = parser["Session"];
 
     sendSetup(0);
 }
@@ -263,7 +265,7 @@ void RtspPusher::sendSetup(unsigned int track_idx) {
         case Rtsp::RTP_TCP: {
             sendRtspRequest("SETUP", control_url, {"Transport",
                                                    StrPrinter << "RTP/AVP/TCP;unicast;interleaved=" << track->_type * 2
-                                                           << "-" << track->_type * 2 + 1});
+                                                           << "-" << track->_type * 2 + 1<<";mode=record"});
         }
             break;
         case Rtsp::RTP_UDP: {


### PR DESCRIPTION
主要由于两点原因
1，annoce 返回，会携带 session ,需要记住，在随后的请求中携带，否则随后的请求setup 会返回404 未发现的错误
2，setup 中 需要加入mode=record ，否则会返回400的错误