### PR TITLE
防止析构函数抛异常导致崩溃问题

### DIFF
--- a/src/Common/MediaSource.cpp
+++ b/src/Common/MediaSource.cpp
@@ -124,7 +124,11 @@ MediaSource::MediaSource(const string &schema, const MediaTuple& tuple): _tuple(
 }
 
 MediaSource::~MediaSource() {
-    unregist();
+    try {
+        unregist();
+    } catch (std::exception &ex) {
+        WarnL << "Exception occurred: " << ex.what();
+    }
 }
 
 const string& MediaSource::getSchema() const {

--- a/src/Player/PlayerProxy.cpp
+++ b/src/Player/PlayerProxy.cpp
@@ -202,7 +202,11 @@ PlayerProxy::~PlayerProxy() {
     _timer.reset();
     // 避免析构时, 忘记回调api请求
     if (_on_play) {
-        _on_play(SockException(Err_shutdown, "player proxy close"));
+        try {
+            _on_play(SockException(Err_shutdown, "player proxy close"));
+        } catch (std::exception &ex) {
+            WarnL << "Exception occurred: " << ex.what();
+        }
         _on_play = nullptr;
     }
 }

--- a/src/Pusher/MediaPusher.cpp
+++ b/src/Pusher/MediaPusher.cpp
@@ -31,8 +31,7 @@ MediaPusher::MediaPusher(const string &schema,
         MediaPusher(MediaSource::find(schema, vhost, app, stream), poller){
 }
 
-MediaPusher::~MediaPusher() {
-}
+MediaPusher::~MediaPusher() = default;
 
 static void setOnCreateSocket_l(const std::shared_ptr<PusherBase> &delegate, const Socket::onCreateSocket &cb){
     auto helper = dynamic_pointer_cast<SocketHelper>(delegate);

--- a/src/Record/HlsMaker.cpp
+++ b/src/Record/HlsMaker.cpp
@@ -22,9 +22,7 @@ HlsMaker::HlsMaker(float seg_duration, uint32_t seg_number, bool seg_keep) {
     _seg_keep = seg_keep;
 }
 
-HlsMaker::~HlsMaker() {
-}
-
+HlsMaker::~HlsMaker() = default;
 
 void HlsMaker::makeIndexFile(bool eof) {
     char file_content[1024];

--- a/src/Record/HlsMediaSource.cpp
+++ b/src/Record/HlsMediaSource.cpp
@@ -46,7 +46,11 @@ HlsCookieData::~HlsCookieData() {
         GET_CONFIG(uint32_t, iFlowThreshold, General::kFlowThreshold);
         uint64_t bytes = _bytes.load();
         if (bytes >= iFlowThreshold * 1024) {
-            NoticeCenter::Instance().emitEvent(Broadcast::kBroadcastFlowReport, _info, bytes, duration, true, static_cast<SockInfo &>(*_sock_info));
+            try {
+                NoticeCenter::Instance().emitEvent(Broadcast::kBroadcastFlowReport, _info, bytes, duration, true, static_cast<SockInfo &>(*_sock_info));
+            } catch (std::exception &ex) {
+                WarnL << "Exception occurred: " << ex.what();
+            }
         }
     }
 }

--- a/src/Record/MP4Demuxer.cpp
+++ b/src/Record/MP4Demuxer.cpp
@@ -21,7 +21,7 @@ using namespace std;
 
 namespace mediakit {
 
-MP4Demuxer::MP4Demuxer() {}
+MP4Demuxer::MP4Demuxer() = default;
 
 MP4Demuxer::~MP4Demuxer() {
     closeMP4();

--- a/src/Rtp/RtpProcess.cpp
+++ b/src/Rtp/RtpProcess.cpp
@@ -66,7 +66,11 @@ RtpProcess::~RtpProcess() {
     //流量统计事件广播
     GET_CONFIG(uint32_t, iFlowThreshold, General::kFlowThreshold);
     if (_total_bytes >= iFlowThreshold * 1024) {
-        NoticeCenter::Instance().emitEvent(Broadcast::kBroadcastFlowReport, _media_info, _total_bytes, duration, false, static_cast<SockInfo &>(*this));
+        try {
+            NoticeCenter::Instance().emitEvent(Broadcast::kBroadcastFlowReport, _media_info, _total_bytes, duration, false, static_cast<SockInfo &>(*this));
+        } catch (std::exception &ex) {
+            WarnL << "Exception occurred: " << ex.what();
+        }
     }
 }
 

--- a/src/Rtp/RtpSender.cpp
+++ b/src/Rtp/RtpSender.cpp
@@ -28,7 +28,11 @@ RtpSender::RtpSender(EventPoller::Ptr poller) {
 }
 
 RtpSender::~RtpSender() {
-    flush();
+    try {
+        flush();
+    } catch (std::exception &ex) {
+        WarnL << "Exception occurred: " << ex.what();
+    }
 }
 
 void RtpSender::startSend(const MediaSourceEvent::SendRtpArgs &args, const function<void(uint16_t local_port, const SockException &ex)> &cb){

--- a/srt/SrtTransportImp.cpp
+++ b/srt/SrtTransportImp.cpp
@@ -16,9 +16,11 @@ SrtTransportImp::~SrtTransportImp() {
     // 流量统计事件广播
     GET_CONFIG(uint32_t, iFlowThreshold, General::kFlowThreshold);
     if (_total_bytes >= iFlowThreshold * 1024) {
-        NoticeCenter::Instance().emitEvent(
-            Broadcast::kBroadcastFlowReport, _media_info, _total_bytes, duration, !_is_pusher,
-            static_cast<SockInfo &>(*this));
+        try {
+            NoticeCenter::Instance().emitEvent(Broadcast::kBroadcastFlowReport, _media_info, _total_bytes, duration, !_is_pusher, static_cast<SockInfo &>(*this));
+        } catch (std::exception &ex) {
+            WarnL << "Exception occurred: " << ex.what();
+        }
     }
 }
 


### PR DESCRIPTION
析构函数是noexcpt的 如果抛异常 将直接导致abort退出程序 通过try catch捕获异常 尽量避免进程退出的问题