### PR TITLE
修复302跳转时, 如果跨域,header不正确的问题

### DIFF
--- a/src/Http/HttpClient.cpp
+++ b/src/Http/HttpClient.cpp
@@ -104,6 +104,7 @@ void HttpClient::clearResponse() {
     _recved_body_size = 0;
     _total_body_size = 0;
     _parser.Clear();
+    _header.clear();
     _chunked_splitter = nullptr;
     _recv_timeout_ticker.resetTime();
     _total_timeout_ticker.resetTime();


### PR DESCRIPTION
修复因为没有及时清除header, 导致header中的host不正确的问题.
