### PR TITLE
避免跳过一个正常的ts包

### DIFF
--- a/src/Rtp/TSDecoder.cpp
+++ b/src/Rtp/TSDecoder.cpp
@@ -35,13 +35,15 @@ const char *TSSegment::onSearchPacketTail(const char *data, size_t len) {
         }
         return nullptr;
     }
-    //下一个包头
+    //精确匹配下一个包头
     if (((uint8_t *) data)[_size] == TS_SYNC_BYTE) {
         return data + _size;
     }
-    auto pos = memchr(data + _size, TS_SYNC_BYTE, len - _size);
-    if (pos) {
-        return (char *) pos;
+    //搜索下一个包头
+    for (int i = 1; i < len - _size; ++i) {
+        if (((uint8_t *) data)[i] == TS_SYNC_BYTE && ((uint8_t *) data)[i + _size] == TS_SYNC_BYTE) {
+            return data + i;
+        }
     }
     if (remainDataSize() > 4 * _size) {
         //数据这么多都没ts包，全部清空


### PR DESCRIPTION
想了想, 虽然你直接操作内存会比较高性能, 但是与反复遍历整个大循环想比直接在这里寻找下一个包头会让代码更加清晰, 降低阅读代码时的心智负担, 所以还是提交了这个修改.

你看下是否合适, 如果不合适就还是按照你的方式修改, 还是使用memchr来寻找并再次循环onSearchPacketTail


