### PR TITLE
C API和WebHook未找到流回调添加直接关闭机制

### DIFF
--- a/api/include/mk_events.h
+++ b/api/include/mk_events.h
@@ -53,8 +53,10 @@ typedef struct {
      * 未找到流后会广播该事件，请在监听该事件后去拉流或其他方式产生流，这样就能按需拉流了
      * @param url_info 播放url相关信息
      * @param sender 播放客户端相关信息
+     * @return 1 直接关闭
+     *         0 等待流注册
      */
-    void (API_CALL *on_mk_media_not_found)(const mk_media_info url_info,
+    int (API_CALL *on_mk_media_not_found)(const mk_media_info url_info,
                                            const mk_sock_info sender);
 
     /**
@@ -152,7 +154,7 @@ typedef struct {
                                        size_t total_seconds,
                                        int is_player,
                                        const mk_sock_info sender);
-                                       
+
 
     /**
      * 日志输出广播
@@ -178,4 +180,3 @@ API_EXPORT void API_CALL mk_events_listen(const mk_events *events);
 }
 #endif
 #endif //MK_EVENTS_H
-

--- a/api/source/mk_events.cpp
+++ b/api/source/mk_events.cpp
@@ -141,8 +141,10 @@ API_EXPORT void API_CALL mk_events_listen(const mk_events *events){
 
         NoticeCenter::Instance().addListener(&s_tag,Broadcast::kBroadcastNotFoundStream,[](BroadcastNotFoundStreamArgs){
             if (s_events.on_mk_media_not_found) {
-                s_events.on_mk_media_not_found((mk_media_info) &args,
-                                               (mk_sock_info) &sender);
+                if (s_events.on_mk_media_not_found((mk_media_info) &args,
+                                                   (mk_sock_info) &sender)) {
+                    closePlayer();
+                }
             }
         });
 

--- a/api/tests/server.c
+++ b/api/tests/server.c
@@ -88,8 +88,10 @@ void API_CALL on_mk_media_play(const mk_media_info url_info,
  * 未找到流后会广播该事件，请在监听该事件后去拉流或其他方式产生流，这样就能按需拉流了
  * @param url_info 播放url相关信息
  * @param sender 播放客户端相关信息
+ * @return 1 直接关闭
+ *         0 等待流注册
  */
-void API_CALL on_mk_media_not_found(const mk_media_info url_info,
+int API_CALL on_mk_media_not_found(const mk_media_info url_info,
                                     const mk_sock_info sender) {
     char ip[64];
     log_printf(LOG_LEV,
@@ -104,6 +106,7 @@ void API_CALL on_mk_media_not_found(const mk_media_info url_info,
                mk_media_info_get_app(url_info),
                mk_media_info_get_stream(url_info),
                mk_media_info_get_params(url_info));
+    return 0;
 }
 
 /**

--- a/server/WebHook.cpp
+++ b/server/WebHook.cpp
@@ -505,8 +505,17 @@ void installWebHook(){
         body["ip"] = sender.get_peer_ip();
         body["port"] = sender.get_peer_port();
         body["id"] = sender.getIdentifier();
+
+        // Hook回复立即关闭流
+        auto res_cb = [closePlayer](const Value &res, const string &err) {
+            bool flag = res["close"].asBool();
+            if (flag) {
+                closePlayer();
+            }
+        };
+
         //执行hook
-        do_http_hook(hook_stream_not_found, body, nullptr);
+        do_http_hook(hook_stream_not_found, body, res_cb);
     });
 
     static auto getRecordInfo = [](const RecordInfo &info) {


### PR DESCRIPTION
使用场景：
监控领域当摄像头不在线时直接返回未找到流