### PR TITLE
修复WebApi退出清理时重复析构问题

### DIFF
--- a/server/WebApi.cpp
+++ b/server/WebApi.cpp
@@ -1911,24 +1911,28 @@ void installWebApi() {
 void unInstallWebApi(){
     {
         lock_guard<recursive_mutex> lck(s_proxyMapMtx);
-        s_proxyMap.clear();
+        auto proxyMap(std::move(s_proxyMap));
+        proxyMap.clear();
     }
 
     {
         lock_guard<recursive_mutex> lck(s_ffmpegMapMtx);
-        s_ffmpegMap.clear();
+        auto ffmpegMap(std::move(s_ffmpegMap));
+        ffmpegMap.clear();
     }
 
     {
         lock_guard<recursive_mutex> lck(s_proxyPusherMapMtx);
-        s_proxyPusherMap.clear();
+        auto proxyPusherMap(std::move(s_proxyPusherMap));
+        proxyPusherMap.clear();
     }
 
     {
 #if defined(ENABLE_RTPPROXY)
         RtpSelector::Instance().clear();
         lock_guard<recursive_mutex> lck(s_rtpServerMapMtx);
-        s_rtpServerMap.clear();
+        auto rtpServerMap(std::move(s_rtpServerMap));
+        rtpServerMap.clear();
 #endif
     }
     NoticeCenter::Instance().delListener(&web_api_tag);


### PR DESCRIPTION
1. s_???Map.clear()会触发key/value的析构，先执行析构再移除map成员。析构执行完之前map成员仍然有可见性。
2. s_???Map的成员析构时，根据当前状态，可能触发回调，如播放终止回调。
3. 在状态变更的回调函数中，通过s_???Map.erase(key)的方式解注册，此时也会触发一次析构。

两次析构导致double free：a) map.erase, b) map.clear