### PR TITLE
on_play回调添加状态码，可选择返回未授权或未找到状态码

### DIFF
--- a/api/include/mk_events_objects.h
+++ b/api/include/mk_events_objects.h
@@ -311,9 +311,13 @@ typedef void* mk_auth_invoker;
 
 /**
  * 执行Broadcast::AuthInvoker
+ * @param err_code 响应状态码，当err_msg参数不为空时生效
+ *                 200 返回成功响应
+ *                 401 返回未授权响应
+ *                 404 返回未找到流响应
  * @param err_msg 为空或null则代表鉴权成功
  */
-API_EXPORT void API_CALL mk_auth_invoker_do(const mk_auth_invoker ctx, const char *err_msg);
+API_EXPORT void API_CALL mk_auth_invoker_do(const mk_auth_invoker ctx, int err_code, const char *err_msg);
 
 /**
  * 克隆mk_auth_invoker对象，通过克隆对象为堆对象，可以实现跨线程异步执行mk_auth_invoker_do

--- a/api/source/mk_events.cpp
+++ b/api/source/mk_events.cpp
@@ -61,7 +61,7 @@ API_EXPORT void API_CALL mk_events_listen(const mk_events *events){
                                            (mk_http_access_path_invoker)&invoker,
                                            (mk_sock_info)&sender);
             } else{
-                invoker("","",0);
+                invoker(200, "","",0);
             }
         });
 
@@ -114,7 +114,7 @@ API_EXPORT void API_CALL mk_events_listen(const mk_events *events){
                                           (mk_auth_invoker) &invoker,
                                           (mk_sock_info) &sender);
             }else{
-                invoker("");
+                invoker(200, "");
             }
         });
 
@@ -125,7 +125,7 @@ API_EXPORT void API_CALL mk_events_listen(const mk_events *events){
                                            (mk_auth_invoker) &invoker,
                                            (mk_sock_info) &sender);
             }else{
-                invoker("");
+                invoker(200, "");
             }
         });
 

--- a/api/source/mk_events_objects.cpp
+++ b/api/source/mk_events_objects.cpp
@@ -344,7 +344,8 @@ API_EXPORT void API_CALL mk_http_access_path_invoker_do(const mk_http_access_pat
                                                         int cookie_life_second){
     assert(ctx);
     HttpSession::HttpAccessPathInvoker *invoker = (HttpSession::HttpAccessPathInvoker *)ctx;
-    (*invoker)(err_msg ? err_msg : "",
+    (*invoker)(401,
+              err_msg ? err_msg : "",
               access_path? access_path : "",
               cookie_life_second);
 }
@@ -428,10 +429,10 @@ API_EXPORT void API_CALL mk_publish_auth_invoker_clone_release(const mk_publish_
 }
 
 ///////////////////////////////////////////Broadcast::AuthInvoker/////////////////////////////////////////////
-API_EXPORT void API_CALL mk_auth_invoker_do(const mk_auth_invoker ctx, const char *err_msg){
+API_EXPORT void API_CALL mk_auth_invoker_do(const mk_auth_invoker ctx, int err_code, const char *err_msg){
     assert(ctx);
     Broadcast::AuthInvoker *invoker = (Broadcast::AuthInvoker *)ctx;
-    (*invoker)(err_msg ? err_msg : "");
+    (*invoker)(err_code, err_msg ? err_msg : "");
 }
 
 API_EXPORT mk_auth_invoker API_CALL mk_auth_invoker_clone(const mk_auth_invoker ctx){

--- a/api/tests/server.c
+++ b/api/tests/server.c
@@ -81,7 +81,7 @@ void API_CALL on_mk_media_play(const mk_media_info url_info,
                mk_media_info_get_params(url_info));
 
     //允许播放
-    mk_auth_invoker_do(invoker, NULL);
+    mk_auth_invoker_do(invoker, 200, NULL);
 }
 
 /**
@@ -427,7 +427,7 @@ void API_CALL on_mk_shell_login(const char *user_name,
               mk_sock_info_peer_port(sender),
               user_name, passwd);
     //允许登录shell
-    mk_auth_invoker_do(invoker, NULL);
+    mk_auth_invoker_do(invoker, 200, NULL);
 }
 
 /**

--- a/src/Common/config.h
+++ b/src/Common/config.h
@@ -80,8 +80,12 @@ extern const std::string kBroadcastMediaPublish;
     const MediaOriginType &type, const MediaInfo &args, const Broadcast::PublishAuthInvoker &invoker, SockInfo &sender
 
 // 播放鉴权结果回调对象
+// code 响应状态码，当err参数不为空时生效
+//      200返回成功响应
+//      401返回未授权响应
+//      404返回未找到流响应
 // 如果err为空则代表鉴权成功
-using AuthInvoker = std::function<void(const std::string &err)>;
+using AuthInvoker = std::function<void(int code, const std::string &err)>;
 
 // 播放rtsp/rtmp/http-flv事件广播，通过该事件控制播放鉴权
 extern const std::string kBroadcastMediaPlayed;

--- a/src/Http/HttpSession.h
+++ b/src/Http/HttpSession.h
@@ -33,11 +33,12 @@ public:
     typedef HttpResponseInvokerImp HttpResponseInvoker;
     friend class AsyncSender;
     /**
+     * @param code 鉴权未通过时返回的状态码
      * @param errMsg 如果为空，则代表鉴权通过，否则为错误提示
      * @param accessPath 运行或禁止访问的根目录
      * @param cookieLifeSecond 鉴权cookie有效期
      **/
-    typedef std::function<void(const std::string &errMsg,const std::string &accessPath, int cookieLifeSecond)> HttpAccessPathInvoker;
+    typedef std::function<void(int code, const std::string &errMsg, const std::string &accessPath, int cookieLifeSecond)> HttpAccessPathInvoker;
 
     HttpSession(const toolkit::Socket::Ptr &pSock);
     ~HttpSession() override;

--- a/src/Rtmp/RtmpSession.h
+++ b/src/Rtmp/RtmpSession.h
@@ -47,7 +47,7 @@ private:
     void onCmd_play(AMFDecoder &dec);
     void onCmd_play2(AMFDecoder &dec);
     void doPlay(AMFDecoder &dec);
-    void doPlayResponse(const std::string &err,const std::function<void(bool)> &cb);
+    void doPlayResponse(int code, const std::string &err,const std::function<void(bool)> &cb);
     void sendPlayResponse(const std::string &err,const RtmpMediaSource::Ptr &src);
 
     void onCmd_seek(AMFDecoder &dec);

--- a/src/Shell/ShellSession.cpp
+++ b/src/Shell/ShellSession.cpp
@@ -124,7 +124,7 @@ inline void ShellSession::pleaseInputPasswd() {
         };
 
         weak_ptr<ShellSession> weakSelf = dynamic_pointer_cast<ShellSession>(shared_from_this());
-        Broadcast::AuthInvoker invoker = [weakSelf,onAuth](const string &errMessage){
+        Broadcast::AuthInvoker invoker = [weakSelf,onAuth](int code, const string &errMessage){
             auto strongSelf =  weakSelf.lock();
             if(!strongSelf){
                 return;

--- a/srt/SrtTransportImp.cpp
+++ b/srt/SrtTransportImp.cpp
@@ -182,7 +182,7 @@ void SrtTransportImp::emitOnPublish() {
 
 void SrtTransportImp::emitOnPlay() {
     std::weak_ptr<SrtTransportImp> weak_self = static_pointer_cast<SrtTransportImp>(shared_from_this());
-    Broadcast::AuthInvoker invoker = [weak_self](const string &err) {
+    Broadcast::AuthInvoker invoker = [weak_self](int code, const string &err) {
         auto strong_self = weak_self.lock();
         if (!strong_self) {
             return;

--- a/tests/test_server.cpp
+++ b/tests/test_server.cpp
@@ -143,14 +143,14 @@ void initEventListener() {
         //监听rtsp/rtsps/rtmp/http-flv播放事件，返回结果告知是否有播放权限(rtsp通过kBroadcastOnRtspAuth或此事件都可以实现鉴权)
         NoticeCenter::Instance().addListener(nullptr, Broadcast::kBroadcastMediaPlayed, [](BroadcastMediaPlayedArgs) {
             DebugL << "播放鉴权:" << args.getUrl() << " " << args._param_strs;
-            invoker("");//鉴权成功
+            invoker(200, "");//鉴权成功
             //invoker("this is auth failed message");//鉴权失败
         });
 
         //shell登录事件，通过shell可以登录进服务器执行一些命令
         NoticeCenter::Instance().addListener(nullptr, Broadcast::kBroadcastShellLogin, [](BroadcastShellLoginArgs) {
             DebugL << "shell login:" << user_name << " " << passwd;
-            invoker("");//鉴权成功
+            invoker(200, "");//鉴权成功
             //invoker("this is auth failed message");//鉴权失败
         });
 

--- a/webrtc/WebRtcTransport.cpp
+++ b/webrtc/WebRtcTransport.cpp
@@ -1185,7 +1185,7 @@ void push_plugin(Session &sender, const WebRtcArgs &args, const WebRtcPluginMana
 void play_plugin(Session &sender, const WebRtcArgs &args, const WebRtcPluginManager::onCreateRtc &cb) {
     MediaInfo info(args["url"]);
     auto session_ptr = sender.shared_from_this();
-    Broadcast::AuthInvoker invoker = [cb, info, session_ptr](const string &err) mutable {
+    Broadcast::AuthInvoker invoker = [cb, info, session_ptr](int code, const string &err) mutable {
         if (!err.empty()) {
             cb(WebRtcException(SockException(Err_other, err)));
             return;
@@ -1210,7 +1210,7 @@ void play_plugin(Session &sender, const WebRtcArgs &args, const WebRtcPluginMana
     auto flag = NoticeCenter::Instance().emitEvent(Broadcast::kBroadcastMediaPlayed, info, invoker, static_cast<SockInfo &>(sender));
     if (!flag) {
         // 该事件无人监听,默认不鉴权
-        invoker("");
+        invoker(200, "");
     }
 }
 


### PR DESCRIPTION
使用场景：播放链接添加有效期。当触发on_play回调时，若链接过期，则返回未找到流状态码，防止弹出认证提示，例如VLC播放RTSP时弹出认证窗口。