### PR TITLE
增加ffmpeg拉流自动重启时间, 避免长时间拉流导致的声音不同步现象

### DIFF
--- a/conf/config.ini
+++ b/conf/config.ini
@@ -26,6 +26,8 @@ snap=%s -i %s -y -f mjpeg -t 0.001 %s
 #FFmpeg日志的路径，如果置空则不生成FFmpeg日志
 #可以为相对(相对于本可执行程序目录)或绝对路径
 log=./ffmpeg/ffmpeg.log
+# 自动重启的时间(秒), 默认为0, 也就是不自动重启. 主要是为了避免长时间ffmpeg拉流导致的不同步现象
+restart_sec=0
 
 [general]
 #是否启用虚拟主机


### PR DESCRIPTION
长时间使用ffmpeg拉流或者推流会导致不同步现象.
通过google搜索发现,这种现象除了修改ffmpeg代码以外最简单的方法就是定时重启.
所以增加了一个定时重启的功能