### PR TITLE
修复RtpProcess析构中抛异常导致崩溃的问题

### DIFF
--- a/src/Rtp/RtpProcess.cpp
+++ b/src/Rtp/RtpProcess.cpp
@@ -211,7 +211,7 @@ void RtpProcess::setOnDetach(function<void()> cb) {
 
 string RtpProcess::get_peer_ip() {
     try {
-        return _addr ? SockUtil::inet_ntoa((sockaddr *)_addr.get()) : "";
+        return _addr ? SockUtil::inet_ntoa((sockaddr *)_addr.get()) : "::";
     } catch (std::exception &ex) {
         return "::";
     }
@@ -226,17 +226,11 @@ uint16_t RtpProcess::get_peer_port() {
 }
 
 string RtpProcess::get_local_ip() {
-    if (_sock) {
-        return _sock->get_local_ip();
-    }
-    return "::";
+    return _sock ? _sock->get_local_ip() : "::";
 }
 
 uint16_t RtpProcess::get_local_port() {
-    if (_sock) {
-        return _sock->get_local_port();
-    }
-    return 0;
+    return _sock ? _sock->get_local_port() : 0;
 }
 
 string RtpProcess::getIdentifier() const {

--- a/src/Rtp/RtpProcess.cpp
+++ b/src/Rtp/RtpProcess.cpp
@@ -210,17 +210,19 @@ void RtpProcess::setOnDetach(function<void()> cb) {
 }
 
 string RtpProcess::get_peer_ip() {
-    if (!_addr) {
+    try {
+        return _addr ? SockUtil::inet_ntoa((sockaddr *)_addr.get()) : "";
+    } catch (std::exception &ex) {
         return "::";
     }
-    return SockUtil::inet_ntoa((sockaddr *)_addr.get());
 }
 
 uint16_t RtpProcess::get_peer_port() {
-    if (!_addr) {
+    try {
+        return _addr ? SockUtil::inet_port((sockaddr *)_addr.get()) : 0;
+    } catch (std::exception &ex) {
         return 0;
     }
-    return SockUtil::inet_port((sockaddr *)_addr.get());
 }
 
 string RtpProcess::get_local_ip() {


### PR DESCRIPTION
WarnP(this) 时会调用get_peer_ip()接口，此接口可能抛异常；
析构中抛异常可导致程序直接退出。