### PR TITLE
更新.gitignore文件，排除out目录。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@
 /.idea/
 /c_wrapper/.idea/
 /release/
+/out/
 /Android/.idea/
 /Android/app/src/main/cpp/libs_export/
 /3rdpart/media-server/.idea/


### PR DESCRIPTION
使用Visual Studio 2022打开项目文件夹后，CMake生成的文件默认放在out目录下面，和源代码无关，故增加一个排除规则，把out目录排除掉。

![image](https://user-images.githubusercontent.com/1552027/186806185-a7d9f0c4-2856-40cb-863f-9153c9d3c8fb.png)
![image](https://user-images.githubusercontent.com/1552027/186805202-ad56d108-d0bb-404b-aa99-7bbcf365a3e9.png)
![image](https://user-images.githubusercontent.com/1552027/186805251-ba1d61b5-879a-4fc2-bb29-f9c5e60831f3.png)
![image](https://user-images.githubusercontent.com/1552027/186805283-4bab7326-01ec-40f2-84da-cfc7b2e7c3a7.png)

