### PR TITLE
降低TCP RTP 2字节头被误判为EHOME头的风险

### DIFF
--- a/src/Rtp/RtpSplitter.cpp
+++ b/src/Rtp/RtpSplitter.cpp
@@ -46,17 +46,20 @@ const char *RtpSplitter::onSearchPacketTail(const char *data, size_t len) {
         return nullptr;
     }
 
-    if (isEhome(data, len)) {
-        //是ehome协议
-        if (len < kEHOME_OFFSET + 4) {
-            //数据不够
-            return nullptr;
+    if ( _is_ehome ) {
+        if (isEhome(data, len)) {
+            //是ehome协议
+            if (len < kEHOME_OFFSET + 4) {
+                //数据不够
+                return nullptr;
+            }
+            //忽略ehome私有头后是rtsp样式的rtp，多4个字节，
+            _offset = kEHOME_OFFSET + 4;
+            _is_ehome = true;
+            //忽略ehome私有头
+            return onSearchPacketTail_l(data + kEHOME_OFFSET + 2, len - kEHOME_OFFSET - 2);
         }
-        //忽略ehome私有头后是rtsp样式的rtp，多4个字节，
-        _offset = kEHOME_OFFSET + 4;
-        _is_ehome = true;
-        //忽略ehome私有头
-        return onSearchPacketTail_l(data + kEHOME_OFFSET + 2, len - kEHOME_OFFSET - 2);
+        _is_ehome = false;
     }
 
     if ( _is_rtsp_interleaved ) {

--- a/src/Rtp/RtpSplitter.h
+++ b/src/Rtp/RtpSplitter.h
@@ -35,7 +35,7 @@ protected:
     const char *onSearchPacketTail_l(const char *data, size_t len);
 
 private:
-    bool _is_ehome = false;
+    bool _is_ehome = true;
     bool _is_rtsp_interleaved = true;
     size_t _offset = 0;
 };


### PR DESCRIPTION
当TCP RTP包大小为256字节时，可能触发RtpSplitter::onSearchPacketTail误判为EHOME格式。 这个修改一旦检测到数据不是EHOME格式，则后续不再进行尝试，以减小误判的风险。

这个修改跟之前那个 #2499 的修改思路一致。但是我没有EHOME的设备，没法测试，哪位兄弟测试一下看看？