### PR TITLE
修复webrtc开启simulcast推流时，统计观看人数线程安全相关bug

### DIFF
--- a/webrtc/WebRtcPusher.cpp
+++ b/webrtc/WebRtcPusher.cpp
@@ -59,7 +59,7 @@ bool WebRtcPusher::close(MediaSource &sender) {
 }
 
 int WebRtcPusher::totalReaderCount(MediaSource &sender) {
-    auto total_count = _push_src->totalReaderCount();
+    auto total_count = _push_src ? _push_src->totalReaderCount() : 0;
     if (_simulcast) {
         std::lock_guard<std::mutex> lock(_mtx);
         for (auto &src : _push_src_sim) {

--- a/webrtc/WebRtcPusher.cpp
+++ b/webrtc/WebRtcPusher.cpp
@@ -59,11 +59,14 @@ bool WebRtcPusher::close(MediaSource &sender) {
 }
 
 int WebRtcPusher::totalReaderCount(MediaSource &sender) {
-    auto total_count = 0;
-    for (auto &src : _push_src_sim) {
-        total_count += src.second->totalReaderCount();
+    auto total_count = _push_src->totalReaderCount();
+    if (_simulcast) {
+        std::lock_guard<std::mutex> lock(_mtx);
+        for (auto &src : _push_src_sim) {
+            total_count += src.second->totalReaderCount();
+        }
     }
-    return total_count + _push_src->totalReaderCount();
+    return total_count;
 }
 
 MediaOriginType WebRtcPusher::getOriginType(MediaSource &sender) const {
@@ -96,6 +99,7 @@ void WebRtcPusher::onRecvRtp(MediaTrack &track, const string &rid, RtpPacket::Pt
         }
     } else {
         //视频
+        std::lock_guard<std::mutex> lock(_mtx);
         auto &src = _push_src_sim[rid];
         if (!src) {
             const auto& stream = _push_src->getMediaTuple().stream;

--- a/webrtc/WebRtcPusher.h
+++ b/webrtc/WebRtcPusher.h
@@ -65,6 +65,7 @@ private:
     //推流所有权
     std::shared_ptr<void> _push_src_ownership;
     //推流的rtsp源,支持simulcast
+    std::mutex _mtx;
     std::unordered_map<std::string/*rid*/, RtspMediaSource::Ptr> _push_src_sim;
     std::unordered_map<std::string/*rid*/, std::shared_ptr<void> > _push_src_sim_ownership;
 };


### PR DESCRIPTION
此bug由知识星球用户反馈：https://t.zsxq.com/0fpmlAGpD

robo 提问：
测试webrtc，发现MediaServer运行一会儿出现crash，日志如附件截图。

看来是某个api（粗查是getMediaList）触发了MediaSource::close(false)，
查询观众数WebRtcPusher::totalReaderCount()出现了异常，
貌似_push_src_sim等成员变量有线程安全问题。

![图片](https://github.com/ZLMediaKit/ZLMediaKit/assets/11495632/a9aec034-db68-4d66-9673-b07025ff0e0e)
