### PR TITLE
修改国标rtp分包对于ehome协议的处理，添加rtp协议dump原始数据流

### DIFF
--- a/src/Rtp/RtpSession.h
+++ b/src/Rtp/RtpSession.h
@@ -53,6 +53,7 @@ private:
     std::string _stream_id;
     struct sockaddr_storage _addr;
     RtpProcess::Ptr _process;
+    std::shared_ptr<FILE> _save_file_rtp;
 };
 
 }//namespace mediakit

--- a/src/Rtp/RtpSplitter.cpp
+++ b/src/Rtp/RtpSplitter.cpp
@@ -30,14 +30,11 @@ ssize_t RtpSplitter::onRecvHeader(const char *data,size_t len){
     return 0;
 }
 
-static bool isEhome(const char *data, size_t len){
+static bool isEhome(const unsigned char *data, size_t len){
     if (len < 4) {
         return false;
     }
-    if ((data[0] == 0x01) && (data[1] == 0x00) && (data[2] >= 0x01)) {
-        return true;
-    }
-    return false;
+    return (data[0] == 0x01) && (data[1] == 0x00) && (data[2] >= 0x01);
 }
 
 const char *RtpSplitter::onSearchPacketTail(const char *data, size_t len) {
@@ -46,17 +43,20 @@ const char *RtpSplitter::onSearchPacketTail(const char *data, size_t len) {
         return nullptr;
     }
 
-    if (isEhome(data, len)) {
-        //是ehome协议
-        if (len < kEHOME_OFFSET + 4) {
-            //数据不够
-            return nullptr;
+    if(_is_ehome) {
+        if (isEhome((const unsigned char*)data, len)) {
+            //是ehome协议
+            if (len < kEHOME_OFFSET + 4) {
+                //数据不够
+                return nullptr;
+            }
+            //忽略ehome私有头后是rtsp样式的rtp，多4个字节，
+            _offset = kEHOME_OFFSET + 4;
+            //忽略ehome私有头
+            return onSearchPacketTail_l(data + kEHOME_OFFSET + 2, len - kEHOME_OFFSET - 2);
+        } else {
+            _is_ehome = false;
         }
-        //忽略ehome私有头后是rtsp样式的rtp，多4个字节，
-        _offset = kEHOME_OFFSET + 4;
-        _is_ehome = true;
-        //忽略ehome私有头
-        return onSearchPacketTail_l(data + kEHOME_OFFSET + 2, len - kEHOME_OFFSET - 2);
     }
 
     if (data[0] == '$') {

--- a/src/Rtp/RtpSplitter.h
+++ b/src/Rtp/RtpSplitter.h
@@ -35,7 +35,7 @@ protected:
     const char *onSearchPacketTail_l(const char *data, size_t len);
 
 private:
-    bool _is_ehome = false;
+    bool _is_ehome = true;
     size_t _offset = 0;
 };
 


### PR DESCRIPTION
在分包查找时ehome协议时只判断一次， 后续不在判断。
在测试海康ipc使用tcp被动国标流时， 由于tcp传输的rtp数据包正好256个字节， 则进入ehome协议判断，导致数据丢包。
附件中有从`RtpSession::onRecv`原始数据包和`RtpReceiver.h`中保存的rtp数据， 对比发现256字节长度数据丢会丢失。

后面是我dump出来的原始数据包[dump.zip](https://github.com/ZLMediaKit/ZLMediaKit/files/11553676/dump.zip)

下图是是ehome协议判断出错时的数据截图
![2023-05-24 18-11-13 的屏幕截图](https://github.com/ZLMediaKit/ZLMediaKit/assets/49055325/4cc553e5-96c3-467a-97b5-b49bc1493f24)
