### PR TITLE
webrtc 支持http信令 销毁

### DIFF
--- a/api/source/mk_common.cpp
+++ b/api/source/mk_common.cpp
@@ -305,7 +305,7 @@ API_EXPORT void API_CALL mk_webrtc_get_answer_sdp2(void *user_data, on_user_data
     auto session = std::make_shared<HttpSession>(Socket::createSocket());
     std::string offer_str = offer;
     std::shared_ptr<void> ptr(user_data, user_data_free ? user_data_free : [](void *) {});
-    WebRtcPluginManager::Instance().getAnswerSdp(*session, type, WebRtcArgsUrl(url),
+    WebRtcPluginManager::Instance().handleRtcPlugin(*session, type, WebRtcArgsUrl(url),
                                                  [offer_str, session, ptr, cb](const WebRtcInterface &exchanger) mutable {
         try {
             auto sdp_answer = const_cast<WebRtcInterface &>(exchanger).getAnswerSdp(offer_str);

--- a/webrtc/WebRtcPusher.cpp
+++ b/webrtc/WebRtcPusher.cpp
@@ -130,14 +130,21 @@ void WebRtcPusher::onDestory() {
         }
     }
 
-    if (_push_src && _continue_push_ms) {
+    WebRtcTransportImp::onDestory();
+}
+
+void WebRtcPusher::onShutdown(const SockException &ex) {
+
+    if (_push_src && _continue_push_ms && ex.getErrCode() != Err_shutdown) {
         //取消所有权
         _push_src_ownership = nullptr;
-        //延时10秒注销流
+        //延时注销流
         auto push_src = std::move(_push_src);
         getPoller()->doDelayTask(_continue_push_ms, [push_src]() { return 0; });
     }
-    WebRtcTransportImp::onDestory();
+
+    WebRtcTransportImp::onShutdown(ex);
+
 }
 
 void WebRtcPusher::onRtcConfigure(RtcConfigure &configure) const {
@@ -150,14 +157,5 @@ float WebRtcPusher::getLossRate(MediaSource &sender,TrackType type){
     return WebRtcTransportImp::getLossRate(type);
 }
 
-void WebRtcPusher::OnDtlsTransportClosed(const RTC::DtlsTransport *dtlsTransport) {
-   //主动关闭推流，那么不等待重推
-    _push_src = nullptr;
-    WebRtcTransportImp::OnDtlsTransportClosed(dtlsTransport);
-}
-
-void WebRtcPusher::onRtcpBye(){
-     WebRtcTransportImp::onRtcpBye();
-}
 
 }// namespace mediakit

--- a/webrtc/WebRtcPusher.h
+++ b/webrtc/WebRtcPusher.h
@@ -27,11 +27,9 @@ protected:
     ///////WebRtcTransportImp override///////
     void onStartWebRTC() override;
     void onDestory() override;
+    void onShutdown(const SockException &ex) override;
     void onRtcConfigure(RtcConfigure &configure) const override;
     void onRecvRtp(MediaTrack &track, const std::string &rid, RtpPacket::Ptr rtp) override;
-    void onRtcpBye() override;
-    ////  dtls相关的回调 ////
-   void OnDtlsTransportClosed(const RTC::DtlsTransport *dtlsTransport) override;
 
 protected:
     ///////MediaSourceEvent override///////

--- a/webrtc/WebRtcTransport.cpp
+++ b/webrtc/WebRtcTransport.cpp
@@ -802,7 +802,6 @@ void WebRtcTransportImp::onRtcp(const char *buf, size_t len) {
                 }
                 _ssrc_to_track.erase(it);
             }
-            onRtcpBye();
             // bye 会在 sender audio track mute 时出现, 因此不能作为 shutdown 的依据
             break;
         }
@@ -1075,7 +1074,6 @@ uint64_t WebRtcTransportImp::getDuration() const {
     return _alive_ticker.createdTime() / 1000;
 }
 
-void WebRtcTransportImp::onRtcpBye(){}
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/webrtc/WebRtcTransport.h
+++ b/webrtc/WebRtcTransport.h
@@ -156,7 +156,6 @@ protected:
     virtual void onShutdown(const SockException &ex) = 0;
     virtual void onBeforeEncryptRtp(const char *buf, int &len, void *ctx) = 0;
     virtual void onBeforeEncryptRtcp(const char *buf, int &len, void *ctx) = 0;
-    virtual void onRtcpBye() = 0;
 
 protected:
     void sendRtcpRemb(uint32_t ssrc, size_t bit_rate);
@@ -266,7 +265,6 @@ protected:
     virtual void onRecvRtp(MediaTrack &track, const std::string &rid, RtpPacket::Ptr rtp) = 0;
     void updateTicker();
     float getLossRate(TrackType type);
-    void onRtcpBye() override;
 
 private:
     void onSortedRtp(MediaTrack &track, const std::string &rid, RtpPacket::Ptr rtp);


### PR DESCRIPTION
@xia-chu 大佬这个pr是来自于使用[libdatachannel推流问题](https://github.com/paullouisageneau/libdatachannel/pull/811)的一点思考。

当客户端关闭了 但dtls close没发或者丢了，那就只能等待超时。在此时间段内设备如果id不变再重新推流就推不上了。

所以想着要不要加个信令来确保连接关闭,正好zlm上可以拓展webrtc插件，增加了一个stop_plugin。