### PR TITLE
fixed ice candidate error

### DIFF
--- a/webrtc/IceServer.hpp
+++ b/webrtc/IceServer.hpp
@@ -126,7 +126,7 @@ namespace RTC
 		std::string oldUsernameFragment;
 		std::string oldPassword;
 		IceState state{ IceState::NEW };
-		std::list<RTC::TransportTuple*> tuples;
+		std::list<std::shared_ptr<RTC::TransportTuple>> tuples;
 		RTC::TransportTuple* selectedTuple{ nullptr };
 		//最大不超过mtu
         static constexpr size_t StunSerializeBufferSize{ 1600 };

--- a/webrtc/IceServer.hpp
+++ b/webrtc/IceServer.hpp
@@ -20,6 +20,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #define MS_RTC_ICE_SERVER_HPP
 
 #include "StunPacket.hpp"
+#include "Network/Session.h"
 #include "logger.h"
 #include "Utils.hpp"
 #include <list>
@@ -27,11 +28,11 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <functional>
 #include <memory>
 
-using _TransportTuple = struct sockaddr;
+//using _TransportTuple = struct sockaddr;
 
 namespace RTC
 {
-    using TransportTuple = _TransportTuple;
+	using TransportTuple = toolkit::Session;
 	class IceServer
 	{
 	public:
@@ -125,7 +126,7 @@ namespace RTC
 		std::string oldUsernameFragment;
 		std::string oldPassword;
 		IceState state{ IceState::NEW };
-		std::list<RTC::TransportTuple> tuples;
+		std::list<RTC::TransportTuple*> tuples;
 		RTC::TransportTuple* selectedTuple{ nullptr };
 		//最大不超过mtu
         static constexpr size_t StunSerializeBufferSize{ 1600 };

--- a/webrtc/IceServer.hpp
+++ b/webrtc/IceServer.hpp
@@ -28,8 +28,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <functional>
 #include <memory>
 
-//using _TransportTuple = struct sockaddr;
-
 namespace RTC
 {
 	using TransportTuple = toolkit::Session;
@@ -81,10 +79,10 @@ namespace RTC
 		{
 			return this->state;
 		}
-		RTC::TransportTuple* GetSelectedTuple() const
+		RTC::TransportTuple* GetSelectedTuple(bool try_last_tuple = false) const
 		{
-			return this->selectedTuple.lock().get();
-		}
+            return try_last_tuple ? this->lastSelectedTuple.lock().get() : this->selectedTuple;
+        }
 		void SetUsernameFragment(const std::string& usernameFragment)
 		{
 			this->oldUsernameFragment = this->usernameFragment;
@@ -129,7 +127,8 @@ namespace RTC
 		std::string oldPassword;
 		IceState state{ IceState::NEW };
 		std::list<RTC::TransportTuple *> tuples;
-		std::weak_ptr<RTC::TransportTuple> selectedTuple;
+        RTC::TransportTuple *selectedTuple;
+        std::weak_ptr<RTC::TransportTuple> lastSelectedTuple;
 		//最大不超过mtu
         static constexpr size_t StunSerializeBufferSize{ 1600 };
         uint8_t StunSerializeBuffer[StunSerializeBufferSize];

--- a/webrtc/IceServer.hpp
+++ b/webrtc/IceServer.hpp
@@ -83,7 +83,7 @@ namespace RTC
 		}
 		RTC::TransportTuple* GetSelectedTuple() const
 		{
-			return this->selectedTuple;
+			return this->selectedTuple.lock().get();
 		}
 		void SetUsernameFragment(const std::string& usernameFragment)
 		{
@@ -101,7 +101,9 @@ namespace RTC
 		// and the given tuple must be an already valid tuple.
 		void ForceSelectedTuple(const RTC::TransportTuple* tuple);
 
-	private:
+        const std::list<RTC::TransportTuple *>& GetTuples() const { return tuples; }
+
+    private:
 		void HandleTuple(RTC::TransportTuple* tuple, bool hasUseCandidate);
 		/**
 		 * Store the given tuple and return its stored address.
@@ -126,8 +128,8 @@ namespace RTC
 		std::string oldUsernameFragment;
 		std::string oldPassword;
 		IceState state{ IceState::NEW };
-		std::list<std::shared_ptr<RTC::TransportTuple>> tuples;
-		RTC::TransportTuple* selectedTuple{ nullptr };
+		std::list<RTC::TransportTuple *> tuples;
+		std::weak_ptr<RTC::TransportTuple> selectedTuple;
 		//最大不超过mtu
         static constexpr size_t StunSerializeBufferSize{ 1600 };
         uint8_t StunSerializeBuffer[StunSerializeBufferSize];

--- a/webrtc/WebRtcPlayer.cpp
+++ b/webrtc/WebRtcPlayer.cpp
@@ -70,21 +70,17 @@ void WebRtcPlayer::onStartWebRTC() {
     }
 }
 void WebRtcPlayer::onDestory() {
-    WebRtcTransportImp::onDestory();
-
     auto duration = getDuration();
     auto bytes_usage = getBytesUsage();
     //流量统计事件广播
     GET_CONFIG(uint32_t, iFlowThreshold, General::kFlowThreshold);
     if (_reader && getSession()) {
-        WarnL << "RTC播放器("
-              << _media_info.shortUrl()
-              << ")结束播放,耗时(s):" << duration;
+        WarnL << "RTC播放器(" << _media_info.shortUrl() << ")结束播放,耗时(s):" << duration;
         if (bytes_usage >= iFlowThreshold * 1024) {
-            NoticeCenter::Instance().emitEvent(Broadcast::kBroadcastFlowReport, _media_info, bytes_usage, duration,
-                                               true, static_cast<SockInfo &>(*getSession()));
+            NoticeCenter::Instance().emitEvent(Broadcast::kBroadcastFlowReport, _media_info, bytes_usage, duration, true, static_cast<SockInfo &>(*getSession()));
         }
     }
+    WebRtcTransportImp::onDestory();
 }
 
 void WebRtcPlayer::onRtcConfigure(RtcConfigure &configure) const {

--- a/webrtc/WebRtcPusher.cpp
+++ b/webrtc/WebRtcPusher.cpp
@@ -118,20 +118,15 @@ void WebRtcPusher::onStartWebRTC() {
 }
 
 void WebRtcPusher::onDestory() {
-    WebRtcTransportImp::onDestory();
-
     auto duration = getDuration();
     auto bytes_usage = getBytesUsage();
     //流量统计事件广播
     GET_CONFIG(uint32_t, iFlowThreshold, General::kFlowThreshold);
 
     if (getSession()) {
-        WarnL << "RTC推流器("
-              << _media_info.shortUrl()
-              << ")结束推流,耗时(s):" << duration;
+        WarnL << "RTC推流器(" << _media_info.shortUrl() << ")结束推流,耗时(s):" << duration;
         if (bytes_usage >= iFlowThreshold * 1024) {
-            NoticeCenter::Instance().emitEvent(Broadcast::kBroadcastFlowReport, _media_info, bytes_usage, duration,
-                                               false, static_cast<SockInfo &>(*getSession()));
+            NoticeCenter::Instance().emitEvent(Broadcast::kBroadcastFlowReport, _media_info, bytes_usage, duration, false, static_cast<SockInfo &>(*getSession()));
         }
     }
 
@@ -142,6 +137,7 @@ void WebRtcPusher::onDestory() {
         auto push_src = std::move(_push_src);
         getPoller()->doDelayTask(_continue_push_ms, [push_src]() { return 0; });
     }
+    WebRtcTransportImp::onDestory();
 }
 
 void WebRtcPusher::onRtcConfigure(RtcConfigure &configure) const {

--- a/webrtc/WebRtcSession.cpp
+++ b/webrtc/WebRtcSession.cpp
@@ -94,7 +94,7 @@ void WebRtcSession::onRecv_l(const char *data, size_t len) {
     }
     _ticker.resetTime();
     CHECK(_transport);
-    _transport->inputSockData((char *)data, len, (struct sockaddr *)&_peer_addr);
+    _transport->inputSockData((char *)data, len, this);// (struct sockaddr *)&_peer_addr);
 }
 
 void WebRtcSession::onRecv(const Buffer::Ptr &buffer) {
@@ -114,9 +114,11 @@ void WebRtcSession::onError(const SockException &err) {
     if (!_transport) {
         return;
     }
+    auto self = shared_from_this();
     auto transport = std::move(_transport);
-    getPoller()->async([transport] {
+    getPoller()->async([transport, self] {
         //延时减引用，防止使用transport对象时，销毁对象
+        transport->RemoveTuple(self.get());
     }, false);
 }
 

--- a/webrtc/WebRtcSession.cpp
+++ b/webrtc/WebRtcSession.cpp
@@ -48,8 +48,6 @@ EventPoller::Ptr WebRtcSession::queryPoller(const Buffer::Ptr &buffer) {
 ////////////////////////////////////////////////////////////////////////////////
 
 WebRtcSession::WebRtcSession(const Socket::Ptr &sock) : Session(sock) {
-    socklen_t addr_len = sizeof(_peer_addr);
-    getpeername(sock->rawFD(), (struct sockaddr *)&_peer_addr, &addr_len);
     _over_tcp = sock->sockType() == SockNum::Sock_TCP;
 }
 
@@ -87,14 +85,12 @@ void WebRtcSession::onRecv_l(const char *data, size_t len) {
             //3、销毁原先的socket和WebRtcSession(原先的对象跟WebRtcTransport不在同一条线程)
             throw std::runtime_error("webrtc over tcp change poller: " + getPoller()->getThreadName() + " -> " + sock->getPoller()->getThreadName());
         }
-
-        transport->setSession(shared_from_this());
         _transport = std::move(transport);
         InfoP(this);
     }
     _ticker.resetTime();
     CHECK(_transport);
-    _transport->inputSockData((char *)data, len, this);// (struct sockaddr *)&_peer_addr);
+    _transport->inputSockData((char *)data, len, this);
 }
 
 void WebRtcSession::onRecv(const Buffer::Ptr &buffer) {
@@ -116,9 +112,11 @@ void WebRtcSession::onError(const SockException &err) {
     }
     auto self = shared_from_this();
     auto transport = std::move(_transport);
-    getPoller()->async([transport, self] {
+    getPoller()->async([transport, self]() mutable {
         //延时减引用，防止使用transport对象时，销毁对象
-        transport->RemoveTuple(self.get());
+        transport->removeTuple(self.get());
+        //确保transport在Session对象前销毁，防止WebRtcTransport::onDestory()时获取不到Session对象
+        transport = nullptr;
     }, false);
 }
 

--- a/webrtc/WebRtcSession.h
+++ b/webrtc/WebRtcSession.h
@@ -46,7 +46,6 @@ private:
     bool _over_tcp = false;
     bool _find_transport = true;
     Ticker _ticker;
-    struct sockaddr_storage _peer_addr;
     std::weak_ptr<toolkit::TcpServer> _server;
     WebRtcTransportImp::Ptr _transport;
 };

--- a/webrtc/WebRtcTransport.cpp
+++ b/webrtc/WebRtcTransport.cpp
@@ -229,7 +229,7 @@ void WebRtcTransport::sendSockData(const char *buf, size_t len, RTC::TransportTu
 }
 
 Session::Ptr WebRtcTransport::getSession() const {
-    auto tuple = _ice_server->GetSelectedTuple();
+    auto tuple = _ice_server->GetSelectedTuple(true);
     return tuple ? tuple->shared_from_this() : nullptr;
 }
 
@@ -307,7 +307,7 @@ static bool isDtls(char *buf) {
 }
 
 static string getPeerAddress(RTC::TransportTuple *tuple) {
-    return tuple->get_peer_ip();// SockUtil::inet_ntoa(tuple);
+    return tuple->get_peer_ip();
 }
 
 void WebRtcTransport::inputSockData(char *buf, int len, RTC::TransportTuple *tuple) {

--- a/webrtc/WebRtcTransport.h
+++ b/webrtc/WebRtcTransport.h
@@ -130,7 +130,6 @@ protected:
 protected:
     //// ice相关的回调 ///
     void OnIceServerSendStunPacket(const RTC::IceServer *iceServer, const RTC::StunPacket *packet, RTC::TransportTuple *tuple) override;
-    void OnIceServerSelectedTuple(const RTC::IceServer *iceServer, RTC::TransportTuple *tuple) override;
     void OnIceServerConnected(const RTC::IceServer *iceServer) override;
     void OnIceServerCompleted(const RTC::IceServer *iceServer) override;
     void OnIceServerDisconnected(const RTC::IceServer *iceServer) override;
@@ -170,11 +169,11 @@ private:
 protected:
     RtcSession::Ptr _offer_sdp;
     RtcSession::Ptr _answer_sdp;
+    std::shared_ptr<RTC::IceServer> _ice_server;
 
 private:
     std::string _identifier;
     EventPoller::Ptr _poller;
-    std::shared_ptr<RTC::IceServer> _ice_server;
     std::shared_ptr<RTC::DtlsTransport> _dtls_transport;
     std::shared_ptr<RTC::SrtpSession> _srtp_session_send;
     std::shared_ptr<RTC::SrtpSession> _srtp_session_recv;
@@ -249,7 +248,9 @@ public:
 
     void createRtpChannel(const std::string &rid, uint32_t ssrc, MediaTrack &track);
 
+    void RemoveTuple(RTC::TransportTuple* tuple);
 protected:
+    void OnIceServerSelectedTuple(const RTC::IceServer *iceServer, RTC::TransportTuple *tuple) override;
     WebRtcTransportImp(const EventPoller::Ptr &poller,bool preferred_tcp = false);
     void OnDtlsTransportApplicationDataReceived(const RTC::DtlsTransport *dtlsTransport, const uint8_t *data, size_t len) override;
     void onStartWebRTC() override;

--- a/webrtc/WebRtcTransport.h
+++ b/webrtc/WebRtcTransport.h
@@ -293,8 +293,6 @@ private:
     Ticker _alive_ticker;
     //pli rtcp计时器
     Ticker _pli_ticker;
-    //当前选中的udp链接
-    Session::Ptr _selected_session;
     //链接迁移前后使用过的udp链接
     std::unordered_map<Session *, std::weak_ptr<Session> > _history_sessions;
     //twcc rtcp发送上下文对象

--- a/webrtc/WebRtcTransport.h
+++ b/webrtc/WebRtcTransport.h
@@ -110,6 +110,7 @@ public:
     void sendRtcpPacket(const char *buf, int len, bool flush, void *ctx = nullptr);
 
     const EventPoller::Ptr& getPoller() const;
+    Session::Ptr getSession() const;
 
 protected:
     ////  dtls相关的回调 ////
@@ -158,7 +159,6 @@ protected:
     virtual void onRtcpBye() = 0;
 
 protected:
-    RTC::TransportTuple* getSelectedTuple() const;
     void sendRtcpRemb(uint32_t ssrc, size_t bit_rate);
     void sendRtcpPli(uint32_t ssrc);
 
@@ -238,8 +238,6 @@ public:
     using Ptr = std::shared_ptr<WebRtcTransportImp>;
     ~WebRtcTransportImp() override;
 
-    void setSession(Session::Ptr session);
-    const Session::Ptr& getSession() const;
     uint64_t getBytesUsage() const;
     uint64_t getDuration() const;
     bool canSendRtp() const;
@@ -247,8 +245,8 @@ public:
     void onSendRtp(const RtpPacket::Ptr &rtp, bool flush, bool rtx = false);
 
     void createRtpChannel(const std::string &rid, uint32_t ssrc, MediaTrack &track);
+    void removeTuple(RTC::TransportTuple* tuple);
 
-    void RemoveTuple(RTC::TransportTuple* tuple);
 protected:
     void OnIceServerSelectedTuple(const RTC::IceServer *iceServer, RTC::TransportTuple *tuple) override;
     WebRtcTransportImp(const EventPoller::Ptr &poller,bool preferred_tcp = false);
@@ -293,8 +291,6 @@ private:
     Ticker _alive_ticker;
     //pli rtcp计时器
     Ticker _pli_ticker;
-    //链接迁移前后使用过的udp链接
-    std::unordered_map<Session *, std::weak_ptr<Session> > _history_sessions;
     //twcc rtcp发送上下文对象
     TwccContext _twcc_ctx;
     //根据发送rtp的track类型获取相关信息


### PR DESCRIPTION
测试发现现有代码，用chrome或edge建立webrtc建立 rtc连接时，有概率出现如下错误：
```
2023-03-02 15:08:44.643 D MediaServer.exe[24192-event poller 3] DtlsTransport.cpp:1018 SendPendingOutgoingDtlsData | 67 bytes of DTLS data ready to sent to the peer
2023-03-02 15:08:44.643 D MediaServer.exe[24192-event poller 3] DtlsTransport.cpp:1207 CheckRemoteFingerprint | valid remote fingerprint
2023-03-02 15:08:44.643 D MediaServer.exe[24192-event poller 3] DtlsTransport.cpp:1381 GetNegotiatedSrtpCryptoSuite | chosen SRTP crypto suite: SRTP_AEAD_AES_256_GCM
2023-03-02 15:08:44.643 I MediaServer.exe[24192-event poller 3] WebRtcTransport.cpp:138 OnDtlsTransportConnected | 
2023-03-02 15:08:44.661 I MediaServer.exe[24192-event poller 3] WebRtcTransport.cpp:857 createRtpChannel | create rtp receiver of ssrc:1888227238, rid:, codec:PCMU
2023-03-02 15:08:44.809 I MediaServer.exe[24192-event poller 3] WebRtcTransport.cpp:1054 setSession | rtc network changed: 192.168.26.66:52599 -> 198.18.0.1:55565, id:zlm_2
2023-03-02 15:08:44.809 I MediaServer.exe[24192-event poller 3] WebRtcSession.cpp:93 onRecv_l | 14-560(198.18.0.1:55565) 

2023-03-02 15:08:46.285 D MediaServer.exe[24192-event poller 3] MediaSink.cpp:149 emitAllTrackReady | All track ready use 1642ms
2023-03-02 15:08:46.285 I MediaServer.exe[24192-event poller 3] MediaSource.cpp:523 emitEvent | 媒体注册:fmp4://__defaultVhost__/live/test
2023-03-02 15:08:46.285 I MediaServer.exe[24192-event poller 3] MultiMediaSourceMuxer.cpp:368 onAllTrackReady | stream: rtc://192.168.24.87:8443/live/test?app=live&stream=test&type=push&session=12-632 , codec info: PCMU[8000/1/16] H264[480/270/0]
2023-03-02 15:08:46.285 I MediaServer.exe[24192-event poller 3] MediaSource.cpp:523 emitEvent | 媒体注册:rtmp://__defaultVhost__/live/test
2023-03-02 15:08:46.285 I MediaServer.exe[24192-event poller 3] MediaSource.cpp:523 emitEvent | 媒体注册:rtsp://__defaultVhost__/live/test
2023-03-02 15:08:46.285 I MediaServer.exe[24192-event poller 3] MediaSource.cpp:523 emitEvent | 媒体注册:ts://__defaultVhost__/live/test
2023-03-02 15:08:50.452 I MediaServer.exe[24192-event poller 3] MediaSource.cpp:523 emitEvent | 媒体注册:hls://__defaultVhost__/live/test
2023-03-02 15:08:51.139 I MediaServer.exe[24192-event poller 3] WebRtcTransport.cpp:113 OnIceServerSelectedTuple |
2023-03-02 15:08:51.642 I MediaServer.exe[24192-event poller 3] WebRtcTransport.cpp:113 OnIceServerSelectedTuple |
    Last message repeated 8 times
2023-03-02 15:08:52.202 I MediaServer.exe[24192-event poller 3] WebRtcTransport.cpp:113 OnIceServerSelectedTuple |
    Last message repeated 9 times
2023-03-02 15:08:52.761 I MediaServer.exe[24192-event poller 3] WebRtcTransport.cpp:113 OnIceServerSelectedTuple |
    Last message repeated 9 times
2023-03-02 15:08:53.264 I MediaServer.exe[24192-event poller 3] WebRtcTransport.cpp:113 OnIceServerSelectedTuple |
    Last message repeated 8 times
2023-03-02 15:08:53.825 I MediaServer.exe[24192-event poller 3] WebRtcTransport.cpp:113 OnIceServerSelectedTuple |
    Last message repeated 9 times
2023-03-02 15:08:54.325 I MediaServer.exe[24192-event poller 3] WebRtcTransport.cpp:113 OnIceServerSelectedTuple |
    Last message repeated 8 times
2023-03-02 15:08:54.891 I MediaServer.exe[24192-event poller 3] WebRtcTransport.cpp:113 OnIceServerSelectedTuple |
    Last message repeated 9 times
2023-03-02 15:08:55.395 I MediaServer.exe[24192-event poller 3] WebRtcTransport.cpp:113 OnIceServerSelectedTuple |
    Last message repeated 8 times
2023-03-02 15:08:55.954 I MediaServer.exe[24192-event poller 3] WebRtcTransport.cpp:113 OnIceServerSelectedTuple |
    Last message repeated 9 times
2023-03-02 15:08:56.458 I MediaServer.exe[24192-event poller 3] WebRtcTransport.cpp:113 OnIceServerSelectedTuple |
    Last message repeated 8 times
2023-03-02 15:08:57.013 I MediaServer.exe[24192-event poller 3] WebRtcTransport.cpp:113 OnIceServerSelectedTuple |
    Last message repeated 9 times
2023-03-02 15:08:57.515 I MediaServer.exe[24192-event poller 3] WebRtcTransport.cpp:113 OnIceServerSelectedTuple |
    Last message repeated 8 times
2023-03-02 15:08:58.076 I MediaServer.exe[24192-event poller 3] WebRtcTransport.cpp:113 OnIceServerSelectedTuple |
    Last message repeated 9 times
2023-03-02 15:08:58.579 I MediaServer.exe[24192-event poller 3] WebRtcTransport.cpp:113 OnIceServerSelectedTuple |
    Last message repeated 8 times
2023-03-02 15:08:59.141 I MediaServer.exe[24192-event poller 3] WebRtcTransport.cpp:113 OnIceServerSelectedTuple |
    Last message repeated 9 times
2023-03-02 15:08:59.647 I MediaServer.exe[24192-event poller 3] WebRtcTransport.cpp:113 OnIceServerSelectedTuple |
    Last message repeated 8 times
2023-03-02 15:08:59.647 I MediaServer.exe[24192-event poller 3] WebRtcTransport.cpp:113 OnIceServerSelectedTuple |
    Last message repeated 3 times
2023-03-02 15:09:00.153 T MediaServer.exe[24192-event poller 3] HttpSession.cpp:119 onError | 12-632(192.168.26.66:55782) session timeout
2023-03-02 15:09:00.153 T MediaServer.exe[24192-event poller 3] HttpSession.cpp:33 ~HttpSession | 12-632(192.168.26.66:55782)
2023-03-02 15:09:07.105 W MediaServer.exe[24192-event poller 3] WebRtcTransport.cpp:1041 onShutdown | 接受rtp/rtcp/datachannel超时
2023-03-02 15:09:07.105 W MediaServer.exe[24192-event poller 3] WebRtcSession.cpp:112 onError | 14-560(198.18.0.1:55565) 接受rtp/rtcp/datachannel超时
2023-03-02 15:09:07.105 W MediaServer.exe[24192-event poller 3] WebRtcSession.cpp:112 onError | 13-628(192.168.26.66:52599) 接受rtp/rtcp/datachannel超时
2023-03-02 15:09:07.105 I MediaServer.exe[24192-event poller 3] WebRtcSession.cpp:57 ~WebRtcSession | 13-628(192.168.26.66:52599)
```
经分析应该是改tcp候选地址引入的：
- setSession 将最后一个WebRtcSession当成 _selected_session，依照ice的建连顺序来说，这一般来都是个tcpsession，
-  而ice默认实现会切换回udp等cost小的连接，并导致输出那么多 OnIceServerSelectedTuple，
- 当前OnIceServerSelectedTuple实现中只是log一行日志，而没进行_selected_session切换；
- 当前WebRtcTransportImp::onSendSockData也只往_selected_session里发送
- 客户端迟迟收不到stun ping的响应，而不发送数据，近而导致接收数据超时而断开

说明白原因了，也就知道怎么改了，修改如pr，应该能修复这个问题。