### PR TITLE
Update MP4Recorder.cpp

### DIFF
--- a/src/Record/MP4Recorder.cpp
+++ b/src/Record/MP4Recorder.cpp
@@ -73,15 +73,18 @@ void MP4Recorder::asyncClose() {
         info.time_len = (float) (::time(NULL) - info.start_time);
         //关闭mp4非常耗时，所以要放在后台线程执行
         muxer->closeMP4();
-        //获取文件大小
-        info.file_size = File::fileSize(full_path_tmp.data());
-        if (info.file_size < 1024) {
-            //录像文件太小，删除之
-            File::delete_file(full_path_tmp.data());
-            return;
+        
+        if(!full_path_tmp.empty()) {
+            //获取文件大小
+            info.file_size = File::fileSize(full_path_tmp.data());
+            if (info.file_size < 1024) {
+                //录像文件太小，删除之
+                File::delete_file(full_path_tmp.data());
+                return;
+            }
+            //临时文件名改成正式文件名，防止mp4未完成时被访问
+            rename(full_path_tmp.data(), full_path.data());
         }
-        //临时文件名改成正式文件名，防止mp4未完成时被访问
-        rename(full_path_tmp.data(), full_path.data());
 
         /////record 业务逻辑//////
         NoticeCenter::Instance().emitEvent(Broadcast::kBroadcastRecordMP4, info);


### PR DESCRIPTION
fix #1679 
_muxer->openMP4 创建非法的文件夹会失败抛出异常  所以_full_path_tmp等都是空字符串
delete_file的时候 就会从此盘符的""(full_path_tmp)目录挨个删除了。 
复现建议新建个盘符...