### PR TITLE
避免m3u8文件为chunked时崩溃

### DIFF
--- a/src/Http/HttpChunkedSplitter.cpp
+++ b/src/Http/HttpChunkedSplitter.cpp
@@ -25,6 +25,9 @@ const char *HttpChunkedSplitter::onSearchPacketTail(const char *data, size_t len
 
 void HttpChunkedSplitter::onRecvContent(const char *data, size_t len) {
     onRecvChunk(data,len - 2);
+    if ((len - 2) <= 0) {
+        _onChunkData = nullptr;
+    }
 }
 
 ssize_t HttpChunkedSplitter::onRecvHeader(const char *data, size_t len) {

--- a/src/Http/HttpChunkedSplitter.cpp
+++ b/src/Http/HttpChunkedSplitter.cpp
@@ -9,32 +9,32 @@
  */
 
 #include <string.h>
+#include "Common/macros.h"
 #include "HttpChunkedSplitter.h"
 
 using namespace std;
 
+//[chunk size][\r\n][chunk data][\r\n][chunk size][\r\n][chunk data][\r\n][chunk size = 0][\r\n][\r\n]
+
 namespace mediakit{
-    
+
 const char *HttpChunkedSplitter::onSearchPacketTail(const char *data, size_t len) {
-    auto pos = strstr(data,"\r\n");
-    if(!pos){
+    auto pos = strstr(data, "\r\n");
+    if (!pos) {
         return nullptr;
     }
     return pos + 2;
 }
 
 void HttpChunkedSplitter::onRecvContent(const char *data, size_t len) {
-    onRecvChunk(data,len - 2);
-    if ((len - 2) <= 0) {
-        _onChunkData = nullptr;
-    }
+    onRecvChunk(data, len - 2);
 }
 
 ssize_t HttpChunkedSplitter::onRecvHeader(const char *data, size_t len) {
-    string str(data,len - 2);
-    int ret;
-    sscanf(str.data(),"%X",&ret);
-    return ret + 2;
+    int size;
+    CHECK(sscanf(data, "%X", &size) == 1 && size >= 0);
+    //包括后面\r\n两个字节
+    return size + 2;
 }
 
 }//namespace mediakit

--- a/src/Http/HttpChunkedSplitter.h
+++ b/src/Http/HttpChunkedSplitter.h
@@ -21,12 +21,10 @@ public:
     /**
      * len == 0时代表结束
      */
-    typedef std::function<void (const char *data,size_t len)> onChunkData;
+   using onChunkData = std::function<void(const char *data, size_t len)>;
 
-    HttpChunkedSplitter(const onChunkData &cb){
-        _onChunkData = cb;
-    };
-    ~HttpChunkedSplitter() override {} ;
+    HttpChunkedSplitter(const onChunkData &cb) { _onChunkData = cb; };
+    ~HttpChunkedSplitter() override { _onChunkData = nullptr; };
 
 protected:
     ssize_t onRecvHeader(const char *data,size_t len) override;


### PR DESCRIPTION
具体问题见
https://github.com/ZLMediaKit/ZLMediaKit/issues/1407

当数据最后小于2个字节时, 应该放弃回调.
做个保险, 避免导致溢出后崩溃.

这个bug很难出现, 但是的确存在. 一些特殊的服务器采用chunked返回的m3u8文件解析时, 有可能会遇到.