### PR TITLE
RTSP支持强制协商RTP传输方式

### DIFF
--- a/conf/config.ini
+++ b/conf/config.ini
@@ -362,6 +362,10 @@ port=554
 sslport=0
 #rtsp 转发是否使用低延迟模式，当开启时，不会缓存rtp包，来提高并发，可以降低一帧的延迟
 lowLatency=0
+#强制协商rtp传输方式 (0:TCP,1:UDP,3:不限制)
+#当客户端发起RTSP SETUP的时候如果传输类型和此配置不一致则返回461 Unsupport Transport
+#迫使客户端重新SETUP并切换到对应协议。目前支持FFMPEG和VLC
+rtpTransportType=3
 [shell]
 #调试telnet服务器接受最大bufffer大小
 maxReqSize=1024

--- a/conf/config.ini
+++ b/conf/config.ini
@@ -362,10 +362,10 @@ port=554
 sslport=0
 #rtsp 转发是否使用低延迟模式，当开启时，不会缓存rtp包，来提高并发，可以降低一帧的延迟
 lowLatency=0
-#强制协商rtp传输方式 (0:TCP,1:UDP,3:不限制)
-#当客户端发起RTSP SETUP的时候如果传输类型和此配置不一致则返回461 Unsupport Transport
+#强制协商rtp传输方式 (0:TCP,1:UDP,2:MULTICAST,-1:不限制)
+#当客户端发起RTSP SETUP的时候如果传输类型和此配置不一致则返回461 Unsupported transport
 #迫使客户端重新SETUP并切换到对应协议。目前支持FFMPEG和VLC
-rtpTransportType=3
+rtpTransportType=-1
 [shell]
 #调试telnet服务器接受最大bufffer大小
 maxReqSize=1024

--- a/src/Common/config.cpp
+++ b/src/Common/config.cpp
@@ -145,7 +145,7 @@ static onceToken token([]() {
     mINI::Instance()[kTSDemand] = 0;
     mINI::Instance()[kFMP4Demand] = 0;
 });
-} // !Protocol
+} // namespace Protocol
 
 ////////////HTTP配置///////////
 namespace Http {
@@ -208,8 +208,8 @@ const string kAuthBasic = RTSP_FIELD "authBasic";
 const string kHandshakeSecond = RTSP_FIELD "handshakeSecond";
 const string kKeepAliveSecond = RTSP_FIELD "keepAliveSecond";
 const string kDirectProxy = RTSP_FIELD "directProxy";
-const string kLowLatency = RTSP_FIELD"lowLatency";
-const string kRtpTransportType = RTSP_FIELD"rtpTransportType";
+const string kLowLatency = RTSP_FIELD "lowLatency";
+const string kRtpTransportType = RTSP_FIELD "rtpTransportType";
 
 static onceToken token([]() {
     // 默认Md5方式认证
@@ -252,7 +252,6 @@ static onceToken token([]() {
     mINI::Instance()[kAudioMtuSize] = 600;
     mINI::Instance()[kRtpMaxSize] = 10;
     mINI::Instance()[kLowLatency] = 0;
-
 });
 } // namespace Rtp
 

--- a/src/Common/config.cpp
+++ b/src/Common/config.cpp
@@ -145,7 +145,7 @@ static onceToken token([]() {
     mINI::Instance()[kTSDemand] = 0;
     mINI::Instance()[kFMP4Demand] = 0;
 });
-} // namespace Protocol
+} // !Protocol
 
 ////////////HTTP配置///////////
 namespace Http {
@@ -208,8 +208,8 @@ const string kAuthBasic = RTSP_FIELD "authBasic";
 const string kHandshakeSecond = RTSP_FIELD "handshakeSecond";
 const string kKeepAliveSecond = RTSP_FIELD "keepAliveSecond";
 const string kDirectProxy = RTSP_FIELD "directProxy";
-const string kLowLatency = RTSP_FIELD "lowLatency";
-const string kRtpTransportType = RTSP_FIELD "rtpTransportType";
+const string kLowLatency = RTSP_FIELD"lowLatency";
+const string kRtpTransportType = RTSP_FIELD"rtpTransportType";
 
 static onceToken token([]() {
     // 默认Md5方式认证
@@ -252,6 +252,7 @@ static onceToken token([]() {
     mINI::Instance()[kAudioMtuSize] = 600;
     mINI::Instance()[kRtpMaxSize] = 10;
     mINI::Instance()[kLowLatency] = 0;
+
 });
 } // namespace Rtp
 

--- a/src/Common/config.cpp
+++ b/src/Common/config.cpp
@@ -218,7 +218,7 @@ static onceToken token([]() {
     mINI::Instance()[kKeepAliveSecond] = 15;
     mINI::Instance()[kDirectProxy] = 1;
     mINI::Instance()[kLowLatency] = 0;
-    mINI::Instance()[kRtpTransportType] = 3;
+    mINI::Instance()[kRtpTransportType] = -1;
 });
 } // namespace Rtsp
 

--- a/src/Common/config.cpp
+++ b/src/Common/config.cpp
@@ -209,6 +209,7 @@ const string kHandshakeSecond = RTSP_FIELD "handshakeSecond";
 const string kKeepAliveSecond = RTSP_FIELD "keepAliveSecond";
 const string kDirectProxy = RTSP_FIELD "directProxy";
 const string kLowLatency = RTSP_FIELD"lowLatency";
+const string kRtpTransportType = RTSP_FIELD"rtpTransportType";
 
 static onceToken token([]() {
     // 默认Md5方式认证
@@ -217,6 +218,7 @@ static onceToken token([]() {
     mINI::Instance()[kKeepAliveSecond] = 15;
     mINI::Instance()[kDirectProxy] = 1;
     mINI::Instance()[kLowLatency] = 0;
+    mINI::Instance()[kRtpTransportType] = 3;
 });
 } // namespace Rtsp
 

--- a/src/Common/config.h
+++ b/src/Common/config.h
@@ -49,7 +49,8 @@ extern const std::string kBroadcastHttpRequest;
 
 // 在http文件服务器中,收到http访问文件或目录的广播,通过该事件控制访问http目录的权限
 extern const std::string kBroadcastHttpAccess;
-#define BroadcastHttpAccessArgs const Parser &parser, const std::string &path, const bool &is_dir, const HttpSession::HttpAccessPathInvoker &invoker, SockInfo &sender
+#define BroadcastHttpAccessArgs                                                                                                                                \
+    const Parser &parser, const std::string &path, const bool &is_dir, const HttpSession::HttpAccessPathInvoker &invoker, SockInfo &sender
 
 // 在http文件服务器中,收到http访问文件或目录前的广播,通过该事件可以控制http url到文件路径的映射
 // 在该事件中通过自行覆盖path参数，可以做到譬如根据虚拟主机或者app选择不同http根目录的目的
@@ -63,7 +64,9 @@ extern const std::string kBroadcastOnGetRtspRealm;
 // 请求认证用户密码事件，user_name为用户名，must_no_encrypt如果为true，则必须提供明文密码(因为此时是base64认证方式),否则会导致认证失败
 // 获取到密码后请调用invoker并输入对应类型的密码和密码类型，invoker执行时会匹配密码
 extern const std::string kBroadcastOnRtspAuth;
-#define BroadcastOnRtspAuthArgs const MediaInfo &args, const std::string &realm, const std::string &user_name, const bool &must_no_encrypt, const RtspSession::onAuth &invoker, SockInfo &sender
+#define BroadcastOnRtspAuthArgs                                                                                                                                \
+    const MediaInfo &args, const std::string &realm, const std::string &user_name, const bool &must_no_encrypt, const RtspSession::onAuth &invoker,            \
+        SockInfo &sender
 
 // 推流鉴权结果回调对象
 // 如果err为空则代表鉴权成功
@@ -107,44 +110,44 @@ extern const std::string kBroadcastReloadConfig;
 
 // rtp server 超时
 extern const std::string KBroadcastRtpServerTimeout;
-#define BroadcastRtpServerTimeout uint16_t &local_port, const string &stream_id,int &tcp_mode, bool &re_use_port, uint32_t &ssrc
+#define BroadcastRtpServerTimeout uint16_t &local_port, const string &stream_id, int &tcp_mode, bool &re_use_port, uint32_t &ssrc
 
 #define ReloadConfigTag ((void *)(0xFF))
-#define RELOAD_KEY(arg, key)                                                                                           \
-    do {                                                                                                               \
-        decltype(arg) arg##_tmp = ::toolkit::mINI::Instance()[key];                                                    \
-        if (arg == arg##_tmp) {                                                                                        \
-            return;                                                                                                    \
-        }                                                                                                              \
-        arg = arg##_tmp;                                                                                               \
-        InfoL << "reload config:" << key << "=" << arg;                                                                \
+#define RELOAD_KEY(arg, key)                                                                                                                                   \
+    do {                                                                                                                                                       \
+        decltype(arg) arg##_tmp = ::toolkit::mINI::Instance()[key];                                                                                            \
+        if (arg == arg##_tmp) {                                                                                                                                \
+            return;                                                                                                                                            \
+        }                                                                                                                                                      \
+        arg = arg##_tmp;                                                                                                                                       \
+        InfoL << "reload config:" << key << "=" << arg;                                                                                                        \
     } while (0)
 
 // 监听某个配置发送变更
-#define LISTEN_RELOAD_KEY(arg, key, ...)                                                                               \
-    do {                                                                                                               \
-        static ::toolkit::onceToken s_token_listen([]() {                                                              \
-            ::toolkit::NoticeCenter::Instance().addListener(                                                           \
-                ReloadConfigTag, Broadcast::kBroadcastReloadConfig, [](BroadcastReloadConfigArgs) { __VA_ARGS__; });   \
-        });                                                                                                            \
+#define LISTEN_RELOAD_KEY(arg, key, ...)                                                                                                                       \
+    do {                                                                                                                                                       \
+        static ::toolkit::onceToken s_token_listen([]() {                                                                                                      \
+            ::toolkit::NoticeCenter::Instance().addListener(                                                                                                   \
+                ReloadConfigTag, Broadcast::kBroadcastReloadConfig, [](BroadcastReloadConfigArgs) { __VA_ARGS__; });                                           \
+        });                                                                                                                                                    \
     } while (0)
 
-#define GET_CONFIG(type, arg, key)                                                                                     \
-    static type arg = ::toolkit::mINI::Instance()[key];                                                                \
+#define GET_CONFIG(type, arg, key)                                                                                                                             \
+    static type arg = ::toolkit::mINI::Instance()[key];                                                                                                        \
     LISTEN_RELOAD_KEY(arg, key, { RELOAD_KEY(arg, key); });
 
-#define GET_CONFIG_FUNC(type, arg, key, ...)                                                                           \
-    static type arg;                                                                                                   \
-    do {                                                                                                               \
-        static ::toolkit::onceToken s_token_set([]() {                                                                 \
-            static auto lam = __VA_ARGS__;                                                                             \
-            static auto arg##_str = ::toolkit::mINI::Instance()[key];                                                  \
-            arg = lam(arg##_str);                                                                                      \
-            LISTEN_RELOAD_KEY(arg, key, {                                                                              \
-                RELOAD_KEY(arg##_str, key);                                                                            \
-                arg = lam(arg##_str);                                                                                  \
-            });                                                                                                        \
-        });                                                                                                            \
+#define GET_CONFIG_FUNC(type, arg, key, ...)                                                                                                                   \
+    static type arg;                                                                                                                                           \
+    do {                                                                                                                                                       \
+        static ::toolkit::onceToken s_token_set([]() {                                                                                                         \
+            static auto lam = __VA_ARGS__;                                                                                                                     \
+            static auto arg##_str = ::toolkit::mINI::Instance()[key];                                                                                          \
+            arg = lam(arg##_str);                                                                                                                              \
+            LISTEN_RELOAD_KEY(arg, key, {                                                                                                                      \
+                RELOAD_KEY(arg##_str, key);                                                                                                                    \
+                arg = lam(arg##_str);                                                                                                                          \
+            });                                                                                                                                                \
+        });                                                                                                                                                    \
     } while (0)
 
 } // namespace Broadcast
@@ -208,12 +211,12 @@ extern const std::string kEnableFMP4;
 
 //是否将mp4录制当做观看者
 extern const std::string kMP4AsPlayer;
-//mp4切片大小，单位秒
+// mp4切片大小，单位秒
 extern const std::string kMP4MaxSecond;
-//mp4录制保存路径
+// mp4录制保存路径
 extern const std::string kMP4SavePath;
 
-//hls录制保存路径
+// hls录制保存路径
 extern const std::string kHlsSavePath;
 
 // 按需转协议的开关
@@ -222,7 +225,7 @@ extern const std::string kRtspDemand;
 extern const std::string kRtmpDemand;
 extern const std::string kTSDemand;
 extern const std::string kFMP4Demand;
-} // !Protocol
+} // namespace Protocol
 
 ////////////HTTP配置///////////
 namespace Http {

--- a/src/Common/config.h
+++ b/src/Common/config.h
@@ -273,6 +273,11 @@ extern const std::string kDirectProxy;
 
 // rtsp 转发是否使用低延迟模式，当开启时，不会缓存rtp包，来提高并发，可以降低一帧的延迟
 extern const std::string kLowLatency;
+
+//强制协商rtp传输方式 (0:TCP,1:UDP,3:不限制)
+//当客户端发起RTSP SETUP的时候如果传输类型和此配置不一致则返回461 Unsupport Transport
+//迫使客户端重新SETUP并切换到对应协议。目前支持FFMPEG和VLC
+extern const std::string kRtpTransportType;
 } // namespace Rtsp
 
 ////////////RTMP服务器配置///////////

--- a/src/Common/config.h
+++ b/src/Common/config.h
@@ -277,7 +277,7 @@ extern const std::string kDirectProxy;
 // rtsp 转发是否使用低延迟模式，当开启时，不会缓存rtp包，来提高并发，可以降低一帧的延迟
 extern const std::string kLowLatency;
 
-//强制协商rtp传输方式 (0:TCP,1:UDP,3:不限制)
+//强制协商rtp传输方式 (0:TCP,1:UDP,-1:不限制)
 //当客户端发起RTSP SETUP的时候如果传输类型和此配置不一致则返回461 Unsupport Transport
 //迫使客户端重新SETUP并切换到对应协议。目前支持FFMPEG和VLC
 extern const std::string kRtpTransportType;

--- a/src/Common/config.h
+++ b/src/Common/config.h
@@ -49,8 +49,7 @@ extern const std::string kBroadcastHttpRequest;
 
 // 在http文件服务器中,收到http访问文件或目录的广播,通过该事件控制访问http目录的权限
 extern const std::string kBroadcastHttpAccess;
-#define BroadcastHttpAccessArgs                                                                                                                                \
-    const Parser &parser, const std::string &path, const bool &is_dir, const HttpSession::HttpAccessPathInvoker &invoker, SockInfo &sender
+#define BroadcastHttpAccessArgs const Parser &parser, const std::string &path, const bool &is_dir, const HttpSession::HttpAccessPathInvoker &invoker, SockInfo &sender
 
 // 在http文件服务器中,收到http访问文件或目录前的广播,通过该事件可以控制http url到文件路径的映射
 // 在该事件中通过自行覆盖path参数，可以做到譬如根据虚拟主机或者app选择不同http根目录的目的
@@ -64,9 +63,7 @@ extern const std::string kBroadcastOnGetRtspRealm;
 // 请求认证用户密码事件，user_name为用户名，must_no_encrypt如果为true，则必须提供明文密码(因为此时是base64认证方式),否则会导致认证失败
 // 获取到密码后请调用invoker并输入对应类型的密码和密码类型，invoker执行时会匹配密码
 extern const std::string kBroadcastOnRtspAuth;
-#define BroadcastOnRtspAuthArgs                                                                                                                                \
-    const MediaInfo &args, const std::string &realm, const std::string &user_name, const bool &must_no_encrypt, const RtspSession::onAuth &invoker,            \
-        SockInfo &sender
+#define BroadcastOnRtspAuthArgs const MediaInfo &args, const std::string &realm, const std::string &user_name, const bool &must_no_encrypt, const RtspSession::onAuth &invoker, SockInfo &sender
 
 // 推流鉴权结果回调对象
 // 如果err为空则代表鉴权成功
@@ -110,44 +107,44 @@ extern const std::string kBroadcastReloadConfig;
 
 // rtp server 超时
 extern const std::string KBroadcastRtpServerTimeout;
-#define BroadcastRtpServerTimeout uint16_t &local_port, const string &stream_id, int &tcp_mode, bool &re_use_port, uint32_t &ssrc
+#define BroadcastRtpServerTimeout uint16_t &local_port, const string &stream_id,int &tcp_mode, bool &re_use_port, uint32_t &ssrc
 
 #define ReloadConfigTag ((void *)(0xFF))
-#define RELOAD_KEY(arg, key)                                                                                                                                   \
-    do {                                                                                                                                                       \
-        decltype(arg) arg##_tmp = ::toolkit::mINI::Instance()[key];                                                                                            \
-        if (arg == arg##_tmp) {                                                                                                                                \
-            return;                                                                                                                                            \
-        }                                                                                                                                                      \
-        arg = arg##_tmp;                                                                                                                                       \
-        InfoL << "reload config:" << key << "=" << arg;                                                                                                        \
+#define RELOAD_KEY(arg, key)                                                                                           \
+    do {                                                                                                               \
+        decltype(arg) arg##_tmp = ::toolkit::mINI::Instance()[key];                                                    \
+        if (arg == arg##_tmp) {                                                                                        \
+            return;                                                                                                    \
+        }                                                                                                              \
+        arg = arg##_tmp;                                                                                               \
+        InfoL << "reload config:" << key << "=" << arg;                                                                \
     } while (0)
 
 // 监听某个配置发送变更
-#define LISTEN_RELOAD_KEY(arg, key, ...)                                                                                                                       \
-    do {                                                                                                                                                       \
-        static ::toolkit::onceToken s_token_listen([]() {                                                                                                      \
-            ::toolkit::NoticeCenter::Instance().addListener(                                                                                                   \
-                ReloadConfigTag, Broadcast::kBroadcastReloadConfig, [](BroadcastReloadConfigArgs) { __VA_ARGS__; });                                           \
-        });                                                                                                                                                    \
+#define LISTEN_RELOAD_KEY(arg, key, ...)                                                                               \
+    do {                                                                                                               \
+        static ::toolkit::onceToken s_token_listen([]() {                                                              \
+            ::toolkit::NoticeCenter::Instance().addListener(                                                           \
+                ReloadConfigTag, Broadcast::kBroadcastReloadConfig, [](BroadcastReloadConfigArgs) { __VA_ARGS__; });   \
+        });                                                                                                            \
     } while (0)
 
-#define GET_CONFIG(type, arg, key)                                                                                                                             \
-    static type arg = ::toolkit::mINI::Instance()[key];                                                                                                        \
+#define GET_CONFIG(type, arg, key)                                                                                     \
+    static type arg = ::toolkit::mINI::Instance()[key];                                                                \
     LISTEN_RELOAD_KEY(arg, key, { RELOAD_KEY(arg, key); });
 
-#define GET_CONFIG_FUNC(type, arg, key, ...)                                                                                                                   \
-    static type arg;                                                                                                                                           \
-    do {                                                                                                                                                       \
-        static ::toolkit::onceToken s_token_set([]() {                                                                                                         \
-            static auto lam = __VA_ARGS__;                                                                                                                     \
-            static auto arg##_str = ::toolkit::mINI::Instance()[key];                                                                                          \
-            arg = lam(arg##_str);                                                                                                                              \
-            LISTEN_RELOAD_KEY(arg, key, {                                                                                                                      \
-                RELOAD_KEY(arg##_str, key);                                                                                                                    \
-                arg = lam(arg##_str);                                                                                                                          \
-            });                                                                                                                                                \
-        });                                                                                                                                                    \
+#define GET_CONFIG_FUNC(type, arg, key, ...)                                                                           \
+    static type arg;                                                                                                   \
+    do {                                                                                                               \
+        static ::toolkit::onceToken s_token_set([]() {                                                                 \
+            static auto lam = __VA_ARGS__;                                                                             \
+            static auto arg##_str = ::toolkit::mINI::Instance()[key];                                                  \
+            arg = lam(arg##_str);                                                                                      \
+            LISTEN_RELOAD_KEY(arg, key, {                                                                              \
+                RELOAD_KEY(arg##_str, key);                                                                            \
+                arg = lam(arg##_str);                                                                                  \
+            });                                                                                                        \
+        });                                                                                                            \
     } while (0)
 
 } // namespace Broadcast
@@ -211,12 +208,12 @@ extern const std::string kEnableFMP4;
 
 //是否将mp4录制当做观看者
 extern const std::string kMP4AsPlayer;
-// mp4切片大小，单位秒
+//mp4切片大小，单位秒
 extern const std::string kMP4MaxSecond;
-// mp4录制保存路径
+//mp4录制保存路径
 extern const std::string kMP4SavePath;
 
-// hls录制保存路径
+//hls录制保存路径
 extern const std::string kHlsSavePath;
 
 // 按需转协议的开关
@@ -225,7 +222,7 @@ extern const std::string kRtspDemand;
 extern const std::string kRtmpDemand;
 extern const std::string kTSDemand;
 extern const std::string kFMP4Demand;
-} // namespace Protocol
+} // !Protocol
 
 ////////////HTTP配置///////////
 namespace Http {

--- a/src/Common/config.h
+++ b/src/Common/config.h
@@ -274,7 +274,7 @@ extern const std::string kDirectProxy;
 // rtsp 转发是否使用低延迟模式，当开启时，不会缓存rtp包，来提高并发，可以降低一帧的延迟
 extern const std::string kLowLatency;
 
-//强制协商rtp传输方式 (0:TCP,1:UDP,-1:不限制)
+//强制协商rtp传输方式 (0:TCP,1:UDP,2:MULTICAST,-1:不限制)
 //当客户端发起RTSP SETUP的时候如果传输类型和此配置不一致则返回461 Unsupport Transport
 //迫使客户端重新SETUP并切换到对应协议。目前支持FFMPEG和VLC
 extern const std::string kRtpTransportType;

--- a/src/Rtsp/RtspSession.cpp
+++ b/src/Rtsp/RtspSession.cpp
@@ -634,18 +634,43 @@ void RtspSession::handleReq_Setup(const Parser &parser) {
         //已经初始化过该Track
         throw SockException(Err_shutdown, "can not setup one track twice");
     }
-    trackRef->_inited = true; //现在初始化
+    
+    static auto getRtpTypeStr = [](const int type){
+        if(Rtsp::RTP_TCP == type){
+            return "TCP";
+        }else if(Rtsp::RTP_UDP == type ){
+            return "UDP";
+        }else if(Rtsp::RTP_MULTICAST == type ){
+            return "MULTICAST";
+        }else{
+            return "Invalid";
+        }
+    };
 
     if(_rtp_type == Rtsp::RTP_Invalid){
         auto &strTransport = parser["Transport"];
+        auto rtpType = Rtsp::RTP_Invalid;
         if(strTransport.find("TCP") != string::npos){
-            _rtp_type = Rtsp::RTP_TCP;
+            rtpType = Rtsp::RTP_TCP;
         }else if(strTransport.find("multicast") != string::npos){
-            _rtp_type = Rtsp::RTP_MULTICAST;
+            rtpType = Rtsp::RTP_MULTICAST;
         }else{
-            _rtp_type = Rtsp::RTP_UDP;
+            rtpType = Rtsp::RTP_UDP;
         }
+        //检查RTP传输类型限制
+        GET_CONFIG(int,transport,Rtsp::kRtpTransportType);
+        if((transport==Rtsp::RTP_TCP||
+            transport==Rtsp::RTP_UDP)&&
+            transport!=rtpType){
+            WarnL<<"rtsp client setup transport "<<getRtpTypeStr(rtpType)<<" but config force transport "<<getRtpTypeStr(transport);
+            //配置限定RTSP传输方式，但是客户端握手方式不一致，返回461
+            sendRtspResponse("461 Unsupported transport");
+            return ;
+        }
+        _rtp_type = rtpType;
     }
+
+    trackRef->_inited = true; //现在初始化
 
     //允许接收rtp、rtcp包
     RtspSplitter::enableRecvRtp(_rtp_type == Rtsp::RTP_TCP);

--- a/src/Rtsp/RtspSession.cpp
+++ b/src/Rtsp/RtspSession.cpp
@@ -8,15 +8,15 @@
  * may be found in the AUTHORS file in the root of the source tree.
  */
 
-#include "RtspSession.h"
-#include "Common/config.h"
-#include "Rtcp/RtcpContext.h"
-#include "RtpMultiCaster.h"
-#include "UDPServer.h"
-#include "Util/MD5.h"
-#include "Util/base64.h"
 #include <atomic>
 #include <iomanip>
+#include "Common/config.h"
+#include "UDPServer.h"
+#include "RtspSession.h"
+#include "Util/MD5.h"
+#include "Util/base64.h"
+#include "RtpMultiCaster.h"
+#include "Rtcp/RtcpContext.h"
 
 using namespace std;
 using namespace toolkit;
@@ -45,14 +45,14 @@ namespace mediakit {
  * zlmediakit在处理rtsp over http的请求时，会把http poster中的content数据base64解码后转发给http getter处理
  */
 
-// rtsp over http 情况下get请求实例，在请求实例用于接收rtp数据包
-static unordered_map<string, weak_ptr<RtspSession>> g_mapGetter;
+
+//rtsp over http 情况下get请求实例，在请求实例用于接收rtp数据包
+static unordered_map<string, weak_ptr<RtspSession> > g_mapGetter;
 //对g_mapGetter上锁保护
 static recursive_mutex g_mtxGetter;
 
-RtspSession::RtspSession(const Socket::Ptr &sock)
-    : Session(sock) {
-    GET_CONFIG(uint32_t, keep_alive_sec, Rtsp::kKeepAliveSecond);
+RtspSession::RtspSession(const Socket::Ptr &sock) : Session(sock) {
+    GET_CONFIG(uint32_t,keep_alive_sec,Rtsp::kKeepAliveSecond);
     sock->setSendTimeOutSecond(keep_alive_sec);
 }
 
@@ -61,7 +61,10 @@ RtspSession::~RtspSession() = default;
 void RtspSession::onError(const SockException &err) {
     bool is_player = !_push_src_ownership;
     uint64_t duration = _alive_ticker.createdTime() / 1000;
-    WarnP(this) << (is_player ? "RTSP播放器(" : "RTSP推流器(") << _media_info.shortUrl() << ")断开:" << err.what() << ",耗时(s):" << duration;
+    WarnP(this) << (is_player ? "RTSP播放器(" : "RTSP推流器(")
+                << _media_info.shortUrl()
+                << ")断开:" << err.what()
+                << ",耗时(s):" << duration;
 
     if (_rtp_type == Rtsp::RTP_MULTICAST) {
         //取消UDP端口监听
@@ -81,7 +84,7 @@ void RtspSession::onError(const SockException &err) {
     }
 
     //如果是主动关闭的，那么不延迟注销
-    if (_push_src && _continue_push_ms && err.getErrCode() != Err_shutdown) {
+    if (_push_src && _continue_push_ms  && err.getErrCode() != Err_shutdown) {
         //取消所有权
         _push_src_ownership = nullptr;
         //延时10秒注销流
@@ -96,7 +99,7 @@ void RtspSession::onManager() {
 
     if (_alive_ticker.createdTime() > handshake_sec * 1000) {
         if (_sessionid.size() == 0) {
-            shutdown(SockException(Err_timeout, "illegal connection"));
+            shutdown(SockException(Err_timeout,"illegal connection"));
             return;
         }
     }
@@ -108,7 +111,7 @@ void RtspSession::onManager() {
     }
 
     if (!_push_src && _rtp_type == Rtsp::RTP_UDP && _alive_ticker.elapsedTime() > keep_alive_sec * 4000) {
-        // rtp over udp播放器超时
+        //rtp over udp播放器超时
         shutdown(SockException(Err_timeout, "rtp over udp player timeout"));
     }
 }
@@ -117,7 +120,7 @@ void RtspSession::onRecv(const Buffer::Ptr &buf) {
     _alive_ticker.resetTime();
     _bytes_usage += buf->size();
     if (_on_recv) {
-        // http poster的请求数据转发给http getter处理
+        //http poster的请求数据转发给http getter处理
         _on_recv(buf);
     } else {
         input(buf->data(), buf->size());
@@ -164,21 +167,19 @@ void RtspSession::onRtpPacket(const char *data, size_t len) {
     uint8_t interleaved = data[1];
     if (interleaved % 2 == 0) {
         auto track_idx = getTrackIndexByInterleaved(interleaved);
-        handleOneRtp(
-            track_idx, _sdp_track[track_idx]->_type, _sdp_track[track_idx]->_samplerate, (uint8_t *)data + RtpPacket::kRtpTcpHeaderSize,
-            len - RtpPacket::kRtpTcpHeaderSize);
+        handleOneRtp(track_idx, _sdp_track[track_idx]->_type, _sdp_track[track_idx]->_samplerate, (uint8_t *) data + RtpPacket::kRtpTcpHeaderSize, len - RtpPacket::kRtpTcpHeaderSize);
     } else {
         auto track_idx = getTrackIndexByInterleaved(interleaved - 1);
         onRtcpPacket(track_idx, _sdp_track[track_idx], data + RtpPacket::kRtpTcpHeaderSize, len - RtpPacket::kRtpTcpHeaderSize);
     }
 }
 
-void RtspSession::onRtcpPacket(int track_idx, SdpTrack::Ptr &track, const char *data, size_t len) {
-    auto rtcp_arr = RtcpHeader::loadFromBytes((char *)data, len);
+void RtspSession::onRtcpPacket(int track_idx, SdpTrack::Ptr &track, const char *data, size_t len){
+    auto rtcp_arr = RtcpHeader::loadFromBytes((char *) data, len);
     for (auto &rtcp : rtcp_arr) {
         _rtcp_context[track_idx]->onRtcp(rtcp);
-        if ((RtcpType)rtcp->pt == RtcpType::RTCP_SR) {
-            auto sr = (RtcpSR *)(rtcp);
+        if ((RtcpType) rtcp->pt == RtcpType::RTCP_SR) {
+            auto sr = (RtcpSR *) (rtcp);
             //设置rtp时间戳与ntp时间戳的对应关系
             setNtpStamp(track_idx, sr->rtpts, sr->getNtpUnixStampMS());
         }
@@ -186,8 +187,8 @@ void RtspSession::onRtcpPacket(int track_idx, SdpTrack::Ptr &track, const char *
 }
 
 ssize_t RtspSession::getContentLength(Parser &parser) {
-    if (parser.method() == "POST") {
-        // http post请求的content数据部分是base64编码后的rtsp请求信令包
+    if(parser.method() == "POST"){
+        //http post请求的content数据部分是base64编码后的rtsp请求信令包
         return remainDataSize();
     }
     return RtspSplitter::getContentLength(parser);
@@ -195,7 +196,7 @@ ssize_t RtspSession::getContentLength(Parser &parser) {
 
 void RtspSession::handleReq_Options(const Parser &parser) {
     //支持这些命令
-    sendRtspResponse("200 OK", { "Public", "OPTIONS, DESCRIBE, SETUP, TEARDOWN, PLAY, PAUSE, ANNOUNCE, RECORD, SET_PARAMETER, GET_PARAMETER" });
+    sendRtspResponse("200 OK",{"Public" , "OPTIONS, DESCRIBE, SETUP, TEARDOWN, PLAY, PAUSE, ANNOUNCE, RECORD, SET_PARAMETER, GET_PARAMETER"});
 }
 
 void RtspSession::handleReq_ANNOUNCE(const Parser &parser) {
@@ -210,7 +211,7 @@ void RtspSession::handleReq_ANNOUNCE(const Parser &parser) {
     if (_media_info.app.empty() || _media_info.stream.empty()) {
         //推流rtsp url必须最少两级(rtsp://host/app/stream_id)，不允许莫名其妙的推流url
         static constexpr auto err = "rtsp推流url非法,最少确保两级rtsp url";
-        sendRtspResponse("403 Forbidden", { "Content-Type", "text/plain" }, err);
+        sendRtspResponse("403 Forbidden", {"Content-Type", "text/plain"}, err);
         throw SockException(Err_shutdown, StrPrinter << err << ":" << full_url);
     }
 
@@ -292,16 +293,15 @@ void RtspSession::handleReq_ANNOUNCE(const Parser &parser) {
         });
     };
 
-    // rtsp推流需要鉴权
-    auto flag = NoticeCenter::Instance().emitEvent(
-        Broadcast::kBroadcastMediaPublish, MediaOriginType::rtsp_push, _media_info, invoker, static_cast<SockInfo &>(*this));
+    //rtsp推流需要鉴权
+    auto flag = NoticeCenter::Instance().emitEvent(Broadcast::kBroadcastMediaPublish, MediaOriginType::rtsp_push, _media_info, invoker, static_cast<SockInfo &>(*this));
     if (!flag) {
         //该事件无人监听,默认不鉴权
         onRes("", ProtocolOption());
     }
 }
 
-void RtspSession::handleReq_RECORD(const Parser &parser) {
+void RtspSession::handleReq_RECORD(const Parser &parser){
     if (_sdp_track.empty() || parser["Session"] != _sessionid) {
         send_SessionNotFound();
         throw SockException(Err_shutdown, _sdp_track.empty() ? "can not find any available track when record" : "session not found when record");
@@ -317,16 +317,16 @@ void RtspSession::handleReq_RECORD(const Parser &parser) {
         rtp_info << "url=" << track->getControlUrl(_content_base) << ",";
     }
     rtp_info.pop_back();
-    sendRtspResponse("200 OK", { "RTP-Info", rtp_info });
+    sendRtspResponse("200 OK", {"RTP-Info", rtp_info});
     if (_rtp_type == Rtsp::RTP_TCP) {
         //如果是rtsp推流服务器，并且是TCP推流，设置socket flags,，这样能提升接收性能
         setSocketFlags();
     }
 }
 
-void RtspSession::emitOnPlay() {
+void RtspSession::emitOnPlay(){
     weak_ptr<RtspSession> weak_self = static_pointer_cast<RtspSession>(shared_from_this());
-    // url鉴权回调
+    //url鉴权回调
     auto onRes = [weak_self](const string &err) {
         auto strong_self = weak_self.lock();
         if (!strong_self) {
@@ -334,7 +334,7 @@ void RtspSession::emitOnPlay() {
         }
         if (!err.empty()) {
             //播放url鉴权失败
-            strong_self->sendRtspResponse("401 Unauthorized", { "Content-Type", "text/plain" }, err);
+            strong_self->sendRtspResponse("401 Unauthorized", {"Content-Type", "text/plain"}, err);
             strong_self->shutdown(SockException(Err_shutdown, StrPrinter << "401 Unauthorized:" << err));
             return;
         }
@@ -346,12 +346,13 @@ void RtspSession::emitOnPlay() {
         if (!strong_self) {
             return;
         }
-        strong_self->async([onRes, err, weak_self]() { onRes(err); });
+        strong_self->async([onRes, err, weak_self]() {
+            onRes(err);
+        });
     };
 
     //广播通用播放url鉴权事件
-    auto flag
-        = _emit_on_play ? false : NoticeCenter::Instance().emitEvent(Broadcast::kBroadcastMediaPlayed, _media_info, invoker, static_cast<SockInfo &>(*this));
+    auto flag = _emit_on_play ? false : NoticeCenter::Instance().emitEvent(Broadcast::kBroadcastMediaPlayed, _media_info, invoker, static_cast<SockInfo &>(*this));
     if (!flag) {
         //该事件无人监听,默认不鉴权
         onRes("");
@@ -364,7 +365,7 @@ void RtspSession::handleReq_Describe(const Parser &parser) {
     //该请求中的认证信息
     auto authorization = parser["Authorization"];
     weak_ptr<RtspSession> weak_self = static_pointer_cast<RtspSession>(shared_from_this());
-    // rtsp专属鉴权是否开启事件回调
+    //rtsp专属鉴权是否开启事件回调
     onGetRealm invoker = [weak_self, authorization](const string &realm) {
         auto strong_self = weak_self.lock();
         if (!strong_self) {
@@ -389,22 +390,22 @@ void RtspSession::handleReq_Describe(const Parser &parser) {
         });
     };
 
-    if (_rtsp_realm.empty()) {
+    if(_rtsp_realm.empty()){
         //广播是否需要rtsp专属认证事件
         if (!NoticeCenter::Instance().emitEvent(Broadcast::kBroadcastOnGetRtspRealm, _media_info, invoker, static_cast<SockInfo &>(*this))) {
             //无人监听此事件，说明无需认证
             invoker("");
         }
-    } else {
+    }else{
         invoker(_rtsp_realm);
     }
 }
 
 void RtspSession::onAuthSuccess() {
     weak_ptr<RtspSession> weak_self = static_pointer_cast<RtspSession>(shared_from_this());
-    MediaSource::findAsync(_media_info, weak_self.lock(), [weak_self](const MediaSource::Ptr &src) {
+    MediaSource::findAsync(_media_info, weak_self.lock(), [weak_self](const MediaSource::Ptr &src){
         auto strong_self = weak_self.lock();
-        if (!strong_self) {
+        if(!strong_self){
             return;
         }
         auto rtsp_src = dynamic_pointer_cast<RtspMediaSource>(src);
@@ -412,7 +413,7 @@ void RtspSession::onAuthSuccess() {
             //未找到相应的MediaSource
             string err = StrPrinter << "no such stream:" << strong_self->_media_info.shortUrl();
             strong_self->send_StreamNotFound();
-            strong_self->shutdown(SockException(Err_shutdown, err));
+            strong_self->shutdown(SockException(Err_shutdown,err));
             return;
         }
         //找到了相应的rtsp流
@@ -421,7 +422,7 @@ void RtspSession::onAuthSuccess() {
             //该流无效
             WarnL << "sdp中无有效track，该流无效:" << rtsp_src->getSdp();
             strong_self->send_StreamNotFound();
-            strong_self->shutdown(SockException(Err_shutdown, "can not find any available track in sdp"));
+            strong_self->shutdown(SockException(Err_shutdown,"can not find any available track in sdp"));
             return;
         }
         strong_self->_rtcp_context.clear();
@@ -430,19 +431,21 @@ void RtspSession::onAuthSuccess() {
         }
         strong_self->_sessionid = makeRandStr(12);
         strong_self->_play_src = rtsp_src;
-        for (auto &track : strong_self->_sdp_track) {
+        for(auto &track : strong_self->_sdp_track){
             track->_ssrc = rtsp_src->getSsrc(track->_type);
             track->_seq = rtsp_src->getSeqence(track->_type);
             track->_time_stamp = rtsp_src->getTimeStamp(track->_type);
         }
 
-        strong_self->sendRtspResponse(
-            "200 OK", { "Content-Base", strong_self->_content_base + "/", "x-Accept-Retransmit", "our-retransmit", "x-Accept-Dynamic-Rate", "1" },
-            rtsp_src->getSdp());
+        strong_self->sendRtspResponse("200 OK",
+                                     {"Content-Base", strong_self->_content_base + "/",
+                                      "x-Accept-Retransmit","our-retransmit",
+                                      "x-Accept-Dynamic-Rate","1"
+                                     },rtsp_src->getSdp());
     });
 }
 
-void RtspSession::onAuthFailed(const string &realm, const string &why, bool close) {
+void RtspSession::onAuthFailed(const string &realm,const string &why,bool close) {
     GET_CONFIG(bool, authBasic, Rtsp::kAuthBasic);
     if (!authBasic) {
         // 我们需要客户端优先以md5方式认证
@@ -458,7 +461,7 @@ void RtspSession::onAuthFailed(const string &realm, const string &why, bool clos
 }
 
 void RtspSession::onAuthBasic(const string &realm, const string &auth_base64) {
-    // base64认证
+    //base64认证
     auto user_passwd = decodeBase64(auth_base64);
     auto user_pwd_vec = split(user_passwd, ":");
     if (user_pwd_vec.size() < 2) {
@@ -482,7 +485,7 @@ void RtspSession::onAuthBasic(const string &realm, const string &auth_base64) {
                 //本对象已经销毁
                 return;
             }
-            // base64忽略encrypted参数，上层必须传入明文密码
+            //base64忽略encrypted参数，上层必须传入明文密码
             if (pwd == good_pwd) {
                 //提供的密码且匹配正确
                 strong_self->onAuthSuccess();
@@ -503,35 +506,35 @@ void RtspSession::onAuthBasic(const string &realm, const string &auth_base64) {
     }
 }
 
-void RtspSession::onAuthDigest(const string &realm, const string &auth_md5) {
+void RtspSession::onAuthDigest(const string &realm,const string &auth_md5){
     DebugP(this) << auth_md5;
     auto mapTmp = Parser::parseArgs(auth_md5, ",", "=");
     decltype(mapTmp) map;
-    for (auto &pr : mapTmp) {
-        map[trim(string(pr.first), " \"")] = trim(pr.second, " \"");
+    for(auto &pr : mapTmp){
+        map[trim(string(pr.first)," \"")] = trim(pr.second," \"");
     }
-    // check realm
-    if (realm != map["realm"]) {
-        onAuthFailed(realm, StrPrinter << "realm not mached:" << realm << " != " << map["realm"]);
-        return;
+    //check realm
+    if(realm != map["realm"]){
+        onAuthFailed(realm,StrPrinter << "realm not mached:" << realm << " != " << map["realm"]);
+        return ;
     }
-    // check nonce
+    //check nonce
     auto nonce = map["nonce"];
-    if (_auth_nonce != nonce) {
-        onAuthFailed(realm, StrPrinter << "nonce not mached:" << nonce << " != " << _auth_nonce);
-        return;
+    if(_auth_nonce != nonce){
+        onAuthFailed(realm,StrPrinter << "nonce not mached:" << nonce << " != " << _auth_nonce);
+        return ;
     }
-    // check username and uri
+    //check username and uri
     auto username = map["username"];
     auto uri = map["uri"];
     auto response = map["response"];
-    if (username.empty() || uri.empty() || response.empty()) {
-        onAuthFailed(realm, StrPrinter << "username/uri/response empty:" << username << "," << uri << "," << response);
-        return;
+    if(username.empty() || uri.empty() || response.empty()){
+        onAuthFailed(realm,StrPrinter << "username/uri/response empty:" << username << "," << uri << "," << response);
+        return ;
     }
 
-    auto realInvoker = [this, realm, nonce, uri, username, response](bool ignoreAuth, bool encrypted, const string &good_pwd) {
-        if (ignoreAuth) {
+    auto realInvoker = [this,realm,nonce,uri,username,response](bool ignoreAuth,bool encrypted,const string &good_pwd){
+        if(ignoreAuth){
             //忽略认证
             TraceP(this) << "auth ignored";
             onAuthSuccess();
@@ -546,81 +549,81 @@ void RtspSession::onAuthDigest(const string &realm, const string &auth_md5) {
             response= md5( md5(username:realm:password):nonce:md5(public_method:url) );
          */
         auto encrypted_pwd = good_pwd;
-        if (!encrypted) {
+        if(!encrypted){
             //提供的是明文密码
-            encrypted_pwd = MD5(username + ":" + realm + ":" + good_pwd).hexdigest();
+            encrypted_pwd = MD5(username+ ":" + realm + ":" + good_pwd).hexdigest();
         }
 
-        auto good_response = MD5(encrypted_pwd + ":" + nonce + ":" + MD5(string("DESCRIBE") + ":" + uri).hexdigest()).hexdigest();
-        if (strcasecmp(good_response.data(), response.data()) == 0) {
+        auto good_response = MD5( encrypted_pwd + ":" + nonce + ":" + MD5(string("DESCRIBE") + ":" + uri).hexdigest()).hexdigest();
+        if(strcasecmp(good_response.data(),response.data()) == 0){
             //认证成功！md5不区分大小写
             onAuthSuccess();
-        } else {
+        }else{
             //认证失败！
-            onAuthFailed(realm, StrPrinter << "password mismatch when md5 auth:" << good_response << " != " << response);
+            onAuthFailed(realm, StrPrinter << "password mismatch when md5 auth:" << good_response << " != " << response );
         }
     };
 
     weak_ptr<RtspSession> weak_self = static_pointer_cast<RtspSession>(shared_from_this());
-    onAuth invoker = [realInvoker, weak_self](bool encrypted, const string &good_pwd) {
+    onAuth invoker = [realInvoker,weak_self](bool encrypted,const string &good_pwd){
         auto strong_self = weak_self.lock();
-        if (!strong_self) {
+        if(!strong_self){
             return;
         }
         //切换到自己的线程确保realInvoker执行时，this指针有效
-        strong_self->async([realInvoker, weak_self, encrypted, good_pwd]() {
+        strong_self->async([realInvoker,weak_self,encrypted,good_pwd](){
             auto strong_self = weak_self.lock();
-            if (!strong_self) {
+            if(!strong_self){
                 return;
             }
-            realInvoker(false, encrypted, good_pwd);
+            realInvoker(false,encrypted,good_pwd);
         });
     };
 
     //此时可以提供明文或md5加密的密码
-    if (!NoticeCenter::Instance().emitEvent(Broadcast::kBroadcastOnRtspAuth, _media_info, realm, username, false, invoker, static_cast<SockInfo &>(*this))) {
+    if(!NoticeCenter::Instance().emitEvent(Broadcast::kBroadcastOnRtspAuth, _media_info, realm, username, false, invoker, static_cast<SockInfo &>(*this))){
         //表明该流需要认证却没监听请求密码事件，这一般是大意的程序所为，警告之
         WarnP(this) << "请监听kBroadcastOnRtspAuth事件！";
         //但是我们还是忽略认证以便完成播放
-        realInvoker(true, true, "");
+        realInvoker(true,true,"");
     }
 }
 
-void RtspSession::onAuthUser(const string &realm, const string &authorization) {
-    if (authorization.empty()) {
-        onAuthFailed(realm, "", false);
+void RtspSession::onAuthUser(const string &realm,const string &authorization){
+    if(authorization.empty()){
+        onAuthFailed(realm,"", false);
         return;
     }
     //请求中包含认证信息
     auto authType = findSubString(authorization.data(), NULL, " ");
     auto authStr = findSubString(authorization.data(), " ", NULL);
-    if (authType.empty() || authStr.empty()) {
+    if(authType.empty() || authStr.empty()){
         //认证信息格式不合法，回复401 Unauthorized
-        onAuthFailed(realm, "can not find auth type or auth string");
+        onAuthFailed(realm,"can not find auth type or auth string");
         return;
     }
-    if (authType == "Basic") {
-        // base64认证，需要明文密码
-        onAuthBasic(realm, authStr);
-    } else if (authType == "Digest") {
-        // md5认证
-        onAuthDigest(realm, authStr);
-    } else {
+    if(authType == "Basic"){
+        //base64认证，需要明文密码
+        onAuthBasic(realm,authStr);
+    }else if(authType == "Digest"){
+        //md5认证
+        onAuthDigest(realm,authStr);
+    }else{
         //其他认证方式？不支持！
-        onAuthFailed(realm, StrPrinter << "unsupported auth type:" << authType);
+        onAuthFailed(realm,StrPrinter << "unsupported auth type:" << authType);
     }
 }
 
 void RtspSession::send_StreamNotFound() {
-    sendRtspResponse("404 Stream Not Found", { "Connection", "Close" });
+    sendRtspResponse("404 Stream Not Found",{"Connection","Close"});
 }
 
 void RtspSession::send_UnsupportedTransport() {
-    sendRtspResponse("461 Unsupported Transport", { "Connection", "Close" });
+    sendRtspResponse("461 Unsupported Transport",{"Connection","Close"});
 }
 
 void RtspSession::send_SessionNotFound() {
-    sendRtspResponse("454 Session Not Found", { "Connection", "Close" });
+    sendRtspResponse("454 Session Not Found",{"Connection","Close"});
 }
 
 void RtspSession::handleReq_Setup(const Parser &parser) {
@@ -631,37 +634,37 @@ void RtspSession::handleReq_Setup(const Parser &parser) {
         //已经初始化过该Track
         throw SockException(Err_shutdown, "can not setup one track twice");
     }
-
-    static auto getRtpTypeStr = [](const int type) {
-        if (Rtsp::RTP_TCP == type) {
+    
+    static auto getRtpTypeStr = [](const int type){
+        if(Rtsp::RTP_TCP == type){
             return "TCP";
         }
-        if (Rtsp::RTP_UDP == type) {
+        if(Rtsp::RTP_UDP == type ){
             return "UDP";
         }
-        if (Rtsp::RTP_MULTICAST == type) {
+        if(Rtsp::RTP_MULTICAST == type ){
             return "MULTICAST";
         }
         return "Invalid";
     };
 
-    if (_rtp_type == Rtsp::RTP_Invalid) {
+    if(_rtp_type == Rtsp::RTP_Invalid){
         auto &strTransport = parser["Transport"];
         auto rtpType = Rtsp::RTP_Invalid;
-        if (strTransport.find("TCP") != string::npos) {
+        if(strTransport.find("TCP") != string::npos){
             rtpType = Rtsp::RTP_TCP;
-        } else if (strTransport.find("multicast") != string::npos) {
+        }else if(strTransport.find("multicast") != string::npos){
             rtpType = Rtsp::RTP_MULTICAST;
-        } else {
+        }else{
             rtpType = Rtsp::RTP_UDP;
         }
         //检查RTP传输类型限制
-        GET_CONFIG(int, transport, Rtsp::kRtpTransportType);
-        if (transport != Rtsp::RTP_Invalid && transport != rtpType) {
-            WarnL << "rtsp client setup transport " << getRtpTypeStr(rtpType) << " but config force transport " << getRtpTypeStr(transport);
+        GET_CONFIG(int,transport,Rtsp::kRtpTransportType);
+        if(transport!=Rtsp::RTP_Invalid&&transport!=rtpType){
+            WarnL<<"rtsp client setup transport "<<getRtpTypeStr(rtpType)<<" but config force transport "<<getRtpTypeStr(transport);
             //配置限定RTSP传输方式，但是客户端握手方式不一致，返回461
             sendRtspResponse("461 Unsupported transport");
-            return;
+            return ;
         }
         _rtp_type = rtpType;
     }
@@ -672,107 +675,110 @@ void RtspSession::handleReq_Setup(const Parser &parser) {
     RtspSplitter::enableRecvRtp(_rtp_type == Rtsp::RTP_TCP);
 
     switch (_rtp_type) {
-        case Rtsp::RTP_TCP: {
-            if (_push_src) {
-                // rtsp推流时，interleaved由推流者决定
-                auto key_values = Parser::parseArgs(parser["Transport"], ";", "=");
-                int interleaved_rtp = -1, interleaved_rtcp = -1;
-                if (2 == sscanf(key_values["interleaved"].data(), "%d-%d", &interleaved_rtp, &interleaved_rtcp)) {
-                    trackRef->_interleaved = interleaved_rtp;
-                } else {
-                    throw SockException(Err_shutdown, "can not find interleaved when setup of rtp over tcp");
-                }
-            } else {
-                // rtsp播放时，由于数据共享分发，所以interleaved必须由服务器决定
-                trackRef->_interleaved = 2 * trackRef->_type;
+    case Rtsp::RTP_TCP: {
+        if(_push_src){
+            //rtsp推流时，interleaved由推流者决定
+            auto key_values =  Parser::parseArgs(parser["Transport"],";","=");
+            int interleaved_rtp = -1 , interleaved_rtcp = -1;
+            if(2 == sscanf(key_values["interleaved"].data(),"%d-%d",&interleaved_rtp,&interleaved_rtcp)){
+                trackRef->_interleaved = interleaved_rtp;
+            }else{
+                throw SockException(Err_shutdown, "can not find interleaved when setup of rtp over tcp");
             }
-            sendRtspResponse(
-                "200 OK",
-                { "Transport",
-                  StrPrinter << "RTP/AVP/TCP;unicast;"
-                             << "interleaved=" << (int)trackRef->_interleaved << "-" << (int)trackRef->_interleaved + 1 << ";"
-                             << "ssrc=" << printSSRC(trackRef->_ssrc),
-                  "x-Transport-Options", "late-tolerance=1.400000", "x-Dynamic-Rate", "1" });
-        } break;
+        }else{
+            //rtsp播放时，由于数据共享分发，所以interleaved必须由服务器决定
+            trackRef->_interleaved = 2 * trackRef->_type;
+        }
+        sendRtspResponse("200 OK",
+                         {"Transport", StrPrinter << "RTP/AVP/TCP;unicast;"
+                                                  << "interleaved=" << (int) trackRef->_interleaved << "-"
+                                                  << (int) trackRef->_interleaved + 1 << ";"
+                                                  << "ssrc=" << printSSRC(trackRef->_ssrc),
+                          "x-Transport-Options", "late-tolerance=1.400000",
+                          "x-Dynamic-Rate", "1"
+                         });
+    }
+        break;
 
-        case Rtsp::RTP_UDP: {
-            std::pair<Socket::Ptr, Socket::Ptr> pr = std::make_pair(createSocket(), createSocket());
-            try {
-                makeSockPair(pr, get_local_ip());
-            } catch (std::exception &ex) {
-                //分配端口失败
-                send_NotAcceptable();
-                throw SockException(Err_shutdown, ex.what());
-            }
+    case Rtsp::RTP_UDP: {
+        std::pair<Socket::Ptr, Socket::Ptr> pr = std::make_pair(createSocket(),createSocket());
+        try {
+            makeSockPair(pr, get_local_ip());
+        } catch (std::exception &ex) {
+            //分配端口失败
+            send_NotAcceptable();
+            throw SockException(Err_shutdown, ex.what());
+        }
 
-            _rtp_socks[trackIdx] = pr.first;
-            _rtcp_socks[trackIdx] = pr.second;
+        _rtp_socks[trackIdx] = pr.first;
+        _rtcp_socks[trackIdx] = pr.second;
 
-            //设置客户端内网端口信息
-            string strClientPort = findSubString(parser["Transport"].data(), "client_port=", NULL);
-            uint16_t ui16RtpPort = atoi(findSubString(strClientPort.data(), NULL, "-").data());
-            uint16_t ui16RtcpPort = atoi(findSubString(strClientPort.data(), "-", NULL).data());
+        //设置客户端内网端口信息
+        string strClientPort = findSubString(parser["Transport"].data(), "client_port=", NULL);
+        uint16_t ui16RtpPort = atoi(findSubString(strClientPort.data(), NULL, "-").data());
+        uint16_t ui16RtcpPort = atoi(findSubString(strClientPort.data(), "-", NULL).data());
 
-            auto peerAddr = SockUtil::make_sockaddr(get_peer_ip().data(), ui16RtpPort);
-            //设置rtp发送目标地址
-            pr.first->bindPeerAddr((struct sockaddr *)(&peerAddr));
+        auto peerAddr = SockUtil::make_sockaddr(get_peer_ip().data(), ui16RtpPort);
+        //设置rtp发送目标地址
+        pr.first->bindPeerAddr((struct sockaddr *) (&peerAddr));
 
-            //设置rtcp发送目标地址
-            peerAddr = SockUtil::make_sockaddr(get_peer_ip().data(), ui16RtcpPort);
-            pr.second->bindPeerAddr((struct sockaddr *)(&peerAddr));
+        //设置rtcp发送目标地址
+        peerAddr = SockUtil::make_sockaddr(get_peer_ip().data(), ui16RtcpPort);
+        pr.second->bindPeerAddr((struct sockaddr *) (&peerAddr));
 
-            //尝试获取客户端nat映射地址
-            startListenPeerUdpData(trackIdx);
-            // InfoP(this) << "分配端口:" << srv_port;
+        //尝试获取客户端nat映射地址
+        startListenPeerUdpData(trackIdx);
+        //InfoP(this) << "分配端口:" << srv_port;
 
-            sendRtspResponse(
-                "200 OK",
-                { "Transport",
-                  StrPrinter << "RTP/AVP/UDP;unicast;"
-                             << "client_port=" << strClientPort << ";"
-                             << "server_port=" << pr.first->get_local_port() << "-" << pr.second->get_local_port() << ";"
-                             << "ssrc=" << printSSRC(trackRef->_ssrc) });
-        } break;
-        case Rtsp::RTP_MULTICAST: {
+        sendRtspResponse("200 OK",
+                         {"Transport", StrPrinter << "RTP/AVP/UDP;unicast;"
+                                                  << "client_port=" << strClientPort << ";"
+                                                  << "server_port=" << pr.first->get_local_port() << "-"
+                                                  << pr.second->get_local_port() << ";"
+                                                  << "ssrc=" << printSSRC(trackRef->_ssrc)
+                         });
+    }
+        break;
+    case Rtsp::RTP_MULTICAST: {
+        if(!_multicaster){
+            _multicaster = RtpMultiCaster::get(*this, get_local_ip(), _media_info.vhost, _media_info.app, _media_info.stream, _multicast_ip, _multicast_video_port, _multicast_audio_port);
             if (!_multicaster) {
-                _multicaster = RtpMultiCaster::get(
-                    *this, get_local_ip(), _media_info.vhost, _media_info.app, _media_info.stream, _multicast_ip, _multicast_video_port, _multicast_audio_port);
-                if (!_multicaster) {
-                    send_NotAcceptable();
-                    throw SockException(Err_shutdown, "can not get a available udp multicast socket");
-                }
-                weak_ptr<RtspSession> weak_self = static_pointer_cast<RtspSession>(shared_from_this());
-                _multicaster->setDetachCB(this, [weak_self]() {
-                    auto strong_self = weak_self.lock();
-                    if (!strong_self) {
-                        return;
-                    }
-                    strong_self->safeShutdown(SockException(Err_shutdown, "ring buffer detached"));
-                });
-            }
-            int iSrvPort = _multicaster->getMultiCasterPort(trackRef->_type);
-            //我们用trackIdx区分rtp和rtcp包
-            //由于组播udp端口是共享的，而rtcp端口为组播udp端口+1，所以rtcp端口需要改成共享端口
-            auto pSockRtcp = UDPServer::Instance().getSock(*this, get_local_ip().data(), 2 * trackIdx + 1, iSrvPort + 1);
-            if (!pSockRtcp) {
-                //分配端口失败
                 send_NotAcceptable();
-                throw SockException(Err_shutdown, "open shared rtcp socket failed");
+                throw SockException(Err_shutdown, "can not get a available udp multicast socket");
             }
-            startListenPeerUdpData(trackIdx);
-            GET_CONFIG(uint32_t, udpTTL, MultiCast::kUdpTTL);
+            weak_ptr<RtspSession> weak_self = static_pointer_cast<RtspSession>(shared_from_this());
+            _multicaster->setDetachCB(this, [weak_self]() {
+                auto strong_self = weak_self.lock();
+                if(!strong_self) {
+                    return;
+                }
+                strong_self->safeShutdown(SockException(Err_shutdown,"ring buffer detached"));
+            });
+        }
+        int iSrvPort = _multicaster->getMultiCasterPort(trackRef->_type);
+        //我们用trackIdx区分rtp和rtcp包
+        //由于组播udp端口是共享的，而rtcp端口为组播udp端口+1，所以rtcp端口需要改成共享端口
+        auto pSockRtcp = UDPServer::Instance().getSock(*this, get_local_ip().data(), 2 * trackIdx + 1, iSrvPort + 1);
+        if (!pSockRtcp) {
+            //分配端口失败
+            send_NotAcceptable();
+            throw SockException(Err_shutdown, "open shared rtcp socket failed");
+        }
+        startListenPeerUdpData(trackIdx);
+        GET_CONFIG(uint32_t,udpTTL,MultiCast::kUdpTTL);
 
-            sendRtspResponse(
-                "200 OK",
-                { "Transport",
-                  StrPrinter << "RTP/AVP;multicast;"
-                             << "destination=" << _multicaster->getMultiCasterIP() << ";"
-                             << "source=" << get_local_ip() << ";"
-                             << "port=" << iSrvPort << "-" << pSockRtcp->get_local_port() << ";"
-                             << "ttl=" << udpTTL << ";"
-                             << "ssrc=" << printSSRC(trackRef->_ssrc) });
-        } break;
-        default: break;
+        sendRtspResponse("200 OK",
+                         {"Transport", StrPrinter << "RTP/AVP;multicast;"
+                                                  << "destination=" << _multicaster->getMultiCasterIP() << ";"
+                                                  << "source=" << get_local_ip() << ";"
+                                                  << "port=" << iSrvPort << "-" << pSockRtcp->get_local_port() << ";"
+                                                  << "ttl=" << udpTTL << ";"
+                                                  << "ssrc=" << printSSRC(trackRef->_ssrc)
+                         });
+    }
+        break;
+    default:
+        break;
     }
 }
 
@@ -782,9 +788,9 @@ void RtspSession::handleReq_Play(const Parser &parser) {
         throw SockException(Err_shutdown, _sdp_track.empty() ? "can not find any available track when play" : "session not found when play");
     }
     auto play_src = _play_src.lock();
-    if (!play_src) {
+    if(!play_src){
         send_StreamNotFound();
-        shutdown(SockException(Err_shutdown, "rtsp stream released"));
+        shutdown(SockException(Err_shutdown,"rtsp stream released"));
         return;
     }
 
@@ -807,8 +813,8 @@ void RtspSession::handleReq_Play(const Parser &parser) {
         if (strStart == "now") {
             strStart = "0";
         }
-        auto iStartTime = 1000 * (float)atof(strStart.data());
-        use_gop = !play_src->seekTo((uint32_t)iStartTime);
+        auto iStartTime = 1000 * (float) atof(strStart.data());
+        use_gop = !play_src->seekTo((uint32_t) iStartTime);
         InfoP(this) << "rtsp seekTo(ms):" << iStartTime;
     }
 
@@ -826,7 +832,7 @@ void RtspSession::handleReq_Play(const Parser &parser) {
 
         rtp_info << "url=" << track->getControlUrl(_content_base) << ";"
                  << "seq=" << track->_seq << ";"
-                 << "rtptime=" << (int)(track->_time_stamp * (track->_samplerate / 1000)) << ",";
+                 << "rtptime=" << (int) (track->_time_stamp * (track->_samplerate / 1000)) << ",";
     }
 
     rtp_info.pop_back();
@@ -885,22 +891,16 @@ void RtspSession::handleReq_Teardown(const Parser &parser) {
     _push_src = nullptr;
     //此时回复可能触发broken pipe事件，从而直接触发onError回调；所以需要先把_push_src置空，防止触发断流续推功能
     sendRtspResponse("200 OK");
-    throw SockException(Err_shutdown, "recv teardown request");
+    throw SockException(Err_shutdown,"recv teardown request");
 }
 
 void RtspSession::handleReq_Get(const Parser &parser) {
     _http_x_sessioncookie = parser["x-sessioncookie"];
-    sendRtspResponse(
-        "200 OK",
-        {
-            "Cache-Control",
-            "no-store",
-            "Pragma",
-            "no-store",
-            "Content-Type",
-            "application/x-rtsp-tunnelled",
-        },
-        "", "HTTP/1.0");
+    sendRtspResponse("200 OK",
+                     {"Cache-Control","no-store",
+                      "Pragma","no-store",
+                      "Content-Type","application/x-rtsp-tunnelled",
+                     },"","HTTP/1.0");
 
     //注册http getter，以便http poster绑定
     lock_guard<recursive_mutex> lock(g_mtxGetter);
@@ -910,60 +910,54 @@ void RtspSession::handleReq_Get(const Parser &parser) {
 void RtspSession::handleReq_Post(const Parser &parser) {
     lock_guard<recursive_mutex> lock(g_mtxGetter);
     string sessioncookie = parser["x-sessioncookie"];
-    // Poster 找到 Getter
+    //Poster 找到 Getter
     auto it = g_mapGetter.find(sessioncookie);
     if (it == g_mapGetter.end()) {
-        throw SockException(Err_shutdown, "can not find http getter by x-sessioncookie");
+        throw SockException(Err_shutdown,"can not find http getter by x-sessioncookie");
     }
 
-    // Poster 找到Getter的SOCK
+    //Poster 找到Getter的SOCK
     auto httpGetterWeak = it->second;
     //移除http getter的弱引用记录
     g_mapGetter.erase(sessioncookie);
 
-    // http poster收到请求后转发给http getter处理
-    _on_recv = [this, httpGetterWeak](const Buffer::Ptr &buf) {
+    //http poster收到请求后转发给http getter处理
+    _on_recv = [this,httpGetterWeak](const Buffer::Ptr &buf){
         auto httpGetterStrong = httpGetterWeak.lock();
-        if (!httpGetterStrong) {
-            shutdown(SockException(Err_shutdown, "http getter released"));
+        if(!httpGetterStrong){
+            shutdown(SockException(Err_shutdown,"http getter released"));
             return;
         }
 
         //切换到http getter的线程
-        httpGetterStrong->async([buf, httpGetterWeak]() {
+        httpGetterStrong->async([buf,httpGetterWeak](){
             auto httpGetterStrong = httpGetterWeak.lock();
-            if (!httpGetterStrong) {
+            if(!httpGetterStrong){
                 return;
             }
             httpGetterStrong->onRecv(std::make_shared<BufferString>(decodeBase64(string(buf->data(), buf->size()))));
         });
     };
 
-    if (!parser.content().empty()) {
-        // http poster后面的粘包
+    if(!parser.content().empty()){
+        //http poster后面的粘包
         _on_recv(std::make_shared<BufferString>(parser.content()));
     }
 
-    sendRtspResponse(
-        "200 OK",
-        {
-            "Cache-Control",
-            "no-store",
-            "Pragma",
-            "no-store",
-            "Content-Type",
-            "application/x-rtsp-tunnelled",
-        },
-        "", "HTTP/1.0");
+    sendRtspResponse("200 OK",
+                     {"Cache-Control","no-store",
+                      "Pragma","no-store",
+                      "Content-Type","application/x-rtsp-tunnelled",
+                     },"","HTTP/1.0");
 }
 
 void RtspSession::handleReq_SET_PARAMETER(const Parser &parser) {
-    // TraceP(this) <<endl;
+    //TraceP(this) <<endl;
     sendRtspResponse("200 OK");
 }
 
 void RtspSession::send_NotAcceptable() {
-    sendRtspResponse("406 Not Acceptable", { "Connection", "Close" });
+    sendRtspResponse("406 Not Acceptable",{"Connection","Close"});
 }
 
 void RtspSession::onRtpSorted(RtpPacket::Ptr rtp, int track_idx) {
@@ -982,7 +976,7 @@ void RtspSession::onRcvPeerUdpData(int interleaved, const Buffer::Ptr &buf, cons
         if (_push_src) {
             //这是rtsp推流上来的rtp包
             auto &ref = _sdp_track[interleaved / 2];
-            handleOneRtp(interleaved / 2, ref->_type, ref->_samplerate, (uint8_t *)buf->data(), buf->size());
+            handleOneRtp(interleaved / 2, ref->_type, ref->_samplerate, (uint8_t *) buf->data(), buf->size());
         } else if (!_udp_connected_flags.count(interleaved)) {
             //这是rtsp播放器的rtp打洞包
             _udp_connected_flags.emplace(interleaved);
@@ -991,7 +985,7 @@ void RtspSession::onRcvPeerUdpData(int interleaved, const Buffer::Ptr &buf, cons
             }
         }
     } else {
-        // rtcp包
+        //rtcp包
         if (!_udp_connected_flags.count(interleaved)) {
             _udp_connected_flags.emplace(interleaved);
             if (_rtcp_socks[(interleaved - 1) / 2]) {
@@ -1005,14 +999,15 @@ void RtspSession::onRcvPeerUdpData(int interleaved, const Buffer::Ptr &buf, cons
 void RtspSession::startListenPeerUdpData(int track_idx) {
     weak_ptr<RtspSession> weak_self = static_pointer_cast<RtspSession>(shared_from_this());
     auto peer_ip = get_peer_ip();
-    auto onUdpData = [weak_self, peer_ip](const Buffer::Ptr &buf, struct sockaddr *peer_addr, int interleaved) {
+    auto onUdpData = [weak_self,peer_ip](const Buffer::Ptr &buf, struct sockaddr *peer_addr, int interleaved){
         auto strong_self = weak_self.lock();
         if (!strong_self) {
             return false;
         }
 
         if (SockUtil::inet_ntoa(peer_addr) != peer_ip) {
-            WarnP(strong_self.get()) << ((interleaved % 2 == 0) ? "收到其他地址的rtp数据:" : "收到其他地址的rtcp数据:") << SockUtil::inet_ntoa(peer_addr);
+            WarnP(strong_self.get()) << ((interleaved % 2 == 0) ? "收到其他地址的rtp数据:" : "收到其他地址的rtcp数据:")
+                                    << SockUtil::inet_ntoa(peer_addr);
             return true;
         }
 
@@ -1033,71 +1028,77 @@ void RtspSession::startListenPeerUdpData(int track_idx) {
         return true;
     };
 
-    switch (_rtp_type) {
-        case Rtsp::RTP_MULTICAST: {
+    switch (_rtp_type){
+        case Rtsp::RTP_MULTICAST:{
             //组播使用的共享rtcp端口
-            UDPServer::Instance().listenPeer(get_peer_ip().data(), this, [onUdpData](int interleaved, const Buffer::Ptr &buf, struct sockaddr *peer_addr) {
+            UDPServer::Instance().listenPeer(get_peer_ip().data(), this,
+                    [onUdpData]( int interleaved, const Buffer::Ptr &buf, struct sockaddr *peer_addr) {
                 return onUdpData(buf, peer_addr, interleaved);
             });
-        } break;
-        case Rtsp::RTP_UDP: {
-            auto setEvent = [&](Socket::Ptr &sock, int interleaved) {
-                if (!sock) {
+        }
+            break;
+        case Rtsp::RTP_UDP:{
+            auto setEvent = [&](Socket::Ptr &sock,int interleaved){
+                if(!sock){
                     WarnP(this) << "udp端口为空:" << interleaved;
                     return;
                 }
-                sock->setOnRead(
-                    [onUdpData, interleaved](const Buffer::Ptr &pBuf, struct sockaddr *pPeerAddr, int addr_len) { onUdpData(pBuf, pPeerAddr, interleaved); });
+                sock->setOnRead([onUdpData,interleaved](const Buffer::Ptr &pBuf, struct sockaddr *pPeerAddr , int addr_len){
+                    onUdpData(pBuf, pPeerAddr, interleaved);
+                });
             };
-            setEvent(_rtp_socks[track_idx], 2 * track_idx);
-            setEvent(_rtcp_socks[track_idx], 2 * track_idx + 1);
-        } break;
+            setEvent(_rtp_socks[track_idx], 2 * track_idx );
+            setEvent(_rtcp_socks[track_idx], 2 * track_idx + 1 );
+        }
+            break;
 
-        default: break;
+        default:
+            break;
     }
+
 }
 
-static string dateStr() {
+static string dateStr(){
     char buf[64];
     time_t tt = time(NULL);
     strftime(buf, sizeof buf, "%a, %b %d %Y %H:%M:%S GMT", gmtime(&tt));
     return buf;
 }
 
-bool RtspSession::sendRtspResponse(const string &res_code, const StrCaseMap &header_const, const string &sdp, const char *protocol) {
+bool RtspSession::sendRtspResponse(const string &res_code, const StrCaseMap &header_const, const string &sdp, const char *protocol){
     auto header = header_const;
-    header.emplace("CSeq", StrPrinter << _cseq);
-    if (!_sessionid.empty()) {
+    header.emplace("CSeq",StrPrinter << _cseq);
+    if(!_sessionid.empty()){
         header.emplace("Session", _sessionid);
     }
 
-    header.emplace("Server", kServerName);
-    header.emplace("Date", dateStr());
+    header.emplace("Server",kServerName);
+    header.emplace("Date",dateStr());
 
-    if (!sdp.empty()) {
-        header.emplace("Content-Length", StrPrinter << sdp.size());
-        header.emplace("Content-Type", "application/sdp");
+    if(!sdp.empty()){
+        header.emplace("Content-Length",StrPrinter << sdp.size());
+        header.emplace("Content-Type","application/sdp");
     }
 
     _StrPrinter printer;
     printer << protocol << " " << res_code << "\r\n";
-    for (auto &pr : header) {
+    for (auto &pr : header){
         printer << pr.first << ": " << pr.second << "\r\n";
     }
 
     printer << "\r\n";
 
-    if (!sdp.empty()) {
+    if(!sdp.empty()){
         printer << sdp;
     }
-    //	DebugP(this) << printer;
-    return send(std::make_shared<BufferString>(std::move(printer))) > 0;
+//	DebugP(this) << printer;
+    return send(std::make_shared<BufferString>(std::move(printer))) > 0 ;
 }
 
-ssize_t RtspSession::send(Buffer::Ptr pkt) {
-    //	if(!_enableSendRtp){
-    //		DebugP(this) << pkt->data();
-    //	}
+ssize_t RtspSession::send(Buffer::Ptr pkt){
+//	if(!_enableSendRtp){
+//		DebugP(this) << pkt->data();
+//	}
     _bytes_usage += pkt->size();
     return Session::send(std::move(pkt));
 }
@@ -1106,14 +1107,14 @@ bool RtspSession::sendRtspResponse(const string &res_code, const std::initialize
     string key;
     StrCaseMap header_map;
     int i = 0;
-    for (auto &val : header) {
-        if (++i % 2 == 0) {
-            header_map.emplace(key, val);
-        } else {
+    for(auto &val : header){
+        if(++i % 2 == 0){
+            header_map.emplace(key,val);
+        }else{
             key = val;
         }
     }
-    return sendRtspResponse(res_code, header_map, sdp, protocol);
+    return sendRtspResponse(res_code,header_map,sdp,protocol);
 }
 
 int RtspSession::getTrackIndexByTrackType(TrackType type) {
@@ -1155,7 +1156,7 @@ int RtspSession::getTrackIndexByInterleaved(int interleaved) {
 bool RtspSession::close(MediaSource &sender) {
     //此回调在其他线程触发
     string err = StrPrinter << "close media: " << sender.getUrl();
-    safeShutdown(SockException(Err_shutdown, err));
+    safeShutdown(SockException(Err_shutdown,err));
     return true;
 }
 
@@ -1163,7 +1164,7 @@ int RtspSession::totalReaderCount(MediaSource &sender) {
     return _push_src ? _push_src->totalReaderCount() : sender.readerCount();
 }
 
-MediaOriginType RtspSession::getOriginType(MediaSource &sender) const {
+MediaOriginType RtspSession::getOriginType(MediaSource &sender) const{
     return MediaOriginType::rtsp_push;
 }
 
@@ -1179,17 +1180,17 @@ toolkit::EventPoller::Ptr RtspSession::getOwnerPoller(MediaSource &sender) {
     return getPoller();
 }
 
-void RtspSession::onBeforeRtpSorted(const RtpPacket::Ptr &rtp, int track_index) {
+void RtspSession::onBeforeRtpSorted(const RtpPacket::Ptr &rtp, int track_index){
     updateRtcpContext(rtp);
 }
 
-void RtspSession::updateRtcpContext(const RtpPacket::Ptr &rtp) {
+void RtspSession::updateRtcpContext(const RtpPacket::Ptr &rtp){
     int track_index = getTrackIndexByTrackType(rtp->type);
     auto &rtcp_ctx = _rtcp_context[track_index];
     rtcp_ctx->onRtp(rtp->getSeq(), rtp->getStamp(), rtp->ntp_stamp, rtp->sample_rate, rtp->size() - RtpPacket::kRtpTcpHeaderSize);
 
     auto &ticker = _rtcp_send_tickers[track_index];
-    // send rtcp every 5 second
+    //send rtcp every 5 second
     if (ticker.elapsedTime() > 5 * 1000 || (_send_sr_rtcp[track_index] && !_push_src)) {
         //确保在发送rtp前，先发送一次sender report rtcp(用于播放器同步音视频)
         ticker.resetTime();
@@ -1206,8 +1207,8 @@ void RtspSession::updateRtcpContext(const RtpPacket::Ptr &rtp) {
         };
 
         auto ssrc = rtp->getSSRC();
-        auto rtcp = _push_src ? rtcp_ctx->createRtcpRR(ssrc + 1, ssrc) : rtcp_ctx->createRtcpSR(ssrc);
-        auto rtcp_sdes = RtcpSdes::create({ kServerName });
+        auto rtcp = _push_src ?  rtcp_ctx->createRtcpRR(ssrc + 1, ssrc) : rtcp_ctx->createRtcpSR(ssrc);
+        auto rtcp_sdes = RtcpSdes::create({kServerName});
         rtcp_sdes->chunks.type = (uint8_t)SdesType::RTCP_SDES_CNAME;
         rtcp_sdes->chunks.ssrc = htonl(ssrc);
         send_rtcp(this, track_index, std::move(rtcp));
@@ -1227,7 +1228,8 @@ void RtspSession::sendRtpPacket(const RtspMediaSource::RingDataType &pkt) {
             });
             flushAll();
             setSendFlushFlag(true);
-        } break;
+        }
+            break;
         case Rtsp::RTP_UDP: {
             //下标0表示视频，1表示音频
             Socket::Ptr rtp_socks[2];
@@ -1250,14 +1252,16 @@ void RtspSession::sendRtpPacket(const RtspMediaSource::RingDataType &pkt) {
                     sock->flushAll();
                 }
             }
-        } break;
-        default: break;
+        }
+            break;
+        default:
+            break;
     }
 }
 
-void RtspSession::setSocketFlags() {
+void RtspSession::setSocketFlags(){
     GET_CONFIG(int, mergeWriteMS, General::kMergeWriteMS);
-    if (mergeWriteMS > 0) {
+    if(mergeWriteMS > 0) {
         //推流模式下，关闭TCP_NODELAY会增加推流端的延时，但是服务器性能将提高
         SockUtil::setNoDelay(getSock()->rawFD(), false);
         //播放模式下，开启MSG_MORE会增加延时，但是能提高发送性能
@@ -1265,5 +1269,5 @@ void RtspSession::setSocketFlags() {
     }
 }
 
-} // namespace mediakit
+}
 /* namespace mediakit */

--- a/src/Rtsp/RtspSession.cpp
+++ b/src/Rtsp/RtspSession.cpp
@@ -636,16 +636,20 @@ void RtspSession::handleReq_Setup(const Parser &parser) {
     }
 
     static auto getRtpTypeStr = [](const int type) {
-        if (Rtsp::RTP_TCP == type) {
+        switch (type)
+        {
+        case Rtsp::RTP_TCP:
             return "TCP";
-        }
-        if (Rtsp::RTP_UDP == type) {
+            break;
+        case Rtsp::RTP_UDP:
             return "UDP";
-        }
-        if (Rtsp::RTP_MULTICAST == type) {
+            break;
+        case Rtsp::RTP_MULTICAST:
             return "MULTICAST";
+            break;
+        default:
+            return "Invalid";
         }
-        return "Invalid";
     };
 
     if (_rtp_type == Rtsp::RTP_Invalid) {

--- a/src/Rtsp/RtspSession.cpp
+++ b/src/Rtsp/RtspSession.cpp
@@ -638,13 +638,14 @@ void RtspSession::handleReq_Setup(const Parser &parser) {
     static auto getRtpTypeStr = [](const int type){
         if(Rtsp::RTP_TCP == type){
             return "TCP";
-        }else if(Rtsp::RTP_UDP == type ){
-            return "UDP";
-        }else if(Rtsp::RTP_MULTICAST == type ){
-            return "MULTICAST";
-        }else{
-            return "Invalid";
         }
+        if(Rtsp::RTP_UDP == type ){
+            return "UDP";
+        }
+        if(Rtsp::RTP_MULTICAST == type ){
+            return "MULTICAST";
+        }
+        return "Invalid";
     };
 
     if(_rtp_type == Rtsp::RTP_Invalid){
@@ -659,9 +660,7 @@ void RtspSession::handleReq_Setup(const Parser &parser) {
         }
         //检查RTP传输类型限制
         GET_CONFIG(int,transport,Rtsp::kRtpTransportType);
-        if((transport==Rtsp::RTP_TCP||
-            transport==Rtsp::RTP_UDP)&&
-            transport!=rtpType){
+        if(transport!=Rtsp::RTP_Invalid&&transport!=rtpType){
             WarnL<<"rtsp client setup transport "<<getRtpTypeStr(rtpType)<<" but config force transport "<<getRtpTypeStr(transport);
             //配置限定RTSP传输方式，但是客户端握手方式不一致，返回461
             sendRtspResponse("461 Unsupported transport");

--- a/src/Rtsp/RtspSession.cpp
+++ b/src/Rtsp/RtspSession.cpp
@@ -640,13 +640,10 @@ void RtspSession::handleReq_Setup(const Parser &parser) {
         {
         case Rtsp::RTP_TCP:
             return "TCP";
-            break;
         case Rtsp::RTP_UDP:
             return "UDP";
-            break;
         case Rtsp::RTP_MULTICAST:
             return "MULTICAST";
-            break;
         default:
             return "Invalid";
         }

--- a/src/Rtsp/RtspSession.cpp
+++ b/src/Rtsp/RtspSession.cpp
@@ -634,37 +634,37 @@ void RtspSession::handleReq_Setup(const Parser &parser) {
         //已经初始化过该Track
         throw SockException(Err_shutdown, "can not setup one track twice");
     }
-    
-    static auto getRtpTypeStr = [](const int type){
-        if(Rtsp::RTP_TCP == type){
+
+    static auto getRtpTypeStr = [](const int type) {
+        if (Rtsp::RTP_TCP == type) {
             return "TCP";
         }
-        if(Rtsp::RTP_UDP == type ){
+        if (Rtsp::RTP_UDP == type) {
             return "UDP";
         }
-        if(Rtsp::RTP_MULTICAST == type ){
+        if (Rtsp::RTP_MULTICAST == type) {
             return "MULTICAST";
         }
         return "Invalid";
     };
 
-    if(_rtp_type == Rtsp::RTP_Invalid){
+    if (_rtp_type == Rtsp::RTP_Invalid) {
         auto &strTransport = parser["Transport"];
         auto rtpType = Rtsp::RTP_Invalid;
-        if(strTransport.find("TCP") != string::npos){
+        if (strTransport.find("TCP") != string::npos) {
             rtpType = Rtsp::RTP_TCP;
-        }else if(strTransport.find("multicast") != string::npos){
+        } else if (strTransport.find("multicast") != string::npos) {
             rtpType = Rtsp::RTP_MULTICAST;
-        }else{
+        } else {
             rtpType = Rtsp::RTP_UDP;
         }
         //检查RTP传输类型限制
-        GET_CONFIG(int,transport,Rtsp::kRtpTransportType);
-        if(transport!=Rtsp::RTP_Invalid&&transport!=rtpType){
-            WarnL<<"rtsp client setup transport "<<getRtpTypeStr(rtpType)<<" but config force transport "<<getRtpTypeStr(transport);
+        GET_CONFIG(int, transport, Rtsp::kRtpTransportType);
+        if (transport != Rtsp::RTP_Invalid && transport != rtpType) {
+            WarnL << "rtsp client setup transport " << getRtpTypeStr(rtpType) << " but config force transport " << getRtpTypeStr(transport);
             //配置限定RTSP传输方式，但是客户端握手方式不一致，返回461
             sendRtspResponse("461 Unsupported transport");
-            return ;
+            return;
         }
         _rtp_type = rtpType;
     }


### PR DESCRIPTION
当客户端发起RTSP SETUP的时候，如果rtp传输类型和配置不一致则返回461 Unsupported transport。迫使客户端切换到对应rtp传输协议并重新SETUP。目前支持FFMPEG和VLC。
![image](https://github.com/ZLMediaKit/ZLMediaKit/assets/9034778/df4f430f-f414-430c-bae4-3d7c735b17ab)
