### PR TITLE
修复调用close_stream同时调用getMediaList引发的崩溃

### DIFF
--- a/src/Rtsp/RtspPlayer.cpp
+++ b/src/Rtsp/RtspPlayer.cpp
@@ -544,6 +544,9 @@ float RtspPlayer::getPacketLossRate(TrackType type) const {
     size_t lost = 0, expected = 0;
     try {
         auto track_idx = getTrackIndexByTrackType(type);
+        if (_rtcp_context.empty()) {
+            return 0;
+        }
         auto ctx = _rtcp_context[track_idx];
         lost = ctx->getLost();
         expected = ctx->getExpectedPackets();


### PR DESCRIPTION
复现条件：chrome打开webrtc demo网页，网页会每秒调用getMediaList。添加一条rtsp拉流，然后再调用close_stream，会偶现进入RtspPlayer::getPacketLossRate函数，然后_rtcp_context为空拿不到指针