### PR TITLE
get ip from env, for externIP in file 'config.ini'

### DIFF
--- a/webrtc/WebRtcTransport.cpp
+++ b/webrtc/WebRtcTransport.cpp
@@ -483,8 +483,9 @@ void WebRtcTransportImp::onStartWebRTC() {
                 // 系统又要有rid，这里手工生成rid，并为其绑定ssrc
                 std::string rid = "r" + std::to_string(index);
                 track->rtp_ext_ctx->setRid(ssrc.ssrc, rid);
-                if(ssrc.rtx_ssrc)
+                if (ssrc.rtx_ssrc) {
                     track->rtp_ext_ctx->setRid(ssrc.rtx_ssrc, rid);
+                }
             }
             ++index;
         }
@@ -702,7 +703,7 @@ void WebRtcTransportImp::onRtcp(const char *buf, size_t len) {
                 if (it != _ssrc_to_track.end()) {
                     auto &track = it->second;
                     auto rtp_chn = track->getRtpChannel(sr->ssrc);
-                    if(!rtp_chn){
+                    if (!rtp_chn) {
                         WarnL << "未识别的sr rtcp包:" << rtcp->dumpString();
                     } else {
                         //InfoL << "接收丢包率,ssrc:" << sr->ssrc << ",loss rate(%):" << rtp_chn->getLossRate();

--- a/webrtc/WebRtcTransport.cpp
+++ b/webrtc/WebRtcTransport.cpp
@@ -52,12 +52,14 @@ static void translateIPFromEnv(std::vector<std::string> &v) {
     for (auto iter = v.begin(); iter != v.end();) {
         if (start_with(*iter, "$")) {
             auto ip = toolkit::getEnv(*iter);
-            if (ip.empty())
+            if (ip.empty()) {
                 iter = v.erase(iter);
-            else
+            } else {
                 *iter++ = ip;
-        } else
+            }
+        } else {
             ++iter;
+        }
     }
 }
 
@@ -491,10 +493,11 @@ void WebRtcTransportImp::onStartWebRTC() {
 
 void WebRtcTransportImp::onCheckAnswer(RtcSession &sdp) {
     //修改answer sdp的ip、端口信息
-    GET_CONFIG_FUNC(std::vector<std::string>, extern_ips, RTC::kExternIP, [](string str){
+    GET_CONFIG_FUNC(std::vector<std::string>, extern_ips, RTC::kExternIP, [](string str) {
         std::vector<std::string> ret;
-        if (str.length())
+        if (str.length()) {
             ret = split(str, ",");
+        }
         translateIPFromEnv(ret);
         return ret;
     });
@@ -570,16 +573,16 @@ void WebRtcTransportImp::onRtcConfigure(RtcConfigure &configure) const {
     //添加接收端口candidate信息
     GET_CONFIG_FUNC(std::vector<std::string>, extern_ips, RTC::kExternIP, [](string str){
         std::vector<std::string> ret;
-        if (str.length())
+        if (str.length()) {
             ret = split(str, ",");
+        }
         translateIPFromEnv(ret);
         return ret;
     });
     if (extern_ips.empty()) {
         std::string localIp = SockUtil::get_local_ip();
         configure.addCandidate(*makeIceCandidate(localIp, local_port, 120, "udp"));
-    }
-    else {
+    } else {
         const uint32_t delta = 10;
         uint32_t priority = 100 + delta * extern_ips.size();
         for (auto ip : extern_ips) {
@@ -588,7 +591,6 @@ void WebRtcTransportImp::onRtcConfigure(RtcConfigure &configure) const {
         }
     }
 }
-
 
 
 ///////////////////////////////////////////////////////////////////

--- a/webrtc/WebRtcTransport.cpp
+++ b/webrtc/WebRtcTransport.cpp
@@ -48,6 +48,19 @@ static onceToken token([]() {
 
 static atomic<uint64_t> s_key{0};
 
+static void translateIPFromEnv(std::vector<std::string> &v) {
+    for (auto iter = v.begin(); iter != v.end();) {
+        if (start_with(*iter, "$")) {
+            auto ip = toolkit::getEnv(*iter);
+            if (ip.empty())
+                iter = v.erase(iter);
+            else
+                *iter++ = ip;
+        } else
+            ++iter;
+    }
+}
+
 WebRtcTransport::WebRtcTransport(const EventPoller::Ptr &poller) {
     _poller = poller;
     _identifier = "zlm_" + to_string(++s_key);
@@ -482,6 +495,7 @@ void WebRtcTransportImp::onCheckAnswer(RtcSession &sdp) {
         std::vector<std::string> ret;
         if (str.length())
             ret = split(str, ",");
+        translateIPFromEnv(ret);
         return ret;
     });
     for (auto &m : sdp.media) {
@@ -558,6 +572,7 @@ void WebRtcTransportImp::onRtcConfigure(RtcConfigure &configure) const {
         std::vector<std::string> ret;
         if (str.length())
             ret = split(str, ",");
+        translateIPFromEnv(ret);
         return ret;
     });
     if (extern_ips.empty()) {


### PR DESCRIPTION
#### 功能
增加读取环境变量功能，用于externIP

#### 用法
修改配置文件externIP字段如下：
```
[rtc]
externIP=$EXTERNIP
```

#### 用途
docker部署的时候，可以将IP地址通过环境变量传递进去，避免了手动修改IP地址的麻烦。
比如：
```
docker run -id  -p 8080:80  -p 8000:8000/udp --env EXTERNIP=192.168.1.123 zlmediakit/zlmediakit:master
```