### PR TITLE
hls拉流时应该适当重试 

### DIFF
--- a/src/Http/HlsPlayer.cpp
+++ b/src/Http/HlsPlayer.cpp
@@ -42,7 +42,22 @@ void HlsPlayer::teardown_l(const SockException &ex) {
         _play_result = true;
         onPlayResult(ex);
     } else {
-        onShutdown(ex);
+        //如果不是主动关闭的，则重新拉取索引文件
+        if (ex.getErrCode() != Err_shutdown) {
+            // 当切片列表已空, 且没有正在下载的切片并且重试次数已经达到最大次数时, 则认为失败关闭播放器
+            if (_ts_list.empty() && !(_http_ts_player && _http_ts_player->waitResponse())
+                && _try_fetch_index_times >= MAX_TRY_FETCH_INDEX_TIMES) {
+                onShutdown(ex);
+            } else {
+                _try_fetch_index_times += 1;
+                shutdown(ex);
+                WarnL << "重新尝试拉取索引文件[" << _try_fetch_index_times << "]:" << _play_url;
+                fetchIndexFile();
+                return;
+            }
+        } else {
+            onShutdown(ex);
+        }
     }
     _timer.reset();
     _timer_ts.reset();

--- a/src/Http/HlsPlayer.h
+++ b/src/Http/HlsPlayer.h
@@ -19,6 +19,7 @@
 
 #define MIN_TIMEOUT_MULTIPLE 2
 #define MAX_TIMEOUT_MULTIPLE 5
+#define MAX_TRY_FETCH_INDEX_TIMES 5
 
 namespace mediakit {
 
@@ -105,6 +106,7 @@ private:
     std::set<std::string, UrlComp> _ts_url_cache;
     HttpTSPlayer::Ptr _http_ts_player;
     int _timeout_multiple = MIN_TIMEOUT_MULTIPLE;
+    int _try_fetch_index_times = 0;
 };
 
 class HlsPlayerImp : public PlayerImp<HlsPlayer, PlayerBase>, private TrackListener {


### PR DESCRIPTION
hls拉取索引文件失败时, 不应该直接上报,而应该内部适当重试几次.
避免由于网络抖动造成的过早释放muxer.
