### PR TITLE
丢弃不正确的包

### DIFF
--- a/src/Rtp/TSDecoder.cpp
+++ b/src/Rtp/TSDecoder.cpp
@@ -62,10 +62,10 @@ TSDecoder::TSDecoder() : _ts_segment() {
     });
     _demuxer_ctx = ts_demuxer_create([](void* param, int program, int stream, int codecid, int flags, int64_t pts, int64_t dts, const void* data, size_t bytes){
         TSDecoder *thiz = (TSDecoder*)param;
-        if(thiz->_on_decode){
-            if(flags & MPEG_FLAG_PACKET_CORRUPT) {
+        if (thiz->_on_decode) {
+            if (flags & MPEG_FLAG_PACKET_CORRUPT) {
                 WarnL << "ts packet lost, dts:" << dts << " pts:" << pts << " bytes:" << bytes;
-            }else{
+            } else {
                 thiz->_on_decode(stream, codecid, flags, pts, dts, data, bytes);
             }
         }

--- a/src/Rtp/TSDecoder.cpp
+++ b/src/Rtp/TSDecoder.cpp
@@ -55,6 +55,7 @@ const char *TSSegment::onSearchPacketTail(const char *data, size_t len) {
 
 #if defined(ENABLE_HLS)
 #include "mpeg-ts.h"
+#include "mpeg-ts-proto.h"
 TSDecoder::TSDecoder() : _ts_segment() {
     _ts_segment.setOnSegment([this](const char *data, size_t len){
         ts_demuxer_input(_demuxer_ctx,(uint8_t*)data,len);

--- a/src/Rtp/TSDecoder.cpp
+++ b/src/Rtp/TSDecoder.cpp
@@ -62,7 +62,11 @@ TSDecoder::TSDecoder() : _ts_segment() {
     _demuxer_ctx = ts_demuxer_create([](void* param, int program, int stream, int codecid, int flags, int64_t pts, int64_t dts, const void* data, size_t bytes){
         TSDecoder *thiz = (TSDecoder*)param;
         if(thiz->_on_decode){
-            thiz->_on_decode(stream,codecid,flags,pts,dts,data,bytes);
+            if(flags & MPEG_FLAG_PACKET_CORRUPT) {
+                WarnL << "ts packet lost, dts:" << dts << " pts:" << pts << " bytes:" << bytes;
+            }else{
+                thiz->_on_decode(stream, codecid, flags, pts, dts, data, bytes);
+            }
         }
         return 0;
     },this);


### PR DESCRIPTION
因为网络抖动或者拉流超时导致ts包不全.
这里丢弃掉有问题的包, 避免客户端解码中断