### PR TITLE
put input and output parameters of ffmpeg in quotes

### DIFF
--- a/conf/config.ini
+++ b/conf/config.ini
@@ -20,9 +20,9 @@ defaultSnap=./www/logo.png
 #FFmpeg可执行程序路径,支持相对路径/绝对路径
 bin=/usr/bin/ffmpeg
 #FFmpeg拉流再推流的命令模板，通过该模板可以设置再编码的一些参数
-cmd=%s -re -i %s -c:a aac -strict -2 -ar 44100 -ab 48k -c:v libx264 -f flv %s
+cmd=%s -re -i "%s" -c:a aac -strict -2 -ar 44100 -ab 48k -c:v libx264 -f flv "%s"
 #FFmpeg生成截图的命令，可以通过修改该配置改变截图分辨率或质量
-snap=%s -i %s -y -f mjpeg -t 0.001 %s
+snap=%s -i "%s" -y -f mjpeg -t 0.001 "%s"
 #FFmpeg日志的路径，如果置空则不生成FFmpeg日志
 #可以为相对(相对于本可执行程序目录)或绝对路径
 log=./ffmpeg/ffmpeg.log


### PR DESCRIPTION
put input and output parameters of ffmpeg in quotes, in case of some special chars (space, & , ? etc.) cause unexpected failure