### PR TITLE
重启子进程太快了

### DIFF
--- a/server/System.cpp
+++ b/server/System.cpp
@@ -110,8 +110,8 @@ void System::startDaemon() {
             int status = 0;
             if(waitpid(pid, &status, 0) >= 0) {
                 WarnL << "子进程退出";
-                //休眠5秒再启动子进程
-                sleep(5);
+                //休眠3秒再启动子进程
+                sleep(3);
                 break;
             }
             DebugL << "waitpid被中断:" << get_uv_errmsg();

--- a/server/System.cpp
+++ b/server/System.cpp
@@ -110,8 +110,8 @@ void System::startDaemon() {
             int status = 0;
             if(waitpid(pid, &status, 0) >= 0) {
                 WarnL << "子进程退出";
-                //休眠1秒再启动子进程
-                sleep(1);
+                //休眠5秒再启动子进程
+                sleep(5);
                 break;
             }
             DebugL << "waitpid被中断:" << get_uv_errmsg();


### PR DESCRIPTION
在负载比较重的机器上重启子进程太快了.
很容易导致端口仍旧还未释放完毕导致的错误
端口已被占用
从而主进程直接退出.
因此适当延长重启的间隔时间