### PR TITLE
修正切片时间为负的问题

### DIFF
--- a/src/Record/HlsMaker.cpp
+++ b/src/Record/HlsMaker.cpp
@@ -106,7 +106,7 @@ void HlsMaker::delOldSegment() {
 }
 
 void HlsMaker::addNewSegment(uint32_t stamp) {
-    if (!_last_file_name.empty() && stamp - _last_seg_timestamp < _seg_duration * 1000) {
+    if (!_last_file_name.empty() && static_cast<float>(stamp - _last_seg_timestamp) < _seg_duration * 1000) {
         //存在上个切片，并且未到分片时间
         return;
     }
@@ -125,11 +125,11 @@ void HlsMaker::flushLastSegment(bool eof){
         return;
     }
     //文件创建到最后一次数据写入的时间即为切片长度
-    auto seg_dur = _last_timestamp - _last_seg_timestamp;
+    int seg_dur = static_cast<int>(_last_timestamp - _last_seg_timestamp);
     if (seg_dur <= 0) {
         seg_dur = 100;
     }
-    _seg_dur_list.push_back(std::make_tuple(seg_dur, std::move(_last_file_name)));
+    _seg_dur_list.emplace_back(seg_dur, std::move(_last_file_name));
     _last_file_name.clear();
     delOldSegment();
     //先flush ts切片，否则可能存在ts文件未写入完毕就被访问的情况


### PR DESCRIPTION
当网络出现抖动, 特别是上游断开在重连后, 有可能导致时间戳跳变或者回退.
特别是拉取http-ts流时, 因为并没有根据当前时间戳进行主动丢帧处理.
所以一旦断开重连, 就会获取到已经重复的帧.

这就造成了在hls切片时, 计算出来的时间为负.
而hls中相关的变量类型都是uint32_t, 这就导致类型错误了.

因此增加强制转换类型, 确保m3u8文件中不会出现负时间