### PR TITLE
docker 优雅关闭（docker stop graceful）

### DIFF
--- a/docker/centos7/Dockerfile.runtime
+++ b/docker/centos7/Dockerfile.runtime
@@ -128,4 +128,4 @@ WORKDIR /opt/zlm
 VOLUME [ "/opt/zlm/conf/","/opt/zlm/log/","opt/zlm/ffmpeg/"]
 COPY --from=build /opt/build /
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH TZ=Asia/Shanghai
-CMD ./MediaServer -c ./conf/config.ini
+CMD ["./MediaServer", "-c" , "./conf/config.ini"]

--- a/docker/ubuntu16.04/Dockerfile.devel
+++ b/docker/ubuntu16.04/Dockerfile.devel
@@ -41,4 +41,4 @@ RUN cmake -DCMAKE_BUILD_TYPE=Release .. && \
     make
 
 ENV PATH /opt/media/ZLMediaKit/release/linux/Release/:$PATH
-CMD MediaServer
+CMD ["MediaServer"]

--- a/docker/ubuntu16.04/Dockerfile.runtime
+++ b/docker/ubuntu16.04/Dockerfile.runtime
@@ -60,4 +60,4 @@ RUN apt-get update && \
 WORKDIR /opt/media/bin/
 COPY --from=build /opt/media/ZLMediaKit/release/linux/Release/MediaServer /opt/media/bin/MediaServer
 ENV PATH /opt/media/bin:$PATH
-CMD MediaServer
+CMD ["MediaServer"]

--- a/docker/ubuntu18.04/Dockerfile.devel
+++ b/docker/ubuntu18.04/Dockerfile.devel
@@ -42,4 +42,4 @@ RUN cmake -DCMAKE_BUILD_TYPE=Release .. && \
     make
 
 ENV PATH /opt/media/ZLMediaKit/release/linux/Release:$PATH
-CMD MediaServer
+CMD ["MediaServer"]

--- a/docker/ubuntu18.04/Dockerfile.runtime
+++ b/docker/ubuntu18.04/Dockerfile.runtime
@@ -60,4 +60,4 @@ RUN apt-get update && \
 WORKDIR /opt/media/bin/
 COPY --from=build /opt/media/ZLMediaKit/release/linux/Release/MediaServer /opt/media/bin/MediaServer
 ENV PATH /opt/media/bin:$PATH
-CMD MediaServer
+CMD ["MediaServer"]

--- a/dockerfile
+++ b/dockerfile
@@ -83,4 +83,4 @@ COPY --from=build /opt/media/ZLMediaKit/release/linux/${MODEL}/MediaServer /opt/
 COPY --from=build /opt/media/ZLMediaKit/release/linux/${MODEL}/config.ini /opt/media/conf/
 COPY --from=build /opt/media/ZLMediaKit/www/ /opt/media/bin/www/
 ENV PATH /opt/media/bin:$PATH
-CMD ["sh","-c","./MediaServer -s default.pem -c ../conf/config.ini -l 0"]
+CMD ["./MediaServer","-s", "default.pem", "-c", "../conf/config.ini", "-l","0"]

--- a/server/System.cpp
+++ b/server/System.cpp
@@ -126,6 +126,12 @@ void System::startDaemon(bool &kill_parent_if_failed) {
             exit(0);
         });
 
+        signal(SIGTERM,[](int) {
+            WarnL << "收到主动退出信号,关闭父进程与子进程";
+            kill(pid, SIGINT);
+            exit(0);
+        });
+
         do {
             int status = 0;
             if (waitpid(pid, &status, 0) >= 0) {

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -421,7 +421,7 @@ int start_main(int argc,char *argv[]) {
         }); // 设置退出信号
 
         signal(SIGTERM,[](int) {
-            WarnL << "SIGINT:exit";
+            WarnL << "SIGTERM:exit";
             signal(SIGTERM, SIG_IGN);
             sem.post();
         });

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -420,6 +420,12 @@ int start_main(int argc,char *argv[]) {
             sem.post();
         }); // 设置退出信号
 
+        signal(SIGTERM,[](int) {
+            WarnL << "SIGINT:exit";
+            signal(SIGTERM, SIG_IGN);
+            sem.post();
+        });
+
 #if !defined(_WIN32)
         signal(SIGHUP, [](int) { mediakit::loadIniConfig(g_ini_file.data()); });
 #endif


### PR DESCRIPTION
1，默认的docker 镜像构建如果使用sh/bash 来运行程序，无法正确处理默认的SIGTERM 信号（docker stop默认是发生SIGTERM信号），从而导致ZLM的docker镜像需要等待10秒，才能关闭，因此修改docker的构建镜像文件，参考如下连接
https://docs.docker.com/compose/faq/#:~:text=The%20docker%20compose%20stop%20command,container%20to%20forcefully%20kill%20it
2，因为需要处理SIGTERM ，才能快速关闭（不需要等10s）,修改代码，SIGTERM 也认为是退出信号
