### PR TITLE
Removed caching for MediaServer target.

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -34,7 +34,6 @@ if(ENABLE_SERVER_LIB)
     PRIVATE ${COMPILE_OPTIONS_DEFAULT})
   target_link_libraries(MediaServer
     PRIVATE ${MK_LINK_LIBRARIES})
-  update_cached(MK_LINK_LIBRARIES MediaServer)
   return()
 endif()
 


### PR DESCRIPTION
When caching Mediaserver Target, it will try to link to itself if configuring several times. This removes that cache line which allows to configure the project several times without error.