### PR TITLE
Feature/fix rtsp player pt error

### DIFF
--- a/src/Rtsp/RtpReceiver.cpp
+++ b/src/Rtsp/RtpReceiver.cpp
@@ -114,6 +114,10 @@ void RtpTrack::setNtpStamp(uint32_t rtp_stamp, uint64_t ntp_stamp_ms) {
     }
 }
 
+void RtpTrack::setPT(uint8_t pt){
+    _pt = pt;
+}
+
 ////////////////////////////////////////////////////////////////////////////////////
 
 void RtpTrackImp::setOnSorted(OnSorted cb) {

--- a/src/Rtsp/RtpReceiver.h
+++ b/src/Rtsp/RtpReceiver.h
@@ -175,6 +175,7 @@ public:
     uint32_t getSSRC() const;
     RtpPacket::Ptr inputRtp(TrackType type, int sample_rate, uint8_t *ptr, size_t len);
     void setNtpStamp(uint32_t rtp_stamp, uint64_t ntp_stamp_ms);
+    void setPT(uint8_t pt);
 
 protected:
     virtual void onRtpSorted(RtpPacket::Ptr rtp) {}
@@ -250,6 +251,11 @@ public:
     void setNtpStamp(int index, uint32_t rtp_stamp, uint64_t ntp_stamp_ms) {
         assert(index < kCount && index >= 0);
         _track[index].setNtpStamp(rtp_stamp, ntp_stamp_ms);
+    }
+
+    void setPT(int index, uint8_t pt){
+        assert(index < kCount && index >= 0);
+        _track[index].setPT(pt);
     }
 
     void clear() {

--- a/src/Rtsp/Rtsp.cpp
+++ b/src/Rtsp/Rtsp.cpp
@@ -212,7 +212,7 @@ void SdpParser::load(const string &sdp) {
             char codec[16] = {0};
 
             sscanf(rtpmap.data(), "%d", &pt);
-            if (track._pt != pt) {
+            if (track._pt != pt && track._pt != 0xff) {
                 //pt不匹配
                 it = track._attr.erase(it);
                 continue;
@@ -237,7 +237,7 @@ void SdpParser::load(const string &sdp) {
             auto &fmtp = it->second;
             int pt;
             sscanf(fmtp.data(), "%d", &pt);
-            if (track._pt != pt) {
+            if (track._pt != pt && track._pt != 0xff) {
                 //pt不匹配
                 it = track._attr.erase(it);
                 continue;

--- a/src/Rtsp/Rtsp.h
+++ b/src/Rtsp/Rtsp.h
@@ -217,7 +217,7 @@ public:
     std::string getControlUrl(const std::string &base_url) const;
 
 public:
-    int _pt;
+    int _pt = 0xff;
     int _channel;
     int _samplerate;
     TrackType _type;

--- a/src/Rtsp/RtspPlayer.cpp
+++ b/src/Rtsp/RtspPlayer.cpp
@@ -208,6 +208,9 @@ void RtspPlayer::handleResDESCRIBE(const Parser& parser) {
     }
     _rtcp_context.clear();
     for (auto &track : _sdp_track) {
+        if(track->_pt != 0xff){
+            setPT(_rtcp_context.size(),track->_pt);
+        }
         _rtcp_context.emplace_back(std::make_shared<RtcpContextForRecv>());
     }
     sendSetup(0);


### PR DESCRIPTION
修复这个问题https://github.com/ZLMediaKit/ZLMediaKit/issues/1804 的提交，主要是视频通道会发几个无效的pt导致pt的初始值错误，vlc 播放正常（应该是过滤掉了其他非sdp指定的pt）。rtsp sdp中的pt 是否值得相信，我也不是很清楚，不知道是否应该合并到主分支，如果合并了，如果sdp中的pt不正确，会导致意外的错误。