### PR TITLE
新增配置项指定H264 rtp打包是否优先采用stap-a模式

### DIFF
--- a/conf/config.ini
+++ b/conf/config.ini
@@ -281,6 +281,9 @@ videoMtuSize=1400
 rtpMaxSize=10
 # rtp 打包时，低延迟开关，默认关闭（为0），h264存在一帧多个slice（NAL）的情况，在这种情况下，如果开启可能会导致画面花屏
 lowLatency=0
+# H264 rtp打包模式是否采用stap-a模式(为了在老版本浏览器上兼容webrtc)还是采用Single NAL unit packet per H.264 模式
+# 有些老的rtsp设备不支持stap-a rtp，设置此配置为0可提高兼容性
+h264_stap_a=1
 
 [rtp_proxy]
 #导出调试数据(包括rtp/ps/h264)至该目录,置空则关闭数据导出

--- a/src/Common/config.cpp
+++ b/src/Common/config.cpp
@@ -244,15 +244,15 @@ const string kVideoMtuSize = RTP_FIELD "videoMtuSize";
 const string kAudioMtuSize = RTP_FIELD "audioMtuSize";
 // rtp包最大长度限制，单位是KB
 const string kRtpMaxSize = RTP_FIELD "rtpMaxSize";
-
 const string kLowLatency = RTP_FIELD "lowLatency";
+const string kH264StapA = RTP_FIELD "h264_stap_a";
 
 static onceToken token([]() {
     mINI::Instance()[kVideoMtuSize] = 1400;
     mINI::Instance()[kAudioMtuSize] = 600;
     mINI::Instance()[kRtpMaxSize] = 10;
     mINI::Instance()[kLowLatency] = 0;
-
+    mINI::Instance()[kH264StapA] = 1;
 });
 } // namespace Rtp
 

--- a/src/Common/config.h
+++ b/src/Common/config.h
@@ -298,6 +298,8 @@ extern const std::string kAudioMtuSize;
 extern const std::string kRtpMaxSize;
 // rtp 打包时，低延迟开关，默认关闭（为0），h264存在一帧多个slice（NAL）的情况，在这种情况下，如果开启可能会导致画面花屏
 extern const std::string kLowLatency;
+//H264 rtp打包模式是否采用stap-a模式(为了在老版本浏览器上兼容webrtc)还是采用Single NAL unit packet per H.264 模式
+extern const std::string kH264StapA;
 } // namespace Rtp
 
 ////////////组播配置///////////

--- a/src/Extension/H264Rtp.h
+++ b/src/Extension/H264Rtp.h
@@ -28,7 +28,7 @@ public:
     using Ptr = std::shared_ptr<H264RtpDecoder>;
 
     H264RtpDecoder();
-    ~H264RtpDecoder() {}
+    ~H264RtpDecoder() override = default;
 
     /**
      * 输入264 rtp包
@@ -77,9 +77,10 @@ public:
                    uint32_t sample_rate = 90000,
                    uint8_t pt = 96,
                    uint8_t interleaved = TrackVideo * 2);
-    ~H264RtpEncoder() {}
 
-    /**
+    ~H264RtpEncoder() override = default;
+
+        /**
      * 输入264帧
      * @param frame 帧数据，必须
      */
@@ -96,6 +97,8 @@ private:
     void packRtp(const char *data, size_t len, uint64_t pts, bool is_mark, bool gop_pos);
     void packRtpFu(const char *data, size_t len, uint64_t pts, bool is_mark, bool gop_pos);
     void packRtpStapA(const char *data, size_t len, uint64_t pts, bool is_mark, bool gop_pos);
+    void packRtpSingleNalu(const char *data, size_t len, uint64_t pts, bool is_mark, bool gop_pos);
+    void packRtpSmallFrame(const char *data, size_t len, uint64_t pts, bool is_mark, bool gop_pos);
 
 private:
     Frame::Ptr _sps;


### PR DESCRIPTION
H264 rtp打包模式是否采用stap-a模式(为了在老版本浏览器上兼容webrtc)还是采用Single NAL unit packet per H.264 模式 有些老的rtsp设备不支持stap-a rtp，设置此配置为0可提高兼容性