### PR TITLE
 webrtc dtls默认采用https证书，如果https证书不存在则随机生成 

### DIFF
--- a/webrtc/DtlsTransport.cpp
+++ b/webrtc/DtlsTransport.cpp
@@ -30,6 +30,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <cstring> // std::memcpy(), std::strcmp()
 #include "Util/util.h"
 #include "Util/SSLBox.h"
+#include "Util/SSLUtil.h"
 
 using namespace std;
 
@@ -316,6 +317,8 @@ namespace RTC
             goto error;
         }
         EVP_PKEY_up_ref(privateKey);
+
+        InfoL << "Load webrtc dtls certificate: " << toolkit::SSLUtil::getServerName(certificate);
         return;
 
     error:

--- a/webrtc/DtlsTransport.cpp
+++ b/webrtc/DtlsTransport.cpp
@@ -29,6 +29,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include <cstdio>  // std::sprintf(), std::fopen()
 #include <cstring> // std::memcpy(), std::strcmp()
 #include "Util/util.h"
+#include "Util/SSLBox.h"
 
 using namespace std;
 
@@ -129,15 +130,14 @@ namespace RTC
         MS_TRACE();
 
         // Generate a X509 certificate and private key (unless PEM files are provided).
-        if (true /*
-          Settings::configuration.dtlsCertificateFile.empty() ||
-          Settings::configuration.dtlsPrivateKeyFile.empty()*/)
+        auto ssl = toolkit::SSL_Initor::Instance().getSSLCtx("", true);
+        if (!ssl)
         {
             GenerateCertificateAndPrivateKey();
         }
         else
         {
-            ReadCertificateAndPrivateKeyFromFiles();
+            ReadCertificateAndPrivateKeyFromContext(ssl.get());
         }
 
         // Create a global SSL_CTX.
@@ -297,59 +297,29 @@ namespace RTC
         MS_THROW_ERROR("DTLS certificate and private key generation failed");
     }
 
-    void DtlsTransport::DtlsEnvironment::ReadCertificateAndPrivateKeyFromFiles()
+    void DtlsTransport::DtlsEnvironment::ReadCertificateAndPrivateKeyFromContext(SSL_CTX *ctx)
     {
-#if 0
         MS_TRACE();
 
-        FILE* file{ nullptr };
-
-        file = fopen(Settings::configuration.dtlsCertificateFile.c_str(), "r");
-
-        if (!file)
-        {
-            MS_ERROR("error reading DTLS certificate file: %s", std::strerror(errno));
-
-            goto error;
-        }
-
-        certificate = PEM_read_X509(file, nullptr, nullptr, nullptr);
-
+        certificate = SSL_CTX_get0_certificate(ctx);
         if (!certificate)
         {
-            LOG_OPENSSL_ERROR("PEM_read_X509() failed");
-
+            LOG_OPENSSL_ERROR("SSL_CTX_get0_certificate() failed");
             goto error;
         }
+        X509_up_ref(certificate);
 
-        fclose(file);
-
-        file = fopen(Settings::configuration.dtlsPrivateKeyFile.c_str(), "r");
-
-        if (!file)
-        {
-            MS_ERROR("error reading DTLS private key file: %s", std::strerror(errno));
-
-            goto error;
-        }
-
-        privateKey = PEM_read_PrivateKey(file, nullptr, nullptr, nullptr);
-
+        privateKey = SSL_CTX_get0_privatekey(ctx);
         if (!privateKey)
         {
-            LOG_OPENSSL_ERROR("PEM_read_PrivateKey() failed");
-
+            LOG_OPENSSL_ERROR("SSL_CTX_get0_privatekey() failed");
             goto error;
         }
-
-        fclose(file);
-
+        EVP_PKEY_up_ref(privateKey);
         return;
 
     error:
-
         MS_THROW_ERROR("error reading DTLS certificate and private key PEM files");
-#endif
     }
 
     void DtlsTransport::DtlsEnvironment::CreateSslCtx()

--- a/webrtc/DtlsTransport.hpp
+++ b/webrtc/DtlsTransport.hpp
@@ -88,7 +88,7 @@ namespace RTC
         private:
             DtlsEnvironment();
             void GenerateCertificateAndPrivateKey();
-            void ReadCertificateAndPrivateKeyFromFiles();
+            void ReadCertificateAndPrivateKeyFromContext(SSL_CTX *ctx);
             void CreateSslCtx();
             void GenerateFingerprints();
 

--- a/webrtc/DtlsTransport.hpp
+++ b/webrtc/DtlsTransport.hpp
@@ -88,7 +88,7 @@ namespace RTC
         private:
             DtlsEnvironment();
             void GenerateCertificateAndPrivateKey();
-            void ReadCertificateAndPrivateKeyFromContext(SSL_CTX *ctx);
+            bool ReadCertificateAndPrivateKeyFromContext(SSL_CTX *ctx);
             void CreateSslCtx();
             void GenerateFingerprints();
 

--- a/webrtc/WebRtcTransport.cpp
+++ b/webrtc/WebRtcTransport.cpp
@@ -251,7 +251,7 @@ void WebRtcTransport::sendSockData(const char *buf, size_t len, RTC::TransportTu
 }
 
 Session::Ptr WebRtcTransport::getSession() const {
-    auto tuple = _ice_server->GetSelectedTuple(true);
+    auto tuple = _ice_server ? _ice_server->GetSelectedTuple(true) : nullptr;
     return tuple ? static_pointer_cast<Session>(tuple->shared_from_this()) : nullptr;
 }
 


### PR DESCRIPTION
之前默认随机创建dtls证书，导致每次启动证书都不一致，而Firefox要求同主机的dtls证书必须一致，所以导致每次服务重启，Firefox可能拒绝dtls握手。
并且在集群模式下，如果Firefox接入多个不同集群实例的webrtc服务，也可能导致webrtc dtls握手失败。