### PR TITLE
RTC: 修复gop没有sps/pps导致的秒开失败问题

### DIFF
--- a/src/Extension/H264Rtp.h
+++ b/src/Extension/H264Rtp.h
@@ -51,6 +51,7 @@ private:
     void outputFrame(const RtpPacket::Ptr &rtp, const H264Frame::Ptr &frame);
 
 private:
+    bool _is_gop = false;
     bool _gop_dropped = false;
     bool _fu_dropped = true;
     uint16_t _last_seq = 0;

--- a/src/Extension/H265Rtp.h
+++ b/src/Extension/H265Rtp.h
@@ -51,6 +51,7 @@ private:
     void outputFrame(const RtpPacket::Ptr &rtp, const H265Frame::Ptr &frame);
 
 private:
+    bool _is_gop = false;
     bool _using_donl_field = false;
     bool _gop_dropped = false;
     bool _fu_dropped = true;


### PR DESCRIPTION
rtc场景下，sdp没有传递sps/pps，因此gop的开始需要是rtp sps/pps配置帧而不是idr关键帧，这样才能保证秒开