### PR TITLE
添加on_server_exited webhook事件,当程序正常退出时触发

### DIFF
--- a/conf/config.ini
+++ b/conf/config.ini
@@ -168,6 +168,8 @@ on_stream_none_reader=https://127.0.0.1/index/hook/on_stream_none_reader
 on_stream_not_found=https://127.0.0.1/index/hook/on_stream_not_found
 #服务器启动报告，可以用于服务器的崩溃重启事件监听
 on_server_started=https://127.0.0.1/index/hook/on_server_started
+#服务器退出报告，当服务器正常退出时触发
+on_server_exited=https://127.0.0.1/index/hook/on_server_exited
 #server保活上报
 on_server_keepalive=https://127.0.0.1/index/hook/on_server_keepalive
 #发送rtp(startSendRtp)被动关闭时回调

--- a/server/WebHook.cpp
+++ b/server/WebHook.cpp
@@ -44,6 +44,7 @@ const string kOnShellLogin = HOOK_FIELD "on_shell_login";
 const string kOnStreamNoneReader = HOOK_FIELD "on_stream_none_reader";
 const string kOnHttpAccess = HOOK_FIELD "on_http_access";
 const string kOnServerStarted = HOOK_FIELD "on_server_started";
+const string kOnServerExited = HOOK_FIELD "on_server_exited";
 const string kOnServerKeepalive = HOOK_FIELD "on_server_keepalive";
 const string kOnSendRtpStopped = HOOK_FIELD "on_send_rtp_stopped";
 const string kOnRtpServerTimeout = HOOK_FIELD "on_rtp_server_timeout";
@@ -69,6 +70,7 @@ static onceToken token([]() {
     mINI::Instance()[kOnStreamNoneReader] = "";
     mINI::Instance()[kOnHttpAccess] = "";
     mINI::Instance()[kOnServerStarted] = "";
+    mINI::Instance()[kOnServerExited] = "";
     mINI::Instance()[kOnServerKeepalive] = "";
     mINI::Instance()[kOnSendRtpStopped] = "";
     mINI::Instance()[kOnRtpServerTimeout] = "";
@@ -236,6 +238,18 @@ static void reportServerStarted() {
     }
     // 执行hook
     do_http_hook(hook_server_started, body, nullptr);
+}
+
+static void reportServerExited() {
+    GET_CONFIG(bool, hook_enable, Hook::kEnable);
+    GET_CONFIG(string, hook_server_exited, Hook::kOnServerExited);
+    if (!hook_enable || hook_server_exited.empty()) {
+        return;
+    }
+
+    const ArgsType body;
+    // 执行hook
+    do_http_hook(hook_server_exited, body, nullptr);
 }
 
 // 服务器定时保活定时器
@@ -667,4 +681,8 @@ void installWebHook() {
 void unInstallWebHook() {
     g_keepalive_timer.reset();
     NoticeCenter::Instance().delListener(&web_hook_tag);
+}
+
+void onProcessExited() {
+    reportServerExited();
 }

--- a/server/WebHook.h
+++ b/server/WebHook.h
@@ -31,6 +31,7 @@ extern const std::string kTimeoutSec;
 
 void installWebHook();
 void unInstallWebHook();
+void onProcessExited();
 /**
  * 触发http hook请求
  * @param url 请求地址

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -409,9 +409,9 @@ int start_main(int argc,char *argv[]) {
         static semaphore sem;
         signal(SIGINT, [](int) {
             InfoL << "SIGINT:exit";
-            signal(SIGINT, SIG_IGN);// 设置退出信号
+            signal(SIGINT, SIG_IGN); // 设置退出信号
             sem.post();
-        });// 设置退出信号
+        }); // 设置退出信号
 
 #if !defined(_WIN32)
         signal(SIGHUP, [](int) { mediakit::loadIniConfig(g_ini_file.data()); });
@@ -420,6 +420,8 @@ int start_main(int argc,char *argv[]) {
     }
     unInstallWebApi();
     unInstallWebHook();
+    onProcessExited();
+
     //休眠1秒再退出，防止资源释放顺序错误
     InfoL << "程序退出中,请等待...";
     sleep(1);


### PR DESCRIPTION
fixed #2585

改进点:
1. 当程序异常结束时触发
2. 当程序收到关机信号时触发

PS:需要更新wiki中的webhook说明页面