### PR TITLE
降低TCP RTP数据被误认为是RTSP Interleaved数据的风险。

### DIFF
--- a/src/Rtp/RtpSplitter.cpp
+++ b/src/Rtp/RtpSplitter.cpp
@@ -59,11 +59,15 @@ const char *RtpSplitter::onSearchPacketTail(const char *data, size_t len) {
         return onSearchPacketTail_l(data + kEHOME_OFFSET + 2, len - kEHOME_OFFSET - 2);
     }
 
-    if (data[0] == '$') {
-        //可能是4个字节的rtp头
-        _offset = 4;
-        return onSearchPacketTail_l(data + 2, len - 2);
+    if ( _is_rtsp_interleaved ) {
+        if (data[0] == '$') {
+            //可能是4个字节的rtp头
+            _offset = 4;
+            return onSearchPacketTail_l(data + 2, len - 2);
+        }
+        _is_rtsp_interleaved = false;
     }
+    
     //两个字节的rtp头
     _offset = 2;
     return onSearchPacketTail_l(data, len);

--- a/src/Rtp/RtpSplitter.h
+++ b/src/Rtp/RtpSplitter.h
@@ -36,6 +36,7 @@ protected:
 
 private:
     bool _is_ehome = false;
+    bool _is_rtsp_interleaved = true;
     size_t _offset = 0;
 };
 


### PR DESCRIPTION
当RFC4571封装的RTP包大小在0x2400到0x24ff之间时，会被误认为是RTSP Interleaved 封装的数据。因为0x24正好是'$'的ASCII码，而RtpSplitter::onSearchPacketTail通过'$'来识别RTSP Interleaved数据。暂时没有想到什么好的办法能够百分之百的正确区分RFC4571数据和RTSP Interleaved数据。增加一个状态变量记录之前的状态，一旦检测到数据不是RTSP Interleaved格式，则后续不再进行尝试，以减小误判的可能性。