### PR TITLE
修正在指定配置文件forwarded_ip_header的值后，无法获取不通过代理播放的客户端IP。

### DIFF
--- a/src/Http/HttpSession.cpp
+++ b/src/Http/HttpSession.cpp
@@ -674,7 +674,10 @@ bool HttpSession::emitHttpEvent(bool doInvoke){
 
 std::string HttpSession::get_peer_ip() {
     GET_CONFIG(string, forwarded_ip_header, Http::kForwardedIpHeader);
-    return forwarded_ip_header.empty() ? TcpSession::get_peer_ip() : _parser.getHeader()[forwarded_ip_header];
+    if(!forwarded_ip_header.empty() && !_parser.getHeader()[forwarded_ip_header].empty()){
+        return _parser.getHeader()[forwarded_ip_header];
+    }
+    return TcpSession::get_peer_ip();
 }
 
 void HttpSession::Handle_Req_POST(ssize_t &content_len) {


### PR DESCRIPTION
修复#1939