### PR TITLE
增加新配置选项, 可选择在心跳包发送的时候同时发送媒体资源统计, 便于上层系统实时监控

### DIFF
--- a/server/WebApi.cpp
+++ b/server/WebApi.cpp
@@ -304,6 +304,21 @@ static inline string getPusherKey(const string &schema, const string &vhost, con
                                   const string &dst_url) {
     return schema + "/" + vhost + "/" + app + "/" + stream + "/" + MD5(dst_url).hexdigest();
 }
+Value makeSimpleMediaSourceJson(MediaSource &media){
+    Value item;
+    item["schema"] = media.getSchema();
+    item[VHOST_KEY] = media.getVhost();
+    item["app"] = media.getApp();
+    item["stream"] = media.getId();
+    item["createStamp"] = (Json::UInt64) media.getCreateStamp();
+    item["aliveSecond"] = (Json::UInt64) media.getAliveSecond();
+    item["bytesSpeed"] = media.getBytesSpeed();
+    item["readerCount"] = media.readerCount();
+    item["totalReaderCount"] = media.totalReaderCount();
+    item["isRecordingMP4"] = media.isRecording(Recorder::type_mp4);
+    item["isRecordingHLS"] = media.isRecording(Recorder::type_hls);
+    return item;
+}
 
 Value makeMediaSourceJson(MediaSource &media){
     Value item;

--- a/server/WebApi.h
+++ b/server/WebApi.h
@@ -235,6 +235,7 @@ bool checkArgs(Args &args, const First &first, const KeyTypes &...keys) {
 void installWebApi();
 void unInstallWebApi();
 Value makeMediaSourceJson(MediaSource &media);
+Value makeSimpleMediaSourceJson(MediaSource &media);
 void getStatisticJson(const function<void(Value &val)> &cb);
 void addStreamProxy(const string &vhost, const string &app, const string &stream, const string &url, int retry_count,
                     bool enable_hls, bool enable_mp4, int rtp_type, float timeout_sec,

--- a/server/WebHook.cpp
+++ b/server/WebHook.cpp
@@ -49,6 +49,8 @@ const string kAliveWithMediaInfo = HOOK_FIELD"alive_with_media_info";
 
 onceToken token([](){
     mINI::Instance()[kEnable] = false;
+    //默认不提交媒体数据
+    mINI::Instance()[kAliveWithMediaInfo] = false;
     mINI::Instance()[kTimeoutSec] = 10;
     //默认hook地址设置为空，采用默认行为(例如不鉴权)
     mINI::Instance()[kOnPublish] = "";


### PR DESCRIPTION
一般来说上层中台都会监控流媒体服务器的状态, 包括媒体状态. 
之前是通过getmedialist那个api由上层系统来调用这个接口获取媒体状态.
但是这对于上层系统来说并不友好, 需要上层系统有定时任务来获取.

一般操作应该是由流媒体服务器主动上报才对, 所以增加一个选项, 开启后在发送alive心跳到上层系统的时候, 同时上报媒体源的简单统计信息.