### PR TITLE
支持单独的datachannel通道

### DIFF
--- a/webrtc/Sdp.cpp
+++ b/webrtc/Sdp.cpp
@@ -1352,6 +1352,10 @@ bool RtcSession::supportSimulcast() const {
     return false;
 }
 
+bool RtcSession::isOnlyDatachannel() const {
+    return 1 == media.size() && TrackApplication == media[0].type;
+}
+
 string const SdpConst::kTWCCRtcpFb = "transport-cc";
 string const SdpConst::kRembRtcpFb = "goog-remb";
 

--- a/webrtc/Sdp.cpp
+++ b/webrtc/Sdp.cpp
@@ -1311,6 +1311,10 @@ void RtcSession::checkValid() const{
     bool have_active_media = false;
     for (auto &item : media) {
         item.checkValid();
+
+        if (TrackApplication == item.type) {
+            have_active_media = true;
+        }
         switch (item.direction) {
             case RtpDirection::sendrecv:
             case RtpDirection::sendonly:
@@ -1596,6 +1600,10 @@ RETRY:
 #ifdef ENABLE_SCTP
         answer_media.direction = matchDirection(offer_media.direction, configure.direction);
         answer_media.candidate = configure.candidate;
+        answer_media.ice_ufrag = configure.ice_ufrag;
+        answer_media.ice_pwd = configure.ice_pwd;
+        answer_media.fingerprint = configure.fingerprint;
+        answer_media.ice_lite = configure.ice_lite;
 #else
         answer_media.direction = RtpDirection::inactive;
 #endif

--- a/webrtc/Sdp.h
+++ b/webrtc/Sdp.h
@@ -678,6 +678,7 @@ public:
     const  RtcMedia *getMedia(mediakit::TrackType type) const;
     bool supportRtcpFb(const std::string &name, mediakit::TrackType type = mediakit::TrackType::TrackVideo) const;
     bool supportSimulcast() const;
+    bool isOnlyDatachannel() const;
 
 private:
     RtcSessionSdp::Ptr toRtcSessionSdp() const;

--- a/webrtc/WebRtcTransport.cpp
+++ b/webrtc/WebRtcTransport.cpp
@@ -367,7 +367,32 @@ void WebRtcTransportImp::onCreate() {
     WebRtcTransport::onCreate();
     registerSelf();
 
+    weak_ptr<WebRtcTransportImp> weak_self = static_pointer_cast<WebRtcTransportImp>(shared_from_this());
+    GET_CONFIG(float, timeoutSec, RTC::kTimeOutSec);
+    _timer = std::make_shared<Timer>(
+        timeoutSec / 2,
+        [weak_self]() {
+            auto strong_self = weak_self.lock();
+            if (!strong_self) {
+                return false;
+            }
+            if (strong_self->_alive_ticker.elapsedTime() > timeoutSec * 1000) {
+                strong_self->onShutdown(SockException(Err_timeout, "接受rtp/rtcp/datachannel超时"));
+            }
+            return true;
+        },
+        getPoller());
+
     _twcc_ctx.setOnSendTwccCB([this](uint32_t ssrc, string fci) { onSendTwcc(ssrc, fci); });
+}
+
+void WebRtcTransportImp::OnDtlsTransportApplicationDataReceived(const RTC::DtlsTransport *dtlsTransport, const uint8_t *data, size_t len) {
+    WebRtcTransport::OnDtlsTransportApplicationDataReceived(dtlsTransport, data, len);
+#ifdef ENABLE_SCTP
+    if (_answer_sdp->isOnlyDatachannel()) {
+        _alive_ticker.resetTime();
+    }
+#endif
 }
 
 WebRtcTransportImp::WebRtcTransportImp(const EventPoller::Ptr &poller)
@@ -415,25 +440,6 @@ bool WebRtcTransportImp::canRecvRtp() const {
 }
 
 void WebRtcTransportImp::onStartWebRTC() {
-    //根据answer_sdp ,当仅有datachannel时 ，忽略rtp和rtcp超时
-    if (!_answer_sdp->isOnlyDatachannel()) {
-        weak_ptr<WebRtcTransportImp> weak_self = static_pointer_cast<WebRtcTransportImp>(shared_from_this());
-        GET_CONFIG(float, timeoutSec, RTC::kTimeOutSec);
-        _timer = std::make_shared<Timer>(
-            timeoutSec / 2,
-            [weak_self]() {
-                auto strong_self = weak_self.lock();
-                if (!strong_self) {
-                    return false;
-                }
-                if (strong_self->_alive_ticker.elapsedTime() > timeoutSec * 1000) {
-                    strong_self->onShutdown(SockException(Err_timeout, "接受rtp和rtcp超时"));
-                }
-                return true;
-            },
-            getPoller());
-    }
-
     // 获取ssrc和pt相关信息,届时收到rtp和rtcp时分别可以根据pt和ssrc找到相关的信息
     for (auto &m_answer : _answer_sdp->media) {
         if (m_answer.type == TrackApplication) {

--- a/webrtc/WebRtcTransport.h
+++ b/webrtc/WebRtcTransport.h
@@ -248,6 +248,7 @@ public:
 
 protected:
     WebRtcTransportImp(const EventPoller::Ptr &poller);
+    void OnDtlsTransportApplicationDataReceived(const RTC::DtlsTransport *dtlsTransport, const uint8_t *data, size_t len) override;
     void onStartWebRTC() override;
     void onSendSockData(Buffer::Ptr buf, bool flush = true, RTC::TransportTuple *tuple = nullptr) override;
     void onCheckSdp(SdpType type, RtcSession &sdp) override;


### PR DESCRIPTION
本次修改主要有两处：
（当仅有datachannel的时候）
1、 ice_ufrag等没有更改 导致后面收到的stun包找不到对应的poller而被丢弃 建立不起来会话.
2、忽略rtp和rtcp超时，避免session被销毁