### PR TITLE
捕获addFFmepgSource接口参数dst_url解析错误的抛错,通过错误回调返回返回错误,清除s_ffmpegMap表中的无效KEY

### DIFF
--- a/server/FFmpegSource.cpp
+++ b/server/FFmpegSource.cpp
@@ -78,7 +78,13 @@ void FFmpegSource::play(const string &ffmpeg_cmd_key, const string &src_url,cons
     _src_url = src_url;
     _dst_url = dst_url;
     _ffmpeg_cmd_key = ffmpeg_cmd_key;
-    _media_info.parse(dst_url);
+
+    try {
+        _media_info.parse(dst_url);
+    } catch (std::exception &ex) {
+        cb(SockException(Err_other, ex.what()));
+        return;
+    }
 
     auto ffmpeg_cmd = ffmpeg_cmd_default;
     if (!ffmpeg_cmd_key.empty()) {


### PR DESCRIPTION
使用appFFmpegSource接口是，如果dst_url地址格式错误，没有启动ffmpeg进程，同时KEY存入MAP中，导致后续请求因为key存在而返回正确。修改后，因为dst_url格式错误，会每次返回错误信息。
问题日志如下：
```
2023-03-14 09:45:27.954 T [MediaServer] [27500-event poller 0] HttpSession.cpp:27 HttpSession | 1-30(192.168.1.22:57377) 
2023-03-14 09:45:27.956 D [MediaServer] [27500-event poller 0] WebApi.cpp:250 http api debug | 
# request:
GET /index/api/addFFmpegSource?src_url=rtsp%3A%2F%2Fadmin%3Ajulong123.%40192.168.1.85%3A554%2FStreaming%2FChannels%2F101%3Ftransportmode%3Dunicast%26profile%3DProfile_1&dst_url=rtmp%3A%2F127.0.0.1%2Ftest%2Ftest&timeout_ms=20000&enable_hls=1&enable_mp4=1&ffmpeg_cmd_key=ffmpeg.cmd_rtsp_to_rtmp&secret=035c73f7-bb6b-4889-a715-d9eb2d1925cc
# header:
Accept : */*
Accept-Encoding : gzip, deflate
Accept-Language : zh-CN,zh;q=0.9
Connection : keep-alive
Cookie : doxygen_width=250; token=adminca13cab39b9149628e19e95e19e4d4df
cross-request-open-sign : 1
Host : 192.168.1.41:8098
User-Agent : Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36
# content:

# response:
{
        "code" : -400,
        "msg" : "Assertion failed: (sscanf(url.data() + pos + 1, \"%\" SCNu16, &port) == 1, parse port from url failed:rtmp:), function splitUrl, file /root/github/ZLMediaKit/src/Common/Parser.cpp, line 298."
}


2023-03-14 09:45:29.146 D [MediaServer] [27500-event poller 0] WebApi.cpp:250 http api debug | 
# request:
GET /index/api/addFFmpegSource?src_url=rtsp%3A%2F%2Fadmin%3Ajulong123.%40192.168.1.85%3A554%2FStreaming%2FChannels%2F101%3Ftransportmode%3Dunicast%26profile%3DProfile_1&dst_url=rtmp%3A%2F127.0.0.1%2Ftest%2Ftest&timeout_ms=20000&enable_hls=1&enable_mp4=1&ffmpeg_cmd_key=ffmpeg.cmd_rtsp_to_rtmp&secret=035c73f7-bb6b-4889-a715-d9eb2d1925cc
# header:
Accept : */*
Accept-Encoding : gzip, deflate
Accept-Language : zh-CN,zh;q=0.9
Connection : keep-alive
Cookie : doxygen_width=250; token=adminca13cab39b9149628e19e95e19e4d4df
cross-request-open-sign : 1
Host : 192.168.1.41:8098
User-Agent : Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36
# content:

# response:
{
        "code" : 0,
        "data" : 
        {
                "key" : "49c2817292eb72f61515ad1c484091bf"
        }
}


2023-03-14 09:45:32.343 D [MediaServer] [27500-event poller 0] WebApi.cpp:250 http api debug | 
# request:
GET /index/api/addFFmpegSource?src_url=rtsp%3A%2F%2Fadmin%3Ajulong123.%40192.168.1.85%3A554%2FStreaming%2FChannels%2F101%3Ftransportmode%3Dunicast%26profile%3DProfile_1&dst_url=rtmp%3A%2F127.0.0.1%2Ftest%2Ftest&timeout_ms=20000&enable_hls=1&enable_mp4=1&ffmpeg_cmd_key=ffmpeg.cmd_rtsp_to_rtmp&secret=035c73f7-bb6b-4889-a715-d9eb2d1925cc
# header:
Accept : */*
Accept-Encoding : gzip, deflate
Accept-Language : zh-CN,zh;q=0.9
Connection : keep-alive
Cookie : doxygen_width=250; token=adminca13cab39b9149628e19e95e19e4d4df
cross-request-open-sign : 1
Host : 192.168.1.41:8098
User-Agent : Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36
# content:

# response:
{
        "code" : 0,
        "data" : 
        {
                "key" : "49c2817292eb72f61515ad1c484091bf"
        }
}
```