### PR TITLE
添加了addStreamProxy的异常捕获处理

### DIFF
--- a/src/Player/PlayerProxy.cpp
+++ b/src/Player/PlayerProxy.cpp
@@ -105,6 +105,7 @@ void PlayerProxy::play(const string &strUrlTmp) {
     } catch (std::exception &ex) {
         ErrorL << ex.what();
         _on_play_result(SockException(Err_other, ex.what()));
+        return;
     }
     _pull_url = strUrlTmp;
     setDirectProxy();

--- a/src/Player/PlayerProxy.cpp
+++ b/src/Player/PlayerProxy.cpp
@@ -100,7 +100,12 @@ void PlayerProxy::play(const string &strUrlTmp) {
             strongSelf->_on_close(err);
         }
     });
-    MediaPlayer::play(strUrlTmp);
+    try{
+        MediaPlayer::play(strUrlTmp);
+    }catch(std::exception &ex){
+        ErrorL << ex.what();
+        _on_play_result(SockException(Err_other, ex.what()));
+    }
     _pull_url = strUrlTmp;
     setDirectProxy();
 }

--- a/src/Player/PlayerProxy.cpp
+++ b/src/Player/PlayerProxy.cpp
@@ -100,9 +100,9 @@ void PlayerProxy::play(const string &strUrlTmp) {
             strongSelf->_on_close(err);
         }
     });
-    try{
+    try {
         MediaPlayer::play(strUrlTmp);
-    }catch(std::exception &ex){
+    } catch (std::exception &ex) {
         ErrorL << ex.what();
         _on_play_result(SockException(Err_other, ex.what()));
     }


### PR DESCRIPTION
原有代码在MediaPlayer::play(strUrlTmp);中如果发送异常时，在拉流代理器中的对象不会被释放，若下次同样的四元组参数进来时会默认这个流已经存在。
我添加了异常捕获，让http返回了正确的异常响应。