### PR TITLE
更加明确推流目标是否是自己

### DIFF
--- a/server/FFmpegSource.cpp
+++ b/server/FFmpegSource.cpp
@@ -64,7 +64,14 @@ static bool is_local_ip(const string &ip){
     }
     return false;
 }
-
+static bool dst_is_self(const mediakit::MediaInfo &dst){
+    bool is_local_host = is_local_ip(dst._host);
+    if (is_local_host) {
+        GET_CONFIG(string, server_port, "rtmp.port");
+        return server_port == dst._port;
+    }
+    return false;
+}
 void FFmpegSource::setupRecordFlag(bool enable_hls, bool enable_mp4){
     _enable_hls = enable_hls;
     _enable_mp4 = enable_mp4;
@@ -96,7 +103,7 @@ void FFmpegSource::play(const string &ffmpeg_cmd_key, const string &src_url,cons
     _process.run(cmd, log_file);
     InfoL << cmd;
 
-    if (is_local_ip(_media_info._host)) {
+    if (dst_is_self(_media_info)) {
         //推流给自己的，通过判断流是否注册上来判断是否正常
         if(_media_info._schema != RTSP_SCHEMA && _media_info._schema != RTMP_SCHEMA){
             cb(SockException(Err_other,"本服务只支持rtmp/rtsp推流"));
@@ -217,7 +224,7 @@ void FFmpegSource::startTimer(int timeout_ms) {
             return false;
         }
         bool needRestart = ffmpeg_restart_sec > 0 && strongSelf->_replay_ticker.elapsedTime() > ffmpeg_restart_sec * 1000;
-        if (is_local_ip(strongSelf->_media_info._host)) {
+        if (dst_is_self(strongSelf->_media_info)) {
             //推流给自己的，我们通过检查是否已经注册来判断FFmpeg是否工作正常
             strongSelf->findAsync(0, [&](const MediaSource::Ptr &src) {
                 //同步查找流


### PR DESCRIPTION
有些情况根据业务的不同, 会在同一个机器上部署多个zlm实例.
比如专门负责转码的, 专门用于截图的?
所以推流时应该根据是否是本地ip与端口来判断是否是推流给了自身.