### PR TITLE
修复拉取srs rtmp 流 play 命令参数类型不对的bug(参考vlc -2000 为number 类型)

### DIFF
--- a/src/Rtmp/RtmpPlayer.cpp
+++ b/src/Rtmp/RtmpPlayer.cpp
@@ -209,7 +209,7 @@ inline void RtmpPlayer::send_createStream() {
 
 inline void RtmpPlayer::send_play() {
     AMFEncoder enc;
-    enc << "play" << ++_send_req_id << nullptr << _stream_id << "-2000";
+    enc << "play" << ++_send_req_id << nullptr << _stream_id << -2000;
     sendRequest(MSG_CMD, enc.data());
     auto fun = [](AMFValue &val) {
         //TraceL << "play onStatus";


### PR DESCRIPTION
修复拉取srs rtmp 流 play 命令参数类型不对的bug(参考vlc -2000 为number 类型)