### PR TITLE
Added support for GCC 13

### DIFF
--- a/src/Http/strCoding.h
+++ b/src/Http/strCoding.h
@@ -13,7 +13,7 @@
 
 #include <iostream>
 #include <string>
-
+#include <cstdint>
 namespace mediakit {
 
 class strCoding {

--- a/src/Record/HlsMaker.h
+++ b/src/Record/HlsMaker.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <deque>
 #include <tuple>
+#include <cstdint>
 
 namespace mediakit {
 

--- a/src/Rtmp/amf.h
+++ b/src/Rtmp/amf.h
@@ -16,6 +16,7 @@
 #include <vector>
 #include <map>
 #include <functional>
+#include <cstdint>
 namespace toolkit {
     class BufferLikeString;
 }


### PR DESCRIPTION
A very minor change that would allow GCC13 and above to compile correctly. In newer versions, cstdint is not implicitly included, hence it errors out during compilation for some files.

These imports fixes the issues for me.



