### PR TITLE
修改一些cmake配置文件

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -461,7 +461,9 @@ if(ENABLE_PLAYER AND ENABLE_FFMPEG)
 endif()
 
 #MediaServer主程序
-add_subdirectory(server)
+if(ENABLE_SERVER)
+  add_subdirectory(server)
+endif()
 
 # Android 会 add_subdirectory 并依赖该变量
 if(ENABLE_SERVER_LIB)

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -74,8 +74,6 @@ generate_export_header(mk_api
   STATIC_DEFINE MediaKitApi_STATIC
   EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/mk_export.h")
 
-add_subdirectory(tests)
-
 file(GLOB API_HEADER_LIST include/*.h ${CMAKE_CURRENT_BINARY_DIR}/*.h)
 install(FILES ${API_HEADER_LIST}
   DESTINATION ${INSTALL_PATH_INCLUDE})
@@ -83,3 +81,7 @@ install(TARGETS mk_api
   ARCHIVE DESTINATION ${INSTALL_PATH_LIB}
   LIBRARY DESTINATION ${INSTALL_PATH_LIB}
   RUNTIME DESTINATION ${INSTALL_PATH_RUNTIME})
+
+if (ENABLE_TESTS)
+  add_subdirectory(tests)
+endif()

--- a/api/tests/CMakeLists.txt
+++ b/api/tests/CMakeLists.txt
@@ -43,15 +43,3 @@ foreach(TEST_SRC ${TEST_SRC_LIST})
   target_link_libraries(${exe_name} mk_api)
   target_compile_options(${exe_name} PRIVATE ${COMPILE_OPTIONS_DEFAULT})
 endforeach()
-
-
-
-
-
-
-
-
-
-
-
-

--- a/api/tests/pusher.c
+++ b/api/tests/pusher.c
@@ -9,6 +9,7 @@
  */
 
 #include <string.h>
+#include <stdio.h>
 #include "mk_mediakit.h"
 
 typedef struct {

--- a/api/tests/server.c
+++ b/api/tests/server.c
@@ -9,6 +9,7 @@
  */
 
 #include <string.h>
+#include <stdio.h>
 #include "mk_mediakit.h"
 #define LOG_LEV 4
 


### PR DESCRIPTION
  * enable_server cmake选项生效;
  * enable_tests 选项在api目录下的test同样生效;
  * 增加stdio.h 防止编译失败;

稍微提一些建议：
 1、ZLMediaKit使用了clang-format作为格式化工具，但很多代码却并为进行格式化，我设置了scode自动格式化代码，每次一保存就会修改代码。
 2、ZLMediaKit并为生成**pkg-config** 和**cmake**配置文件，会导致引用库比较麻烦，还要手动指定路径；
