### PR TITLE
API目录支持安卓编译，输出libmk_api.a[参考 wasphin大佬的指导改进了一些地方]

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -14,7 +14,7 @@ android {
             externalNativeBuild {
                 cmake {
                     cppFlags "-std=c++11 -frtti -fexceptions"
-                    arguments "-DENABLE_API=on", "-DENABLE_API_STATIC_LIB=on", "-DCMAKE_BUILD_TYPE=Release", "-DENABLE_TESTS=off", "-DENABLE_PLAYER=off", "-DENABLE_SERVER_LIB=on"
+                    arguments "-DENABLE_API=on", "-DENABLE_API_STATIC_LIB=on", "-DENABLE_TESTS=off", "-DENABLE_PLAYER=off", "-DENABLE_SERVER_LIB=on"
                 }
             }
             ndk {

--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 28
-    ndkVersion "21.4.7075529"
+    ndkVersion "25.0.8775105"
     defaultConfig {
         applicationId "com.zlmediakit.demo"
         minSdkVersion 15

--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -14,7 +14,7 @@ android {
             externalNativeBuild {
                 cmake {
                     cppFlags "-std=c++11 -frtti -fexceptions"
-                    arguments "-DENABLE_API=off", "-DENABLE_TESTS=off", "-DENABLE_PLAYER=off", "-DENABLE_SERVER_LIB=on"
+                    arguments "-DENABLE_API=on", "-DENABLE_API_STATIC_LIB=on", "-DCMAKE_BUILD_TYPE=Release", "-DENABLE_TESTS=off", "-DENABLE_PLAYER=off", "-DENABLE_SERVER_LIB=on"
                 }
             }
             ndk {

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -30,7 +30,6 @@ file(GLOB API_SRC_LIST
 
 set(LINK_LIBRARIES ${MK_LINK_LIBRARIES} jsoncpp)
 
-
 if(IOS)
   add_library(mk_api STATIC ${API_SRC_LIST})
   target_link_libraries(mk_api
@@ -60,9 +59,8 @@ target_include_directories(mk_api
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   target_link_libraries(mk_api -Wl,--start-group ${LINK_LIBRARIES} -Wl,--end-group)
 elseif(CMAKE_SYSTEM_NAME MATCHES "Android")
-  find_library(log-lib log)
   include_directories("${CMAKE_BINARY_DIR}")
-  target_link_libraries(mk_api -Wl,--start-group ${LINK_LIBRARIES} ${log-lib} -Wl,--end-group)
+  target_link_libraries(mk_api log -Wl,--start-group ${LINK_LIBRARIES} -Wl,--end-group)
 else()
   target_link_libraries(mk_api jsoncpp ${LINK_LIBRARIES})
 endif()

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -30,6 +30,7 @@ file(GLOB API_SRC_LIST
 
 set(LINK_LIBRARIES ${MK_LINK_LIBRARIES} jsoncpp)
 
+
 if(IOS)
   add_library(mk_api STATIC ${API_SRC_LIST})
   target_link_libraries(mk_api
@@ -58,6 +59,10 @@ target_include_directories(mk_api
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   target_link_libraries(mk_api -Wl,--start-group ${LINK_LIBRARIES} -Wl,--end-group)
+elseif(CMAKE_SYSTEM_NAME MATCHES "Android")
+  find_library(log-lib log)
+  include_directories("${CMAKE_BINARY_DIR}")
+  target_link_libraries(mk_api -Wl,--start-group ${LINK_LIBRARIES} ${log-lib} -Wl,--end-group)
 else()
   target_link_libraries(mk_api jsoncpp ${LINK_LIBRARIES})
 endif()


### PR DESCRIPTION
1.  在android studio里可以通过设置"Build Variant"  来决定是Rlease  or Debug.
2.  根据wasphin大佬的指导，可以直接使用系统自带的 log库。
3.  加入 include_directories("${CMAKE_BINARY_DIR}") 是为了查找 mk_export.h