### PR TITLE
1-调整 json 的源码引入，外部可以引入 json/json.h 使用；2-针对 iOS 工程调整 cmake 配置，解决 iOS 环…

### DIFF
--- a/3rdpart/CMakeLists.txt
+++ b/3rdpart/CMakeLists.txt
@@ -29,7 +29,6 @@ file(GLOB JSONCPP_SRC_LIST
   ${CMAKE_CURRENT_SOURCE_DIR}/jsoncpp/src/lib_json/*.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/jsoncpp/src/lib_json/*.h)
   
-aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/jsoncpp/src/lib_json JSONCPP_SRC_LIST)
 add_library(jsoncpp STATIC ${JSONCPP_SRC_LIST})
 target_compile_options(jsoncpp
   PRIVATE ${COMPILE_OPTIONS_DEFAULT})

--- a/3rdpart/CMakeLists.txt
+++ b/3rdpart/CMakeLists.txt
@@ -24,6 +24,11 @@
 ##############################################################################
 
 # jsoncpp
+file(GLOB JSONCPP_SRC_LIST
+  ${CMAKE_CURRENT_SOURCE_DIR}/jsoncpp/include/json/*.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/jsoncpp/src/lib_json/*.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/jsoncpp/src/lib_json/*.h)
+  
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/jsoncpp/src/lib_json JSONCPP_SRC_LIST)
 add_library(jsoncpp STATIC ${JSONCPP_SRC_LIST})
 target_compile_options(jsoncpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -449,11 +449,6 @@ if(ENABLE_API)
   add_subdirectory(api)
 endif()
 
-# IOS 不编译可执行程序
-if(IOS)
-  return()
-endif()
-
 ##############################################################################
 
 if(ENABLE_PLAYER AND ENABLE_FFMPEG)
@@ -468,6 +463,11 @@ endif()
 # Android 会 add_subdirectory 并依赖该变量
 if(ENABLE_SERVER_LIB)
   set(MK_LINK_LIBRARIES ${MK_LINK_LIBRARIES} PARENT_SCOPE)
+endif()
+
+# IOS 不编译可执行程序
+if(IOS)
+  return()
 endif()
 
 #cpp测试demo程序

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -30,13 +30,6 @@ file(GLOB API_SRC_LIST
 
 set(LINK_LIBRARIES ${MK_LINK_LIBRARIES})
 
-if(IOS)
-  add_library(mk_api STATIC ${API_SRC_LIST})
-  target_link_libraries(mk_api
-    PRIVATE ${LINK_LIBRARIES})
-  return()
-endif ()
-
 set(COMPILE_DEFINITIONS ${MK_COMPILE_DEFINITIONS})
 
 if (MSVC)
@@ -46,6 +39,8 @@ endif ()
 if(ENABLE_API_STATIC_LIB)
   add_library(mk_api STATIC ${API_SRC_LIST})
   list(APPEND COMPILE_DEFINITIONS MediaKitApi_STATIC)
+elseif(IOS)
+  add_library(mk_api STATIC ${API_SRC_LIST})
 else()
   add_library(mk_api SHARED ${API_SRC_LIST})
 endif()
@@ -81,6 +76,11 @@ install(TARGETS mk_api
   ARCHIVE DESTINATION ${INSTALL_PATH_LIB}
   LIBRARY DESTINATION ${INSTALL_PATH_LIB}
   RUNTIME DESTINATION ${INSTALL_PATH_RUNTIME})
+
+# IOS 跳过测试代码
+if(IOS)
+  return()
+endif()
 
 if (ENABLE_TESTS)
   add_subdirectory(tests)

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -38,7 +38,13 @@ if(ENABLE_SERVER_LIB)
   return()
 endif()
 
-add_executable(MediaServer ${MediaServer_SRC_LIST})
+# IOS 不编译可执行程序，只做依赖库
+if(IOS)
+  add_library(MediaServer STATIC ${MediaServer_SRC_LIST})
+else()
+  add_executable(MediaServer ${MediaServer_SRC_LIST})
+endif()
+
 target_compile_definitions(MediaServer
   PRIVATE ${COMPILE_DEFINITIONS})
 target_compile_options(MediaServer


### PR DESCRIPTION
1-调整 json 的源码引入，外部可以引入 json/json.h 使用；2-针对 iOS 工程调整 cmake 配置，解决 iOS 环境下 mk_util.h 找不到问题；同时在 iOS 工程中引入 media server 静态库；