### PR TITLE
双重保险, 避免重启失败

### DIFF
--- a/server/System.cpp
+++ b/server/System.cpp
@@ -84,6 +84,7 @@ static void sig_crash(int sig) {
 void System::startDaemon() {
 #ifndef _WIN32
     static pid_t pid;
+    static bool is_restart = false;
     do{
         pid = fork();
         if(pid == -1){
@@ -100,17 +101,26 @@ void System::startDaemon() {
 
         //父进程,监视子进程是否退出
         DebugL << "启动子进程:"  << pid;
+        signal(SIGUSR1, [](int) {
+            if (!is_restart){
+                DebugL << "子进程启动错误, 即将退出";
+                kill(pid, SIGINT);
+                exit(0);
+            }else{
+                WarnL << "尝试再次重启子进程";
+            }
+        });
         signal(SIGINT, [](int) {
             WarnL << "收到主动退出信号,关闭父进程与子进程";
             kill(pid,SIGINT);
             exit(0);
         });
-
         do{
             int status = 0;
             if(waitpid(pid, &status, 0) >= 0) {
                 WarnL << "子进程退出";
-                //休眠3秒再启动子进程
+                //休眠1秒再启动子进程
+                is_restart = true;
                 sleep(3);
                 break;
             }

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -318,7 +318,7 @@ int start_main(int argc,char *argv[]) {
             sleep(1);
 #if !defined(_WIN32)
             if (pid != getpid()) {
-                kill(pid, SIGINT);
+                kill(pid, SIGUSR1);
             }
 #endif
             return -1;


### PR DESCRIPTION
业务繁忙的服务器当子进程崩溃后,
虽然延时了3秒, 但是如果服务器负载很高, 或者开启了coredump
会导致拉起子进程时, 仍旧端口占用导致子进程重启失败而直接退出主进程.

因此, 这里做了双重保险, 当子进程拉起时如果端口占用, 那么子进程会继续重试.