### PR TITLE
修复h264相关bug

### DIFF
--- a/src/Extension/Frame.h
+++ b/src/Extension/Frame.h
@@ -445,6 +445,67 @@ protected:
 };
 
 /**
+ * 该对象的功能是把一个不可缓存的帧转换成可缓存的帧
+ */
+class FrameCacheAble : public FrameFromPtr {
+public:
+    typedef std::shared_ptr<FrameCacheAble> Ptr;
+
+    FrameCacheAble(const Frame::Ptr &frame, bool force_key_frame = false) {
+        if (frame->cacheAble()) {
+            _frame = frame;
+            _ptr = frame->data();
+        } else {
+            _buffer = FrameImp::create();
+            _buffer->_buffer.assign(frame->data(), frame->size());
+            _ptr = _buffer->data();
+        }
+        _size = frame->size();
+        _dts = frame->dts();
+        _pts = frame->pts();
+        _prefix_size = frame->prefixSize();
+        _codec_id = frame->getCodecId();
+        _key = force_key_frame ? true : frame->keyFrame();
+        _config = frame->configFrame();
+        _drop_able = frame->dropAble();
+        _decode_able = frame->decodeAble();
+    }
+
+    ~FrameCacheAble() override = default;
+
+    /**
+     * 可以被缓存
+     */
+    bool cacheAble() const override {
+        return true;
+    }
+
+    bool keyFrame() const override{
+        return _key;
+    }
+
+    bool configFrame() const override{
+        return _config;
+    }
+
+    bool dropAble() const override {
+        return _drop_able;
+    }
+
+    bool decodeAble() const override {
+        return _decode_able;
+    }
+
+private:
+    bool _key;
+    bool _config;
+    bool _drop_able;
+    bool _decode_able;
+    Frame::Ptr _frame;
+    FrameImp::Ptr _buffer;
+};
+
+/**
  * 该对象可以把Buffer对象转换成可缓存的Frame对象
  */
 template <typename Parent>

--- a/src/Extension/H264.h
+++ b/src/Extension/H264.h
@@ -138,7 +138,7 @@ private:
     void insertConfigFrame(const Frame::Ptr &frame);
 
 private:
-    bool _is_idr = false;
+    bool _insert_config_frame = false;
     int _width = 0;
     int _height = 0;
     float _fps = 0;


### PR DESCRIPTION
1.修复由于识别不出关键帧而导致hls不能切片.
2.修复由于丢弃sei帧导致ffplay不能正常播放