### PR TITLE
hls拉流修改拉取m3u8延时

### DIFF
--- a/src/Http/HlsParser.cpp
+++ b/src/Http/HlsParser.cpp
@@ -137,4 +137,7 @@ bool HlsParser::isM3u8Inner() const {
     return _is_m3u8_inner;
 }
 
+float HlsParser::getTotalDuration() const {
+    return _total_dur;
+}
 }//namespace mediakit

--- a/src/Http/HlsParser.h
+++ b/src/Http/HlsParser.h
@@ -74,7 +74,12 @@ public:
      * 内部是否含有子m3u8
      */
     bool isM3u8Inner() const;
-
+    /**
+     * 得到总时间
+     * @return
+     */
+    float getTotalDuration() const;
+ 
 protected:
     //解析出ts文件地址回调
     virtual void onParsed(bool is_m3u8_inner,int64_t sequence,const map<int,ts_segment> &ts_list) {};


### PR DESCRIPTION
拉去hls索引文件时, 不能仅仅只是按照m3u8文件中的分段时间来拉取, 这样在网络延迟的情况下很容易出现问题, 根据规范与ffmpeg中实现如下