### PR TITLE
修复HlsPlayer播放器BUG

### DIFF
--- a/src/Player/PlayerProxy.cpp
+++ b/src/Player/PlayerProxy.cpp
@@ -121,6 +121,11 @@ void PlayerProxy::setDirectProxy() {
 
 PlayerProxy::~PlayerProxy() {
     _timer.reset();
+    // 避免析构时, 忘记回调api请求
+     if(_on_play) {
+        _on_play(SockException(Err_shutdown, "player proxy close"));
+        _on_play = nullptr;
+    }
 }
 
 void PlayerProxy::rePlay(const string &strUrl, int iFailedCnt) {


### PR DESCRIPTION
当拉取加密流时, 因为不能正常播放, 所以不会触发playresult.
因此一直不会回调api请求.

接下去由于超时或者其他原因, 虽然会正常PlayerPoxy析构了.
但是也丢掉了回调函数.

因此会导致如果上层业务系统不主动结束addStreamProxy请求, 那么就会不停的重复拉流.

如果这时上层业务系统发起一个新的addStreamProxy请求, 那么两个请求就会互相干扰.

所以, 在PlayerProxy析构时, 应该主动释放addStreamProxy的请求回调.
