### PR TITLE
rtmp拉流的相关改动

### DIFF
--- a/src/Rtmp/RtmpPlayer.cpp
+++ b/src/Rtmp/RtmpPlayer.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 The ZLMediaKit project authors. All Rights Reserved.
  *
  * This file is part of ZLMediaKit(https://github.com/xia-chu/ZLMediaKit).

--- a/src/Rtmp/RtmpPlayer.cpp
+++ b/src/Rtmp/RtmpPlayer.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2016 The ZLMediaKit project authors. All Rights Reserved.
  *
  * This file is part of ZLMediaKit(https://github.com/xia-chu/ZLMediaKit).
@@ -214,7 +214,7 @@ inline void RtmpPlayer::send_createStream() {
 
 inline void RtmpPlayer::send_play() {
     AMFEncoder enc;
-    enc << "play" << ++_send_req_id << nullptr << _stream_id << (double) _stream_index;
+    enc << "play" << ++_send_req_id << nullptr << _stream_id << "-2000";
     sendRequest(MSG_CMD, enc.data());
     auto fun = [](AMFValue &val) {
         //TraceL << "play onStatus";
@@ -297,7 +297,8 @@ void RtmpPlayer::onCmd_onStatus(AMFDecoder &dec) {
         auto level = val["level"];
         auto code = val["code"].as_string();
         if (level.type() == AMF_STRING) {
-            if (level.as_string() != "status") {
+            // warning 不应该断开
+            if (level.as_string() != "status" && level.as_string() != "warning") {
                 throw std::runtime_error(StrPrinter << "onStatus 失败:" << level.as_string() << " " << code << endl);
             }
         }

--- a/src/Rtmp/RtmpProtocol.cpp
+++ b/src/Rtmp/RtmpProtocol.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 The ZLMediaKit project authors. All Rights Reserved.
  *
  * This file is part of ZLMediaKit(https://github.com/xia-chu/ZLMediaKit).


### PR DESCRIPTION
1. 修复play指令的bug
2. 服务器返回的一些warning状态, 比如带宽不足等, 不应该直接报错断开.
3. 处理集合消息时根据ffmpeg的相关方式来计算时间戳.

目前这几处修改仍旧感觉不完善.
我从网上找到的测试流进行测试时, 时间戳已经不会回跳了, 但是ffmpeg播放仍旧有错误.

```
[aac @ 0x7f946001ed40] decode_band_types: Input buffer exhausted before END element found
[aac @ 0x7f946001ed40] decode_band_types: Input buffer exhausted before END element found
    Last message repeated 2 times
[aac @ 0x7f946001ed40] decode_band_types: Input buffer exhausted before END element found
    Last message repeated 2 times
[aac @ 0x7f946001ed40] decode_band_types: Input buffer exhausted before END element found
    Last message repeated 2 times
[aac @ 0x7f946001ed40] decode_band_types: Input buffer exhausted before END element found
    Last message repeated 2 times
[aac @ 0x7f946001ed40] decode_band_types: Input buffer exhausted before END element found

```

这个错误不知道如何解决了.
测试地址还是群里我发的地址.