### PR TITLE
hls拉取索引文件避免循环重试

### DIFF
--- a/src/Player/PlayerProxy.cpp
+++ b/src/Player/PlayerProxy.cpp
@@ -56,6 +56,8 @@ void PlayerProxy::play(const string &strUrlTmp) {
         }
 
         if (!err) {
+            // 取消定时器,避免hls拉流索引文件因为网络波动失败重连成功后出现循环重试的情况
+           strongSelf->_timer.reset();
             // 播放成功
             *piFailedCnt = 0;//连续播放失败次数清0
             strongSelf->onPlaySuccess();


### PR DESCRIPTION
当hls拉取索引文件失败时会触发重试.
但是play失败会调用一次rePlay, OnShutdow又会调用一次的rePlay.
由于m3u8文件非常小, 很大可能上短时间马上就会重试成功.
但是由于有两次的rePlay所以很可能再次析构了player, 又循环触发了更多的rePlay.

所以在播放成功后, 应该取消掉定时器