### PR TITLE
修复启动参数log-size单位错误bug

### DIFF
--- a/server/main.cpp
+++ b/server/main.cpp
@@ -240,7 +240,7 @@ int start_main(int argc,char *argv[]) {
         // 日志最多保存天数
         fileChannel->setMaxDay(cmd_main["max_day"]);
         fileChannel->setFileMaxCount(cmd_main["log-slice"]);
-        fileChannel->setFileMaxSize(1024 * 1024 * cmd_main["log-size"].as<uint32_t>());
+        fileChannel->setFileMaxSize(cmd_main["log-size"]);
         Logger::Instance().add(fileChannel);
 #endif // !defined(ANDROID)
 


### PR DESCRIPTION
FileChannel内部已经把做了转换为MB操作，外面无须再乘以1024x1024