### PR TITLE
API目录支持安卓编译，输出libmk_api.a

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -14,7 +14,7 @@ android {
             externalNativeBuild {
                 cmake {
                     cppFlags "-std=c++11 -frtti -fexceptions"
-                    arguments "-DENABLE_API=off", "-DENABLE_TESTS=off", "-DENABLE_PLAYER=off", "-DENABLE_SERVER_LIB=on"
+                    arguments "-DENABLE_API=on", "-DENABLE_API_STATIC_LIB=on", "-DCMAKE_BUILD_TYPE=Release", "-DENABLE_TESTS=off", "-DENABLE_PLAYER=off", "-DENABLE_SERVER_LIB=on"
                 }
             }
             ndk {

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -30,6 +30,7 @@ file(GLOB API_SRC_LIST
 
 set(LINK_LIBRARIES ${MK_LINK_LIBRARIES} jsoncpp)
 
+
 if(IOS)
   add_library(mk_api STATIC ${API_SRC_LIST})
   target_link_libraries(mk_api
@@ -58,6 +59,10 @@ target_include_directories(mk_api
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   target_link_libraries(mk_api -Wl,--start-group ${LINK_LIBRARIES} -Wl,--end-group)
+elseif(CMAKE_SYSTEM_NAME MATCHES "Android")
+  find_library(log-lib log)
+  include_directories("${CMAKE_BINARY_DIR}")
+  target_link_libraries(mk_api -Wl,--start-group ${LINK_LIBRARIES} ${log-lib} -Wl,--end-group)
 else()
   target_link_libraries(mk_api jsoncpp ${LINK_LIBRARIES})
 endif()


### PR DESCRIPTION
支持android下编译API目录，输出"libmk_api.a"， 为了减小体积默认编译成Release版本。
如果需要Debug版本或者so文件，可以改动 build.gradle中的参数。
