### PR TITLE
加速track的准备速度

### DIFF
--- a/src/Common/MediaSink.h
+++ b/src/Common/MediaSink.h
@@ -109,11 +109,12 @@ public:
     vector<Track::Ptr> getTracks(bool trackReady = true) const override;
     
     /**
-    * 返回是否track已经准备完成
-    */
-    bool isTrackReady() const{
+     * 返回是否所有track已经准备完成
+     */
+    bool isAllTrackReady() const {
         return _all_track_ready;
     }
+    
     /**
      * 添加aac静音轨道
      */

--- a/src/Common/MediaSink.h
+++ b/src/Common/MediaSink.h
@@ -107,7 +107,13 @@ public:
      * @param trackReady 是否获取已经准备好的Track
      */
     vector<Track::Ptr> getTracks(bool trackReady = true) const override;
-
+    
+    /**
+    * 返回是否track已经准备完成
+    */
+    bool isTrackReady() const{
+        return _all_track_ready;
+    }
     /**
      * 添加aac静音轨道
      */

--- a/src/Http/HlsPlayer.cpp
+++ b/src/Http/HlsPlayer.cpp
@@ -318,6 +318,11 @@ void HlsDemuxer::start(const EventPoller::Ptr &poller, TrackListener *listener) 
 bool HlsDemuxer::inputFrame(const Frame::Ptr &frame) {
     //计算相对时间戳
     int64_t dts, pts;
+    //为了避免track准备时间过长, 因此在没准备好之前, 直接消费掉所有的帧
+    if (!_delegate.isTrackReady()) {
+        _delegate.inputFrame(Frame::getCacheAbleFrame(frame));
+        return true;
+    }
     _stamp[frame->getTrackType()].revise(frame->dts(), frame->pts(), dts, pts);
     //根据时间戳缓存frame
     _frame_cache.emplace(dts, Frame::getCacheAbleFrame(frame));

--- a/src/Http/HlsPlayer.cpp
+++ b/src/Http/HlsPlayer.cpp
@@ -316,13 +316,14 @@ void HlsDemuxer::start(const EventPoller::Ptr &poller, TrackListener *listener) 
 }
 
 bool HlsDemuxer::inputFrame(const Frame::Ptr &frame) {
-    //计算相对时间戳
-    int64_t dts, pts;
     //为了避免track准备时间过长, 因此在没准备好之前, 直接消费掉所有的帧
-    if (!_delegate.isTrackReady()) {
-        _delegate.inputFrame(Frame::getCacheAbleFrame(frame));
+    if (!_delegate.isAllTrackReady()) {
+        _delegate.inputFrame(frame);
         return true;
     }
+    
+    //计算相对时间戳
+    int64_t dts, pts;
     _stamp[frame->getTrackType()].revise(frame->dts(), frame->pts(), dts, pts);
     //根据时间戳缓存frame
     _frame_cache.emplace(dts, Frame::getCacheAbleFrame(frame));


### PR DESCRIPTION
其实这个问题很早就跟您反馈过了, 当拉流的远程一端码流率很大,或者是网络质量不好的情况下, track的准备速度非常慢.
所以,我的想法就是在track准备好之前, 先直接消费掉所有的帧, 并不加入缓存并等待缓存的周期性消费.这样有助于能快速的完成track的准备.特别是对于使用api来添加流的用户来说, 这有助于避免因为track准备时间过长而导致的http api调用返回超时.
以下是测试的流地址与测试结果, 希望能对您的项目有小小的帮助.
http://39.135.138.59:18890/PLTV/88888910/224/3221225633/index.m3u8
这个是测试流, 我是电信网络, 这个是移动网络

当使用原始代码时的情况如下, 可以看到准备完成使用了emitAllTrackReady | all track ready use 28684ms:

```
2021-12-17 14:23:09.692 I MediaServer[10920-MediaServer] System.cpp:130 systemSetup | core文件大小设置为:18446744073709551615
2021-12-17 14:23:09.692 I MediaServer[10920-MediaServer] System.cpp:139 systemSetup | 文件最大描述符个数设置为:1048576
2021-12-17 14:23:09.697 D MediaServer[10920-MediaServer] SSLBox.cpp:171 setContext | add certificate of: default.zlmediakit.com
2021-12-17 14:23:09.698 D MediaServer[10920-stamp thread] util.cpp:343 operator() | Stamp thread started!
2021-12-17 14:23:09.703 I MediaServer[10920-MediaServer] EventPoller.cpp:466 EventPollerPool | 创建EventPoller个数:16
2021-12-17 14:23:09.704 I MediaServer[10920-MediaServer] TcpServer.cpp:195 start_l | TCP Server listening on 0.0.0.0:554
2021-12-17 14:23:09.704 I MediaServer[10920-MediaServer] TcpServer.cpp:195 start_l | TCP Server listening on 0.0.0.0:1935
2021-12-17 14:23:09.705 I MediaServer[10920-MediaServer] TcpServer.cpp:195 start_l | TCP Server listening on 0.0.0.0:8081
2021-12-17 14:23:09.705 I MediaServer[10920-MediaServer] TcpServer.cpp:195 start_l | TCP Server listening on 0.0.0.0:443
2021-12-17 14:23:09.705 I MediaServer[10920-MediaServer] TcpServer.cpp:195 start_l | TCP Server listening on 0.0.0.0:10000
2021-12-17 14:23:09.756 I MediaServer[10920-MediaServer] UdpServer.cpp:78 start_l | UDP Server bind to 0.0.0.0:10000
2021-12-17 14:23:09.757 I MediaServer[10920-MediaServer] main.cpp:327 start_main | 已启动http api 接口
2021-12-17 14:23:09.757 I MediaServer[10920-MediaServer] main.cpp:329 start_main | 已启动http hook 接口
2021-12-17 14:23:33.898 T MediaServer[10920-event poller 0] HttpSession.cpp:25 HttpSession | 58(127.0.0.1:35982) 
2021-12-17 14:23:41.424 I MediaServer[10920-event poller 0] Decoder.cpp:243 onTrack | got track: H264
2021-12-17 14:23:41.424 I MediaServer[10920-event poller 0] Decoder.cpp:243 onTrack | got track: mpeg4-generic
2021-12-17 14:23:41.424 I MediaServer[10920-event poller 0] Decoder.cpp:150 onStream | add track finished
2021-12-17 14:24:05.727 T MediaServer[10920-event poller 0] HttpSession.cpp:119 onError | 58(127.0.0.1:35982) session timeout
2021-12-17 14:24:05.727 T MediaServer[10920-event poller 0] HttpSession.cpp:31 ~HttpSession | 58(127.0.0.1:35982) 
2021-12-17 14:24:05.728 T MediaServer[10920-event poller 1] HttpSession.cpp:25 HttpSession | 58(127.0.0.1:36242) 
2021-12-17 14:24:05.728 D MediaServer[10920-event poller 1] WebApi.cpp:230 http api debug | 

# request:

GET /index/api/addStreamProxy?stream=aoshi&url=http://39.135.138.59:18890/PLTV/88888910/224/3221225633/index.m3u8&app=proxy&enable_mp4=0&rtp_type=0&vhost=__defaultVhost__&secret=035c73f7-bb6b-4889-a715-d9eb2d1925cc&enable_hls=1

# header:

Accept : text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8

Accept-Encoding : gzip, deflate

Accept-Language : en-US,en;q=0.5

Connection : keep-alive

Cookie : csrftoken=RBNp4VwVyaDmEwhIlUQa2js8HMN6ISIZ

DNT : 1

Host : 127.0.0.1:8081

Sec-Fetch-Dest : document

Sec-Fetch-Mode : navigate

Sec-Fetch-Site : none

Sec-Fetch-User : ?1

Sec-GPC : 1

Upgrade-Insecure-Requests : 1

User-Agent : Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:95.0) Gecko/20100101 Firefox/95.0

# content:



# response:

{
   "code" : 0,
   "data" : {
      "key" : "__defaultVhost__/proxy/aoshi"
   }
}



2021-12-17 14:24:10.108 D MediaServer[10920-event poller 0] MediaSink.cpp:135 emitAllTrackReady | all track ready use 28684ms
2021-12-17 14:24:10.108 W MediaServer[10920-event poller 0] MediaSink.cpp:142 emitAllTrackReady | track not ready for a long time, ignored: mpeg4-generic
2021-12-17 14:24:10.108 T MediaServer[10920-event poller 0] MediaSink.cpp:259 addMuteAudioTrack | mute aac track added
2021-12-17 14:24:10.108 D MediaServer[10920-event poller 0] WebApi.cpp:230 http api debug | 

# request:

GET /index/api/addStreamProxy?stream=aoshi&url=http://39.135.138.59:18890/PLTV/88888910/224/3221225633/index.m3u8&app=proxy&enable_mp4=0&rtp_type=0&vhost=__defaultVhost__&secret=035c73f7-bb6b-4889-a715-d9eb2d1925cc&enable_hls=1

# header:

Accept : text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8

Accept-Encoding : gzip, deflate

Accept-Language : en-US,en;q=0.5

Connection : keep-alive

Cookie : csrftoken=RBNp4VwVyaDmEwhIlUQa2js8HMN6ISIZ

DNT : 1
Host : 127.0.0.1:8081

Sec-Fetch-Dest : document

Sec-Fetch-Mode : navigate

Sec-Fetch-Site : none

Sec-Fetch-User : ?1

Sec-GPC : 1

Upgrade-Insecure-Requests : 1

User-Agent : Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:95.0) Gecko/20100101 Firefox/95.0

# content:



# response:

{
   "code" : 0,
   "data" : {
      "key" : "__defaultVhost__/proxy/aoshi"
   }
}



2021-12-17 14:24:10.111 I MediaServer[10920-event poller 0] MediaSource.cpp:414 emitEvent | 媒体注册:hls __defaultVhost__ proxy aoshi
2021-12-17 14:24:10.112 D MediaServer[10920-event poller 0] MediaSink.cpp:135 emitAllTrackReady | all track ready use 0ms
2021-12-17 14:24:10.112 I MediaServer[10920-event poller 0] MultiMediaSourceMuxer.cpp:300 onAllTrackReady | stream: http://39.135.138.59:18890/PLTV/88888910/224/3221225633/index.m3u8 , codec info: mpeg4-generic[8000/1/16] H264[1920/1080/25] 
2021-12-17 14:24:10.112 I MediaServer[10920-event poller 0] MediaSource.cpp:414 emitEvent | 媒体注册:rtmp __defaultVhost__ proxy aoshi
2021-12-17 14:24:10.112 I MediaServer[10920-event poller 0] MediaSource.cpp:414 emitEvent | 媒体注册:rtsp __defaultVhost__ proxy aoshi
2021-12-17 14:24:10.112 I MediaServer[10920-event poller 0] MediaSource.cpp:414 emitEvent | 媒体注册:ts __defaultVhost__ proxy aoshi
2021-12-17 14:24:10.113 W MediaServer[10920-event poller 0] Stamp.cpp:83 revise_l | 强制同步:8278322 < 8278322
2021-12-17 14:24:10.114 W MediaServer[10920-event poller 0] Stamp.cpp:83 revise_l | 强制同步:8278386 < 8278386
2021-12-17 14:24:10.114 W MediaServer[10920-event poller 0] Stamp.cpp:83 revise_l | 强制同步:8278386 < 8278386
2021-12-17 14:24:10.114 W MediaServer[10920-event poller 0] Stamp.cpp:83 revise_l | 强制同步:8278386 < 8278386
2021-12-17 14:24:10.131 I MediaServer[10920-event poller 0] MediaSource.cpp:414 emitEvent | 媒体注册:fmp4 __defaultVhost__ proxy aoshi
2021-12-17 14:24:35.734 T MediaServer[10920-event poller 1] HttpSession.cpp:119 onError | 58(127.0.0.1:36242) session timeout
2021-12-17 14:24:35.734 T MediaServer[10920-event poller 1] HttpSession.cpp:31 ~HttpSession | 58(127.0.0.1:36242) 
2021-12-17 14:24:38.427 W MediaServer[10920-event poller 0] TSDecoder.cpp:24 onRecvHeader | 不是ts包:71 363
```


使用修改后的代码, 只需要109ms:

```
2021-12-17 14:26:34.950 I MediaServer[11925-MediaServer] System.cpp:130 systemSetup | core文件大小设置为:18446744073709551615
2021-12-17 14:26:34.951 I MediaServer[11925-MediaServer] System.cpp:139 systemSetup | 文件最大描述符个数设置为:1048576
2021-12-17 14:26:34.956 D MediaServer[11925-MediaServer] SSLBox.cpp:171 setContext | add certificate of: default.zlmediakit.com
2021-12-17 14:26:34.956 D MediaServer[11925-stamp thread] util.cpp:343 operator() | Stamp thread started!
2021-12-17 14:26:34.962 I MediaServer[11925-MediaServer] EventPoller.cpp:466 EventPollerPool | 创建EventPoller个数:16
2021-12-17 14:26:34.963 I MediaServer[11925-MediaServer] TcpServer.cpp:195 start_l | TCP Server listening on 0.0.0.0:554
2021-12-17 14:26:34.964 I MediaServer[11925-MediaServer] TcpServer.cpp:195 start_l | TCP Server listening on 0.0.0.0:1935
2021-12-17 14:26:34.964 I MediaServer[11925-MediaServer] TcpServer.cpp:195 start_l | TCP Server listening on 0.0.0.0:8081
2021-12-17 14:26:34.965 I MediaServer[11925-MediaServer] TcpServer.cpp:195 start_l | TCP Server listening on 0.0.0.0:443
2021-12-17 14:26:34.965 I MediaServer[11925-MediaServer] TcpServer.cpp:195 start_l | TCP Server listening on 0.0.0.0:10000
2021-12-17 14:26:34.992 I MediaServer[11925-MediaServer] UdpServer.cpp:78 start_l | UDP Server bind to 0.0.0.0:10000
2021-12-17 14:26:34.993 I MediaServer[11925-MediaServer] main.cpp:327 start_main | 已启动http api 接口
2021-12-17 14:26:34.993 I MediaServer[11925-MediaServer] main.cpp:329 start_main | 已启动http hook 接口
2021-12-17 14:26:38.657 T MediaServer[11925-event poller 8] HttpSession.cpp:25 HttpSession | 58(127.0.0.1:37494) 
2021-12-17 14:26:38.946 I MediaServer[11925-event poller 8] Decoder.cpp:243 onTrack | got track: H264
2021-12-17 14:26:38.946 I MediaServer[11925-event poller 8] Decoder.cpp:243 onTrack | got track: mpeg4-generic
2021-12-17 14:26:38.946 I MediaServer[11925-event poller 8] Decoder.cpp:150 onStream | add track finished
2021-12-17 14:26:39.054 D MediaServer[11925-event poller 8] MediaSink.cpp:135 emitAllTrackReady | all track ready use 109ms
2021-12-17 14:26:39.055 D MediaServer[11925-event poller 8] WebApi.cpp:230 http api debug | 

# request:

GET /index/api/addStreamProxy?stream=aoshi&url=http://39.135.138.59:18890/PLTV/88888910/224/3221225633/index.m3u8&app=proxy&enable_mp4=0&rtp_type=0&vhost=__defaultVhost__&secret=035c73f7-bb6b-4889-a715-d9eb2d1925cc&enable_hls=1

# header:

Accept : text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8

Accept-Encoding : gzip, deflate

Accept-Language : en-US,en;q=0.5

Cache-Control : max-age=0

Connection : keep-alive

Cookie : csrftoken=RBNp4VwVyaDmEwhIlUQa2js8HMN6ISIZ

DNT : 1

Host : 127.0.0.1:8081

Sec-Fetch-Dest : document

Sec-Fetch-Mode : navigate

Sec-Fetch-Site : none

Sec-Fetch-User : ?1

Sec-GPC : 1

Upgrade-Insecure-Requests : 1
User-Agent : Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:95.0) Gecko/20100101 Firefox/95.0

# content:



# response:

{
   "code" : 0,
   "data" : {
      "key" : "__defaultVhost__/proxy/aoshi"
   }
}



2021-12-17 14:26:39.056 I MediaServer[11925-event poller 8] MediaSource.cpp:414 emitEvent | 媒体注册:hls __defaultVhost__ proxy aoshi
2021-12-17 14:26:39.056 D MediaServer[11925-event poller 8] MediaSink.cpp:135 emitAllTrackReady | all track ready use 0ms
2021-12-17 14:26:39.057 I MediaServer[11925-event poller 8] MultiMediaSourceMuxer.cpp:300 onAllTrackReady | stream: http://39.135.138.59:18890/PLTV/88888910/224/3221225633/index.m3u8 , codec info: mpeg4-generic[48000/6/16] H264[1920/1080/25] 
2021-12-17 14:26:39.057 I MediaServer[11925-event poller 8] MediaSource.cpp:414 emitEvent | 媒体注册:rtmp __defaultVhost__ proxy aoshi
2021-12-17 14:26:39.057 I MediaServer[11925-event poller 8] MediaSource.cpp:414 emitEvent | 媒体注册:rtsp __defaultVhost__ proxy aoshi
2021-12-17 14:26:39.057 I MediaServer[11925-event poller 8] MediaSource.cpp:414 emitEvent | 媒体注册:ts __defaultVhost__ proxy aoshi
2021-12-17 14:26:39.057 W MediaServer[11925-event poller 8] Stamp.cpp:83 revise_l | 强制同步:8458354 < 8458354
```