### PR TITLE
避免服务器端返回content-length=0时,TsPlayer不能正确释放的问题

### DIFF
--- a/src/Http/HttpClient.cpp
+++ b/src/Http/HttpClient.cpp
@@ -226,7 +226,7 @@ ssize_t HttpClient::onRecvHeader(const char *data, size_t len) {
 
     if (_total_body_size == 0) {
         //后续没content，本次http请求结束
-        onResponseCompleted_l(SockException(Err_success, "success"));
+        onResponseCompleted_l(SockException(Err_success, "The request is successful but has no body"));
         return 0;
     }
 
@@ -260,7 +260,7 @@ void HttpClient::onRecvContent(const char *data, size_t len) {
     if (_recved_body_size == (size_t)_total_body_size) {
         //content接收完毕
         onResponseBody(data, len);
-        onResponseCompleted_l(SockException(Err_success, "success"));
+        onResponseCompleted_l(SockException(Err_success, "completed"));
         return;
     }
 
@@ -329,7 +329,7 @@ void HttpClient::onResponseCompleted_l(const SockException &ex) {
 
     if (_total_body_size > 0 && _recved_body_size >= (size_t)_total_body_size) {
         //回复header中有content-length信息，那么收到的body大于等于声明值则认为成功
-        onResponseCompleted(SockException(Err_success, "success"));
+        onResponseCompleted(SockException(Err_success, "read body completed"));
         return;
     }
 

--- a/src/Http/TsPlayer.cpp
+++ b/src/Http/TsPlayer.cpp
@@ -34,7 +34,12 @@ void TsPlayer::teardown() {
 void TsPlayer::onResponseCompleted(const SockException &ex) {
     if (!_play_result) {
         _play_result = true;
-        onPlayResult(ex);
+        if (!ex && responseBodyTotalSize() == 0 && responseBodySize() == 0) {
+            //if the server does not return any data, it is considered a failure
+            onShutdown(ex);
+        } else {
+            onPlayResult(ex);
+        }
     } else {
         onShutdown(ex);
     }
@@ -44,7 +49,7 @@ void TsPlayer::onResponseCompleted(const SockException &ex) {
 void TsPlayer::onResponseBody(const char *buf, size_t size) {
     if (!_play_result) {
         _play_result = true;
-        onPlayResult(SockException(Err_success, "play http-ts success"));
+        onPlayResult(SockException(Err_success, "read http-ts stream successfully"));
     }
     if (!_benchmark_mode) {
         HttpTSPlayer::onResponseBody(buf, size);


### PR DESCRIPTION
1. 当有些服务器在直播流离线时, 错误的返回了content-length =0 时, 作为httpclient, 那么代表一次请求已完成没问题. 但是如果作为http-ts播放器, 那么这时候就会导致这个流没办法自己关闭. 所以这里增加一个判断.
2. 总是返回success不便于跟踪问题.因此修改了部分的提示字符, 让日志更好理解.