### PR TITLE
调整启动命令，可自定义日志级别。

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -85,4 +85,4 @@ COPY --from=build /opt/media/ZLMediaKit/www/ /opt/media/bin/www/
 ENV PATH /opt/media/bin:$PATH
 ENV LogLevel 0
 #CMD ["sh","-c","./MediaServer -s default.pem -c ../conf/config.ini -l 0"]
-ENTRYPOINT ["sh","-c","./MediaServer -s default.pem -c ../conf/config.ini -l $LogLevel"]
+CMD ["sh","-c","./MediaServer -s default.pem -c ../conf/config.ini -l $LogLevel"]

--- a/dockerfile
+++ b/dockerfile
@@ -83,6 +83,6 @@ COPY --from=build /opt/media/ZLMediaKit/release/linux/${MODEL}/MediaServer /opt/
 COPY --from=build /opt/media/ZLMediaKit/release/linux/${MODEL}/config.ini /opt/media/conf/
 COPY --from=build /opt/media/ZLMediaKit/www/ /opt/media/bin/www/
 ENV PATH /opt/media/bin:$PATH
-ENV LogLevel 0do
+ENV LogLevel 0
 #CMD ["sh","-c","./MediaServer -s default.pem -c ../conf/config.ini -l 0"]
 ENTRYPOINT ["sh","-c","./MediaServer -s default.pem -c ../conf/config.ini -l $LogLevel"]

--- a/dockerfile
+++ b/dockerfile
@@ -83,4 +83,6 @@ COPY --from=build /opt/media/ZLMediaKit/release/linux/${MODEL}/MediaServer /opt/
 COPY --from=build /opt/media/ZLMediaKit/release/linux/${MODEL}/config.ini /opt/media/conf/
 COPY --from=build /opt/media/ZLMediaKit/www/ /opt/media/bin/www/
 ENV PATH /opt/media/bin:$PATH
-CMD ["sh","-c","./MediaServer -s default.pem -c ../conf/config.ini -l 0"]
+ENV LogLevel 0do
+#CMD ["sh","-c","./MediaServer -s default.pem -c ../conf/config.ini -l 0"]
+ENTRYPOINT ["sh","-c","./MediaServer -s default.pem -c ../conf/config.ini -l $LogLevel"]


### PR DESCRIPTION
原来默认 -l 为0，导致运行产生大量日志占满/var/lib/docker目录所在文件系统的空间。修改后可以通过 -e "LogLevel=n"来指定日志级别。 另外需要等待ZLM程序修改以使其可以处理SIGTERM信号，另容器可以在两三秒内完成退出（而非等10s超时）