### PR TITLE
解决CentOS7下Parse.cpp编译不通过问题

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,12 @@ if(CCACHE_FOUND)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
 endif(CCACHE_FOUND)
 
+#add_compile_options(-D__STDC_FORMAT_MACROS)
+if(CMAKE_COMPILER_IS_GNUCXX)
+	add_compile_options(-D__STDC_FORMAT_MACROS)
+    message(STATUS "-D__STDC_FORMAT_MACROS")
+endif(CMAKE_COMPILER_IS_GNUCXX)
+
 #set(CMAKE_BUILD_TYPE "Release")
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "")
     set(CMAKE_BUILD_TYPE "Debug")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ endif(CCACHE_FOUND)
 
 #add_compile_options(-D__STDC_FORMAT_MACROS)
 if(CMAKE_COMPILER_IS_GNUCXX)
-	add_compile_options(-D__STDC_FORMAT_MACROS)
+    add_compile_options(-D__STDC_FORMAT_MACROS)
     message(STATUS "-D__STDC_FORMAT_MACROS")
 endif(CMAKE_COMPILER_IS_GNUCXX)
 


### PR DESCRIPTION
解决CentOS7下Parse.cpp编译不通过问题