### PR TITLE
调整与优化onRtpSorted逻辑

### DIFF
--- a/src/Rtsp/RtpReceiver.cpp
+++ b/src/Rtsp/RtpReceiver.cpp
@@ -118,6 +118,18 @@ void RtpTrack::setPT(uint8_t pt){
     _pt = pt;
 }
 
+void RtpTrack::onRtpSorted(RtpPacket::Ptr rtp) {
+    if (_on_sorted) {
+        _on_sorted(std::move(rtp));
+    }
+}
+
+void RtpTrack::onBeforeRtpSorted(const RtpPacket::Ptr &rtp) {
+    if (_on_before_sorted) {
+        _on_before_sorted(rtp);
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////////
 
 void RtpTrackImp::setOnSorted(OnSorted cb) {
@@ -128,16 +140,6 @@ void RtpTrackImp::setBeforeSorted(BeforeSorted cb) {
     _on_before_sorted = std::move(cb);
 }
 
-void RtpTrackImp::onRtpSorted(RtpPacket::Ptr rtp) {
-    if (_on_sorted) {
-        _on_sorted(std::move(rtp));
-    }
-}
 
-void RtpTrackImp::onBeforeRtpSorted(const RtpPacket::Ptr &rtp) {
-    if (_on_before_sorted) {
-        _on_before_sorted(rtp);
-    }
-}
 
 }//namespace mediakit

--- a/src/Rtsp/RtpReceiver.h
+++ b/src/Rtsp/RtpReceiver.h
@@ -161,6 +161,9 @@ private:
 
 class RtpTrack : private PacketSortor<RtpPacket::Ptr>{
 public:
+    using OnSorted = std::function<void(RtpPacket::Ptr)>;
+    using BeforeSorted = std::function<void(const RtpPacket::Ptr &)>;
+
     class BadRtpException : public std::invalid_argument {
     public:
         template<typename Type>
@@ -178,8 +181,12 @@ public:
     void setPT(uint8_t pt);
 
 protected:
-    virtual void onRtpSorted(RtpPacket::Ptr rtp) {}
-    virtual void onBeforeRtpSorted(const RtpPacket::Ptr &rtp) {}
+    void onRtpSorted(RtpPacket::Ptr rtp);
+    void onBeforeRtpSorted(const RtpPacket::Ptr &rtp);
+
+protected:
+    OnSorted _on_sorted;
+    BeforeSorted _on_before_sorted;
 
 private:
     bool _disable_ntp = false;
@@ -191,22 +198,11 @@ private:
 
 class RtpTrackImp : public RtpTrack{
 public:
-    using OnSorted = std::function<void(RtpPacket::Ptr)>;
-    using BeforeSorted = std::function<void(const RtpPacket::Ptr &)>;
-
     RtpTrackImp() = default;
     ~RtpTrackImp() override = default;
 
     void setOnSorted(OnSorted cb);
     void setBeforeSorted(BeforeSorted cb);
-
-protected:
-    void onRtpSorted(RtpPacket::Ptr rtp) override;
-    void onBeforeRtpSorted(const RtpPacket::Ptr &rtp) override;
-
-private:
-    OnSorted _on_sorted;
-    BeforeSorted _on_before_sorted;
 };
 
 template<int kCount = 2>
@@ -285,14 +281,14 @@ protected:
      * @param rtp rtp数据包
      * @param track_index track索引
      */
-    virtual void onRtpSorted(RtpPacket::Ptr rtp, int index) {}
+    virtual void onRtpSorted(RtpPacket::Ptr rtp, int index) = 0;
 
     /**
      * 解析出rtp但还未排序
      * @param rtp rtp数据包
      * @param track_index track索引
      */
-    virtual void onBeforeRtpSorted(const RtpPacket::Ptr &rtp, int index) {}
+    virtual void onBeforeRtpSorted(const RtpPacket::Ptr &rtp, int index) = 0;
 
 private:
     RtpTrackImp _track[kCount];


### PR DESCRIPTION
大佬，在看RtspSession的onRtpSorted如何设置到PacketSorter里的回调cb时，被里面的各种onRtpSorted搞蒙了。
修改主要有两点：
1）RtpMultiReceiver里的onRtpSorted修改为纯虚函数，子类的才有具体的意义；
2）RtpTrackImp里的onRtpSorted放入其直接父类里，层次更好；
大佬，帮着看看这样修改可以吗？