### PR TITLE
当调用mk_media_source_close(ptr, 1);时，主动注销流

### DIFF
--- a/src/Common/MediaSource.cpp
+++ b/src/Common/MediaSource.cpp
@@ -204,12 +204,11 @@ bool MediaSource::speed(float speed) {
 }
 
 bool MediaSource::close(bool force) {
-    unregist();
     auto listener = _listener.lock();
     if(!listener){
         return false;
     }
-    return listener->close(*this,force);
+    return listener->close(*this,force) && unregist();
 }
 
 void MediaSource::onReaderChanged(int size) {

--- a/src/Common/MediaSource.cpp
+++ b/src/Common/MediaSource.cpp
@@ -204,6 +204,7 @@ bool MediaSource::speed(float speed) {
 }
 
 bool MediaSource::close(bool force) {
+    unregist();
     auto listener = _listener.lock();
     if(!listener){
         return false;


### PR DESCRIPTION
应用场景中，若发生`on_mk_media_no_reader`事件，此时需要主动发送命令给上游停止推流。
上游推流停止后，由于断连续推，需要`continue_push_ms`时间后，才会触发析构media source。
若这段时间内，有新的播放器链接进来，经测试不会触发`on_mk_media_not_found`事件。上游无法收到重新开始推流命令。

以上问题我当前处理路线是，发生`on_mk_media_no_reader`时，同步进行：1)通知上游停止推流。2)调用`mk_media_source_close`强制关闭media source。

遗憾的是，目前`MediaSource::unregist`仅在析构时调用，而对象的智能指针已被断连续推功能持有，在`continue_push_ms`时间内，析构反注册不会发生。

进而我在`MediaSource::close`函数内，直接调用反注册。

经过简单测试，这样调整后，达成了以下效果：`on_mk_media_no_reader`事件时，即使打开`continue_push_ms`，也能立即注销流，为短时间内下一个客户端触发按需推流做好了准备。