### PR TITLE
动态计算切片超时时间

### DIFF
--- a/src/Http/HlsPlayer.cpp
+++ b/src/Http/HlsPlayer.cpp
@@ -104,6 +104,11 @@ void HlsPlayer::fetchSegment() {
         }
         if (err) {
             WarnL << "download ts segment " << url << " failed:" << err.what();
+            if (err.getErrCode() == Err_timeout) {
+                strong_self->_timeout_multiple = MAX(strong_self->_timeout_multiple + 1, MAX_TIMEOUT_MULTIPLE);
+            }else{
+                strong_self->_timeout_multiple = MAX(strong_self->_timeout_multiple -1 , MIN_TIMEOUT_MULTIPLE);
+            }
         }
         //提前半秒下载好
         auto delay = duration - ticker.elapsedTime() / 1000.0f - 0.5;
@@ -122,8 +127,8 @@ void HlsPlayer::fetchSegment() {
     });
 
     _http_ts_player->setMethod("GET");
-    //ts切片必须在其时长的3倍内下载完毕
-    _http_ts_player->setCompleteTimeout(3 * duration * 1000);
+    //ts切片必须在其时长的2-5倍内下载完毕
+    _http_ts_player->setCompleteTimeout(_timeout_multiple * duration * 1000);
     _http_ts_player->sendRequest(url);
 }
 

--- a/src/Http/HlsPlayer.h
+++ b/src/Http/HlsPlayer.h
@@ -17,6 +17,9 @@
 #include "HlsParser.h"
 #include "Rtp/TSDecoder.h"
 
+#define MIN_TIMEOUT_MULTIPLE 2
+#define MAX_TIMEOUT_MULTIPLE 5
+
 namespace mediakit {
 
 class HlsDemuxer : public MediaSinkInterface , public TrackSource, public std::enable_shared_from_this<HlsDemuxer> {
@@ -101,6 +104,7 @@ private:
     std::list<std::string> _ts_url_sort;
     std::set<std::string, UrlComp> _ts_url_cache;
     HttpTSPlayer::Ptr _http_ts_player;
+    int _timeout_multiple = MIN_TIMEOUT_MULTIPLE;
 };
 
 class HlsPlayerImp : public PlayerImp<HlsPlayer, PlayerBase>, private TrackListener {


### PR DESCRIPTION
设置最大超时时间倍数和最小倍数,然后根据上一个切片的下载情况动态增加或者减少切片的超时时间.