### PR TITLE
避免m3u8文件出现问题或直播结束后,无限重试

### DIFF
--- a/src/Http/HlsParser.cpp
+++ b/src/Http/HlsParser.cpp
@@ -107,7 +107,9 @@ bool HlsParser::parse(const string &http_url, const string &m3u8) {
 bool HlsParser::isM3u8() const {
     return _is_m3u8;
 }
-
+void HlsParser::setIsM3U8(bool isM3U8) {
+    _is_m3u8 = isM3U8;
+}
 bool HlsParser::isLive() const{
     return _is_live;
 }

--- a/src/Http/HlsParser.cpp
+++ b/src/Http/HlsParser.cpp
@@ -98,19 +98,14 @@ bool HlsParser::parse(const string &http_url, const string &m3u8) {
         continue;
     }
 
-    if (_is_m3u8) {
-        onParsed(_is_m3u8_inner, _sequence, ts_map);
-    }
-    return _is_m3u8;
+    return _is_m3u8 && onParsed(_is_m3u8_inner, _sequence, ts_map);
 }
 
 bool HlsParser::isM3u8() const {
     return _is_m3u8;
 }
-void HlsParser::setIsM3U8(bool isM3U8) {
-    _is_m3u8 = isM3U8;
-}
-bool HlsParser::isLive() const{
+
+bool HlsParser::isLive() const {
     return _is_live;
 }
 

--- a/src/Http/HlsParser.h
+++ b/src/Http/HlsParser.h
@@ -79,7 +79,8 @@ public:
      * 得到总时间
      */
     float getTotalDuration() const;
- 
+    void setIsM3U8(bool isM3U8);
+
 protected:
     //解析出ts文件地址回调
     virtual void onParsed(bool is_m3u8_inner,int64_t sequence,const std::map<int,ts_segment> &ts_list) {};

--- a/src/Http/HlsParser.h
+++ b/src/Http/HlsParser.h
@@ -36,8 +36,9 @@ typedef struct{
 
 class HlsParser {
 public:
-    HlsParser(){}
-    ~HlsParser(){}
+    HlsParser() = default;
+    ~HlsParser() = default;
+
     bool parse(const std::string &http_url,const std::string &m3u8);
 
     /**
@@ -79,11 +80,16 @@ public:
      * 得到总时间
      */
     float getTotalDuration() const;
-    void setIsM3U8(bool isM3U8);
 
 protected:
-    //解析出ts文件地址回调
-    virtual void onParsed(bool is_m3u8_inner,int64_t sequence,const std::map<int,ts_segment> &ts_list) {};
+    /**
+     * 解析m3u8文件回调
+     * @param is_m3u8_inner 该m3u8文件中是否包含多个hls地址
+     * @param sequence ts序号
+     * @param ts_list ts地址列表
+     * @return 是否解析成功，返回false时，将导致HlsParser::parse返回false
+     */
+    virtual bool onParsed(bool is_m3u8_inner, int64_t sequence, const std::map<int, ts_segment> &ts_list) = 0;
 
 private:
     bool _is_m3u8 = false;

--- a/src/Http/HlsPlayer.cpp
+++ b/src/Http/HlsPlayer.cpp
@@ -51,7 +51,7 @@ void HlsPlayer::teardown_l(const SockException &ex) {
             } else {
                 _try_fetch_index_times += 1;
                 shutdown(ex);
-                WarnL << "重新尝试拉取索引文件[" << _try_fetch_index_times << "]:" << _play_url;
+                WarnL << "Attempt to pull the m3u8 file again[" << _try_fetch_index_times << "]:" << _play_url;
                 fetchIndexFile();
                 return;
             }
@@ -118,7 +118,7 @@ void HlsPlayer::fetchSegment() {
             return;
         }
         if (err) {
-            WarnL << "download ts segment " << url << " failed:" << err.what();
+            WarnL << "Download ts segment " << url << " failed:" << err.what();
             if (err.getErrCode() == Err_timeout) {
                 strong_self->_timeout_multiple = MAX(strong_self->_timeout_multiple + 1, MAX_TIMEOUT_MULTIPLE);
             }else{
@@ -147,40 +147,41 @@ void HlsPlayer::fetchSegment() {
     _http_ts_player->sendRequest(url);
 }
 
-void HlsPlayer::onParsed(bool is_m3u8_inner, int64_t sequence, const map<int, ts_segment> &ts_map) {
+bool HlsPlayer::onParsed(bool is_m3u8_inner, int64_t sequence, const map<int, ts_segment> &ts_map) {
     if (!is_m3u8_inner) {
-        //这是ts播放列表
+        // 这是ts播放列表
         if (_last_sequence == sequence) {
             // 如果是重复的ts列表，那么忽略
             // 但是需要注意, 如果当前ts列表为空了, 那么表明直播结束了或者m3u8文件有问题,需要重新拉流
             // 这里的5倍是为了防止m3u8文件有问题导致的无限重试
-            if (_last_sequence > 0 && _ts_list.empty() && HlsParser::isLive() && _wait_index_update_ticker.elapsedTime() > (uint64_t)HlsParser::getTargetDur() * 1000 * 5) {
+            if (_last_sequence > 0 && _ts_list.empty() && HlsParser::isLive()
+                && _wait_index_update_ticker.elapsedTime() > (uint64_t)HlsParser::getTargetDur() * 1000 * 5) {
                 _wait_index_update_ticker.resetTime();
-                HlsParser::setIsM3U8(false);
-                WarnL << "ts列表为空且m3u8文件长时间未更新,重置m3u8文件";
+                WarnL << "Fetch new ts list from m3u8 timeout";
+                return false;
             }
-            return;
-        }else{
-            _wait_index_update_ticker.resetTime();
+            return true;
         }
+
         _last_sequence = sequence;
+        _wait_index_update_ticker.resetTime();
         for (auto &pr : ts_map) {
             auto &ts = pr.second;
             if (_ts_url_cache.emplace(ts.url).second) {
-                //该ts未重复
+                // 该ts未重复
                 _ts_list.emplace_back(ts);
-                //按时间排序
+                // 按时间排序
                 _ts_url_sort.emplace_back(ts.url);
             }
         }
         if (_ts_url_sort.size() > 2 * ts_map.size()) {
-            //去除防重列表中过多的数据
+            // 去除防重列表中过多的数据
             _ts_url_cache.erase(_ts_url_sort.front());
             _ts_url_sort.pop_front();
         }
         fetchSegment();
     } else {
-        //这是m3u8列表,我们播放最高清的子hls
+        // 这是m3u8列表,我们播放最高清的子hls
         if (ts_map.empty()) {
             throw invalid_argument("empty sub hls list:" + getUrl());
         }
@@ -194,6 +195,7 @@ void HlsPlayer::onParsed(bool is_m3u8_inner, int64_t sequence, const map<int, ts
             }
         }, false);
     }
+    return true;
 }
 
 void HlsPlayer::onResponseHeader(const string &status, const HttpClient::HttpHeader &headers) {
@@ -203,7 +205,7 @@ void HlsPlayer::onResponseHeader(const string &status, const HttpClient::HttpHea
     }
     auto content_type = strToLower(const_cast<HttpClient::HttpHeader &>(headers)["Content-Type"]);
     if (content_type.find("application/vnd.apple.mpegurl") != 0 && content_type.find("/x-mpegurl") == _StrPrinter::npos) {
-        WarnL << "may not a hls video: " << content_type << ", url: " << getUrl();
+        WarnL << "May not a hls video: " << content_type << ", url: " << getUrl();
     }
     _m3u8.clear();
 }
@@ -218,7 +220,7 @@ void HlsPlayer::onResponseCompleted(const SockException &ex) {
         return;
     }
     if (!HlsParser::parse(getUrl(), _m3u8)) {
-        teardown_l(SockException(Err_other, "parse m3u8 failed:" + _m3u8));
+        teardown_l(SockException(Err_other, "parse m3u8 failed:" + _play_url));
         return;
     }
     if (!_play_result) {

--- a/src/Http/HlsPlayer.h
+++ b/src/Http/HlsPlayer.h
@@ -73,11 +73,11 @@ protected:
     virtual void onPacket(const char *data, size_t len) = 0;
 
 private:
-    void onParsed(bool is_m3u8_inner,int64_t sequence,const map<int,ts_segment> &ts_map) override;
-    void onResponseHeader(const std::string &status,const HttpHeader &headers) override;
-    void onResponseBody(const char *buf,size_t size) override;
+    bool onParsed(bool is_m3u8_inner, int64_t sequence, const map<int, ts_segment> &ts_map) override;
+    void onResponseHeader(const std::string &status, const HttpHeader &headers) override;
+    void onResponseBody(const char *buf, size_t size) override;
     void onResponseCompleted(const toolkit::SockException &e) override;
-    bool onRedirectUrl(const std::string &url,bool temporary) override;
+    bool onRedirectUrl(const std::string &url, bool temporary) override;
 
 private:
     void playDelay();

--- a/src/Http/HlsPlayer.h
+++ b/src/Http/HlsPlayer.h
@@ -101,6 +101,7 @@ private:
     std::string _play_url;
     toolkit::Timer::Ptr _timer;
     toolkit::Timer::Ptr _timer_ts;
+    toolkit::Ticker _wait_index_update_ticker;
     std::list<ts_segment> _ts_list;
     std::list<std::string> _ts_url_sort;
     std::set<std::string, UrlComp> _ts_url_cache;


### PR DESCRIPTION
有时如果对方直播结束了, 但是挂了一个nginx做反代, 导致m3u8文件可以访问, 最后的切片也可以下载, 这时zlm就会无限读取m3u8文件.

这里通过计时器来计算, 如果超过了5倍的切片时间, 仍旧没有新的切片生成.
那么就应该断开, 避免无限重试.

 因为我正在使用的zlm落后主分支太多, 所以这个patch是从我的zlm通过diff到当前版本的, 在我正在使用的版本上实际测试没有问题, 代码改动很少, 从代码阅读上应该也不存在问题.


