### PR TITLE
服务器不支持datachannel下， sdp携带datachanne webrtc 推流失败

### DIFF
--- a/webrtc/Sdp.cpp
+++ b/webrtc/Sdp.cpp
@@ -1556,7 +1556,7 @@ shared_ptr<RtcSession> RtcConfigure::createAnswer(const RtcSession &offer) const
     if (!offer.group.mids.empty()) {
         for (auto &m : ret->media) {
             //The remote end has rejected (port 0) the m-section, so it should not be putting its mid in the group attribute.
-            if(m.port) {
+            if (m.port) {
                 ret->group.mids.emplace_back(m.mid);
             }
         }
@@ -1620,9 +1620,11 @@ RETRY:
         answer_media.ice_pwd = configure.ice_pwd;
         answer_media.fingerprint = configure.fingerprint;
         answer_media.ice_lite = configure.ice_lite;
-#ifndef ENABLE_SCTP
+#ifdef ENABLE_SCTP
+        answer_media.candidate = configure.candidate;
+#else
         answer_media.port = 0;
-        WarnL << "answer sdp忽略application, 请安装usrsctp后再测试datachannel功能";
+        WarnL << "answer sdp忽略application mline, 请安装usrsctp后再测试datachannel功能";
 #endif
         ret->media.emplace_back(answer_media);
         return;

--- a/webrtc/WebRtcTransport.cpp
+++ b/webrtc/WebRtcTransport.cpp
@@ -564,8 +564,10 @@ void WebRtcTransportImp::onCheckAnswer(RtcSession &sdp) {
 
         GET_CONFIG(uint16_t, udp_port, Rtc::kPort);
         GET_CONFIG(uint16_t, tcp_port, Rtc::kTcpPort);
-        m.rtcp_addr.port = m.port ? (udp_port ? udp_port : tcp_port) : 0;
-        m.port = m.rtcp_addr.port;
+        m.port = m.port ? (udp_port ? udp_port : tcp_port) : 0;
+        if (m.type != TrackApplication) {
+            m.rtcp_addr.port = m.port;
+        }
         sdp.origin.address = m.addr.address;
     }
 


### PR DESCRIPTION
【现象】
zlm 未安装 sctp  下  亚马逊sdk  webrtc推流 失败

【复现】
1、 zlm 未安装sctp的情况下 回复的ice_ufrag不是以 "zlm_"开头的；
2、而[亚马逊sdk](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/b2b05c8982beed62e4c589d2890621bf98638153/src/source/PeerConnection/PeerConnection.c#L1049)以最后一个mline的ice_ufrag为准
3、导致发送的stun包 被zlm 忽略不回复打洞失败
<img width="704" alt="image" src="https://github.com/ZLMediaKit/ZLMediaKit/assets/36155473/01ded34d-4f27-4363-bb7b-4934388f52f3">

【修改】
1、 datachannel 不支持的话 port 设置为 0； 
2、去掉了datachannel 中direction RtpDirection::inactive（好像是设置rtp的传输方向的？
3、track端口复用 (谷歌ok   火狐报错"No transceiver for bundled mid 1"

<img width="817" alt="image" src="https://github.com/ZLMediaKit/ZLMediaKit/assets/36155473/8734a6f7-6652-4fed-b0ee-a6f1bcbe9f1b">


ref: 
https://developer.mozilla.org/zh-CN/docs/Web/API/RTCRtpTransceiver/direction

https://bugzilla.mozilla.org/show_bug.cgi?id=1504058


