### PR TITLE
支持SDP munging方式simulicast

### DIFF
--- a/webrtc/Sdp.cpp
+++ b/webrtc/Sdp.cpp
@@ -895,7 +895,7 @@ void RtcSession::loadFrom(const string &str) {
             CHECK(rtc_media.rtp_rtx_ssrc.size() <= 1);
         } else {
             //simulcast的情况下，要么没有指定ssrc，要么指定的ssrc个数与rid个数一致
-            CHECK(rtc_media.rtp_ssrc_sim.empty() || rtc_media.rtp_ssrc_sim.size() == rtc_media.rtp_rids.size());
+            //CHECK(rtc_media.rtp_ssrc_sim.empty() || rtc_media.rtp_ssrc_sim.size() == rtc_media.rtp_rids.size());
         }
 
         auto rtpmap_arr = media.getAllItem<SdpAttrRtpMap>('a', "rtpmap");
@@ -1290,7 +1290,7 @@ void RtcMedia::checkValid() const{
     CHECK(type == TrackApplication || rtcp_mux, "只支持rtcp-mux模式");
 
     bool send_rtp = (direction == RtpDirection::sendonly || direction == RtpDirection::sendrecv);
-    if (rtp_rids.empty() && rtp_ssrc_sim.empty()) {
+    if (!supportSimulcast()) {
         //非simulcast时，检查有没有指定rtp ssrc
         CHECK(!rtp_rtx_ssrc.empty() || !send_rtp);
     }
@@ -1594,7 +1594,6 @@ RETRY:
 #ifdef ENABLE_SCTP
             answer_media.direction = matchDirection(offer_media.direction, configure.direction);
             answer_media.candidate = configure.candidate;
-
 #else
             answer_media.direction = RtpDirection::inactive;
 #endif
@@ -1640,7 +1639,10 @@ RETRY:
             answer_media.fingerprint = configure.fingerprint;
             answer_media.ice_lite = configure.ice_lite;
             answer_media.candidate = configure.candidate;
+            // copy simulicast setting
             answer_media.rtp_rids = offer_media.rtp_rids;
+            answer_media.rtp_ssrc_sim = offer_media.rtp_ssrc_sim;
+
             answer_media.role = mathDtlsRole(offer_media.role);
 
             //如果codec匹配失败，那么禁用该track

--- a/webrtc/WebRtcTransport.cpp
+++ b/webrtc/WebRtcTransport.cpp
@@ -463,6 +463,13 @@ void WebRtcTransportImp::onStartWebRTC() {
             if (m_offer->rtp_rids.size() > index) {
                 //支持firefox的simulcast, 提前映射好ssrc和rid的关系
                 track->rtp_ext_ctx->setRid(ssrc.ssrc, m_offer->rtp_rids[index]);
+            } else {
+                // SDP munging没有rid, 它通过group-ssrc:SIM给出ssrc列表;
+                // 系统又要有rid，这里手工生成rid，并为其绑定ssrc
+                std::string rid = "r" + std::to_string(index);
+                track->rtp_ext_ctx->setRid(ssrc.ssrc, rid);
+                if(ssrc.rtx_ssrc)
+                    track->rtp_ext_ctx->setRid(ssrc.rtx_ssrc, rid);
             }
             ++index;
         }


### PR DESCRIPTION
虽然说planb要被webrtc废弃了，但有些库使用的是老版的webrtc，很遗憾的是我这边维护的就是这样的一个库；
只能使用SDP munging支持simulicast，如下代码
```c++
PeerConnectionInterface::RTCConfiguration config;
// config.sdp_semantics = SdpSemantics::kUnifiedPlan;
pc_ = pc_factory->CreatePeerConnection(config,...)

 PeerConnectionInterface::RTCOfferAnswerOptions opt;
 opt.num_simulcast_layers = 2;
 pc_->addStream(media);
 pc_->CreateOffer(this, opt); 
 ```
这样就能产生SDP munging的sdp，
```sdp
a=ssrc-group:SIM 1815289772 3974668332
a=ssrc-group:FID 1815289772 1199324968
a=ssrc-group:FID 3974668332 4137902746
a=ssrc:1815289772 cname:+smA2eG33lclHZb2
a=ssrc:1815289772 msid:test zlm_video
a=ssrc:1815289772 mslabel:test
a=ssrc:1815289772 label:zlm_video
a=ssrc:3974668332 cname:+smA2eG33lclHZb2
a=ssrc:3974668332 msid:test zlm_video
a=ssrc:3974668332 mslabel:test
a=ssrc:3974668332 label:zlm_video
a=ssrc:1199324968 cname:+smA2eG33lclHZb2
a=ssrc:1199324968 msid:test zlm_video
a=ssrc:1199324968 mslabel:test
a=ssrc:1199324968 label:zlm_video
a=ssrc:4137902746 cname:+smA2eG33lclHZb2
a=ssrc:4137902746 msid:test zlm_video
a=ssrc:4137902746 mslabel:test
a=ssrc:4137902746 label:zlm_video
```
但此时是没有rid扩展报头的，zlm默认是不支持的，但好在sdp实现得比较好；
小修改了下代码，也能支持sdp munging机制

其中 sdp.cpp:1644 行的 answer_media.rtp_ssrc_sim = offer_media.rtp_ssrc_sim; 是可以不加的，
但此时就必须修改WebRtcPusher中关于_simulcast的判断，即将
WebRtcPusher.cpp:107中的
    _simulcast = _answer_sdp->supportSimulcast();
改成
    _simulcast = _offer_sdp->supportSimulcast();

打完这补丁后，服务器会自动为SDP munging的ssrc生成以r0 r1 r2方式的rid，并绑定其ssrc
拉流也是在后面加上_r0后缀