### PR TITLE
webrtc push/play支持通过http参数指定tcp

### DIFF
--- a/server/WebApi.cpp
+++ b/server/WebApi.cpp
@@ -344,7 +344,8 @@ Value makeMediaSourceJson(MediaSource &media){
     }
 
     //getLossRate有线程安全问题；使用getMediaInfo接口才能获取丢包率；getMediaList接口将忽略丢包率
-    auto current_thread = media.getOwnerPoller()->isCurrentThread();
+    auto current_thread = false;
+    try { current_thread = media.getOwnerPoller()->isCurrentThread();} catch (...) {}
     float last_loss = -1;
     for(auto &track : media.getTracks(false)){
         Value obj;

--- a/src/Common/MediaSource.h
+++ b/src/Common/MediaSource.h
@@ -406,7 +406,6 @@ private:
     std::string _app;
     std::string _stream_id;
     std::weak_ptr<MediaSourceEvent> _listener;
-    toolkit::EventPoller::Ptr _default_poller;
     // 对象个数统计
     toolkit::ObjectStatistic<MediaSource> _statistic;
 };

--- a/webrtc/WebRtcPlayer.cpp
+++ b/webrtc/WebRtcPlayer.cpp
@@ -17,8 +17,8 @@ namespace mediakit {
 WebRtcPlayer::Ptr WebRtcPlayer::create(const EventPoller::Ptr &poller,
                                        const RtspMediaSource::Ptr &src,
                                        const MediaInfo &info,
-                                       bool force_tcp) {
-    WebRtcPlayer::Ptr ret(new WebRtcPlayer(poller, src, info, force_tcp), [](WebRtcPlayer *ptr) {
+                                       bool perferred_tcp) {
+    WebRtcPlayer::Ptr ret(new WebRtcPlayer(poller, src, info, perferred_tcp), [](WebRtcPlayer *ptr) {
         ptr->onDestory();
         delete ptr;
     });
@@ -29,7 +29,7 @@ WebRtcPlayer::Ptr WebRtcPlayer::create(const EventPoller::Ptr &poller,
 WebRtcPlayer::WebRtcPlayer(const EventPoller::Ptr &poller,
                            const RtspMediaSource::Ptr &src,
                            const MediaInfo &info,
-                           bool force_tcp) : WebRtcTransportImp(poller,force_tcp) {
+                           bool perferred_tcp) : WebRtcTransportImp(poller,perferred_tcp) {
     _media_info = info;
     _play_src = src;
     CHECK(_play_src);

--- a/webrtc/WebRtcPlayer.h
+++ b/webrtc/WebRtcPlayer.h
@@ -19,7 +19,7 @@ class WebRtcPlayer : public WebRtcTransportImp {
 public:
     using Ptr = std::shared_ptr<WebRtcPlayer>;
     ~WebRtcPlayer() override = default;
-    static Ptr create(const EventPoller::Ptr &poller, const RtspMediaSource::Ptr &src, const MediaInfo &info, bool force_tcp = false);
+    static Ptr create(const EventPoller::Ptr &poller, const RtspMediaSource::Ptr &src, const MediaInfo &info, bool perferred_tcp = false);
 
 protected:
     ///////WebRtcTransportImp override///////
@@ -29,7 +29,7 @@ protected:
     void onRecvRtp(MediaTrack &track, const std::string &rid, RtpPacket::Ptr rtp) override {};
 
 private:
-    WebRtcPlayer(const EventPoller::Ptr &poller, const RtspMediaSource::Ptr &src, const MediaInfo &info, bool force_tcp);
+    WebRtcPlayer(const EventPoller::Ptr &poller, const RtspMediaSource::Ptr &src, const MediaInfo &info, bool perferred_tcp);
 
 private:
     //媒体相关元数据

--- a/webrtc/WebRtcPusher.cpp
+++ b/webrtc/WebRtcPusher.cpp
@@ -19,8 +19,8 @@ WebRtcPusher::Ptr WebRtcPusher::create(const EventPoller::Ptr &poller,
                                        const std::shared_ptr<void> &ownership,
                                        const MediaInfo &info,
                                        const ProtocolOption &option,
-                                       bool force_tcp) {
-    WebRtcPusher::Ptr ret(new WebRtcPusher(poller, src, ownership, info, option,force_tcp), [](WebRtcPusher *ptr) {
+                                       bool perferred_tcp) {
+    WebRtcPusher::Ptr ret(new WebRtcPusher(poller, src, ownership, info, option,perferred_tcp), [](WebRtcPusher *ptr) {
         ptr->onDestory();
         delete ptr;
     });
@@ -33,7 +33,7 @@ WebRtcPusher::WebRtcPusher(const EventPoller::Ptr &poller,
                            const std::shared_ptr<void> &ownership,
                            const MediaInfo &info,
                            const ProtocolOption &option,
-                           bool force_tcp) : WebRtcTransportImp(poller,force_tcp) {
+                           bool perferred_tcp) : WebRtcTransportImp(poller,perferred_tcp) {
     _media_info = info;
     _push_src = src;
     _push_src_ownership = ownership;

--- a/webrtc/WebRtcPusher.h
+++ b/webrtc/WebRtcPusher.h
@@ -20,7 +20,7 @@ public:
     using Ptr = std::shared_ptr<WebRtcPusher>;
     ~WebRtcPusher() override = default;
     static Ptr create(const EventPoller::Ptr &poller, const RtspMediaSourceImp::Ptr &src,
-                      const std::shared_ptr<void> &ownership, const MediaInfo &info, const ProtocolOption &option, bool force_tcp = false);
+                      const std::shared_ptr<void> &ownership, const MediaInfo &info, const ProtocolOption &option, bool perferred_tcp = false);
 
 protected:
     ///////WebRtcTransportImp override///////
@@ -51,7 +51,7 @@ protected:
 
 private:
     WebRtcPusher(const EventPoller::Ptr &poller, const RtspMediaSourceImp::Ptr &src,
-                 const std::shared_ptr<void> &ownership, const MediaInfo &info, const ProtocolOption &option, bool force_tcp);
+                 const std::shared_ptr<void> &ownership, const MediaInfo &info, const ProtocolOption &option, bool perferred_tcp);
 
 private:
     bool _simulcast = false;

--- a/webrtc/WebRtcTransport.cpp
+++ b/webrtc/WebRtcTransport.cpp
@@ -402,8 +402,8 @@ void WebRtcTransportImp::OnDtlsTransportApplicationDataReceived(const RTC::DtlsT
 #endif
 }
 
-WebRtcTransportImp::WebRtcTransportImp(const EventPoller::Ptr &poller,bool force_tcp)
-    : WebRtcTransport(poller),_force_tcp(force_tcp) {
+WebRtcTransportImp::WebRtcTransportImp(const EventPoller::Ptr &poller,bool perferred_tcp)
+    : WebRtcTransport(poller), _perferred_tcp(perferred_tcp) {
     InfoL << getIdentifier();
 }
 
@@ -628,14 +628,14 @@ void WebRtcTransportImp::onRtcConfigure(RtcConfigure &configure) const {
     });
     if (extern_ips.empty()) {
         std::string local_ip = SockUtil::get_local_ip();
-        if (local_udp_port && !_force_tcp) { configure.addCandidate(*makeIceCandidate(local_ip, local_udp_port, 120, "udp")); }
-        if (local_tcp_port) { configure.addCandidate(*makeIceCandidate(local_ip, local_tcp_port, 110, "tcp")); }
+        if (local_udp_port) { configure.addCandidate(*makeIceCandidate(local_ip, local_udp_port, 120, "udp")); }
+        if (local_tcp_port) { configure.addCandidate(*makeIceCandidate(local_ip, local_tcp_port, _perferred_tcp ? 125 : 115, "tcp")); }
     } else {
         const uint32_t delta = 10;
         uint32_t priority = 100 + delta * extern_ips.size();
         for (auto ip : extern_ips) {
-            if (local_udp_port && !_force_tcp) { configure.addCandidate(*makeIceCandidate(ip, local_udp_port, priority + 5, "udp")); }
-            if (local_tcp_port) { configure.addCandidate(*makeIceCandidate(ip, local_tcp_port, priority, "tcp")); }
+            if (local_udp_port) { configure.addCandidate(*makeIceCandidate(ip, local_udp_port, priority, "udp")); }
+            if (local_tcp_port) { configure.addCandidate(*makeIceCandidate(ip, local_tcp_port, priority - (_perferred_tcp ? -5 : 5), "tcp")); }
             priority -= delta;
         }
     }
@@ -1153,9 +1153,9 @@ void echo_plugin(Session &sender, const WebRtcArgs &args, const WebRtcPluginMana
 
 void push_plugin(Session &sender, const WebRtcArgs &args, const WebRtcPluginManager::onCreateRtc &cb) {
     MediaInfo info(args["url"]);
-    bool force_tcp = args["force_tcp"].operator bool();
+    bool perferred_tcp = args["perferred_tcp"];
 
-    Broadcast::PublishAuthInvoker invoker = [cb, info, force_tcp](const string &err, const ProtocolOption &option) mutable {
+    Broadcast::PublishAuthInvoker invoker = [cb, info, perferred_tcp](const string &err, const ProtocolOption &option) mutable {
         if (!err.empty()) {
             cb(WebRtcException(SockException(Err_other, err)));
             return;
@@ -1194,7 +1194,7 @@ void push_plugin(Session &sender, const WebRtcArgs &args, const WebRtcPluginMana
             push_src_ownership = push_src->getOwnership();
             push_src->setProtocolOption(option);
         }
-        auto rtc = WebRtcPusher::create(EventPollerPool::Instance().getPoller(), push_src, push_src_ownership, info, option, force_tcp);
+        auto rtc = WebRtcPusher::create(EventPollerPool::Instance().getPoller(), push_src, push_src_ownership, info, option, perferred_tcp);
         push_src->setListener(rtc);
         cb(*rtc);
     };
@@ -1209,10 +1209,10 @@ void push_plugin(Session &sender, const WebRtcArgs &args, const WebRtcPluginMana
 
 void play_plugin(Session &sender, const WebRtcArgs &args, const WebRtcPluginManager::onCreateRtc &cb) {
     MediaInfo info(args["url"]);
-    bool force_tcp = args["force_tcp"].operator bool();
+    bool perferred_tcp = args["perferred_tcp"];
 
     auto session_ptr = sender.shared_from_this();
-    Broadcast::AuthInvoker invoker = [cb, info, session_ptr, force_tcp](const string &err) mutable {
+    Broadcast::AuthInvoker invoker = [cb, info, session_ptr, perferred_tcp](const string &err) mutable {
         if (!err.empty()) {
             cb(WebRtcException(SockException(Err_other, err)));
             return;
@@ -1228,7 +1228,7 @@ void play_plugin(Session &sender, const WebRtcArgs &args, const WebRtcPluginMana
             }
             // 还原成rtc，目的是为了hook时识别哪种播放协议
             info._schema = RTC_SCHEMA;
-            auto rtc = WebRtcPlayer::create(EventPollerPool::Instance().getPoller(), src, info, force_tcp);
+            auto rtc = WebRtcPlayer::create(EventPollerPool::Instance().getPoller(), src, info, perferred_tcp);
             cb(*rtc);
         });
     };

--- a/webrtc/WebRtcTransport.h
+++ b/webrtc/WebRtcTransport.h
@@ -251,7 +251,7 @@ public:
     void createRtpChannel(const std::string &rid, uint32_t ssrc, MediaTrack &track);
 
 protected:
-    WebRtcTransportImp(const EventPoller::Ptr &poller,bool force_tcp = false);
+    WebRtcTransportImp(const EventPoller::Ptr &poller,bool perferred_tcp = false);
     void OnDtlsTransportApplicationDataReceived(const RTC::DtlsTransport *dtlsTransport, const uint8_t *data, size_t len) override;
     void onStartWebRTC() override;
     void onSendSockData(Buffer::Ptr buf, bool flush = true, RTC::TransportTuple *tuple = nullptr) override;
@@ -281,7 +281,7 @@ private:
     void onCheckAnswer(RtcSession &sdp);
 
 private:
-    bool _force_tcp;
+    bool _perferred_tcp;
     uint16_t _rtx_seq[2] = {0, 0};
     //用掉的总流量
     uint64_t _bytes_usage = 0;


### PR DESCRIPTION
使用tcp的一些情况：
1、udp被封锁时，完全不可用  2、udp不太好使，用户想指定tcp推流或者拉流
使用方法: http增加参数force_tcp. eg:
https://127.0.0.1/index/api/webrtc?app=live&stream=test&type=play&force_tcp=true
https://127.0.0.1/index/api/webrtc?app=live&stream=test&type=push&force_tcp=true