### PR TITLE
解决：udp单端口模式下rtp鉴权失败后，继续接收流

### DIFF
--- a/src/Rtp/RtpProcess.cpp
+++ b/src/Rtp/RtpProcess.cpp
@@ -79,6 +79,9 @@ bool RtpProcess::inputRtp(bool is_udp, const Socket::Ptr &sock, const char *data
         WarnP(this) << "Not rtp packet";
         return false;
     }
+    if (!_auth_err.empty()) {
+        throw toolkit::SockException(toolkit::Err_other, _auth_err);
+    }
     if (_sock != sock) {
         // 第一次运行本函数
         bool first = !_sock;
@@ -260,6 +263,7 @@ void RtpProcess::emitOnPublish() {
                 strong_self->doCachedFunc();
                 InfoP(strong_self) << "允许RTP推流";
             } else {
+                strong_self->_auth_err = err;
                 WarnP(strong_self) << "禁止RTP推流:" << err;
             }
         });

--- a/src/Rtp/RtpProcess.h
+++ b/src/Rtp/RtpProcess.h
@@ -94,6 +94,7 @@ private:
 
 private:
     bool _only_audio = false;
+    std::string _auth_err;
     uint64_t _dts = 0;
     uint64_t _total_bytes = 0;
     std::unique_ptr<sockaddr_storage> _addr;

--- a/src/Rtp/RtpSession.cpp
+++ b/src/Rtp/RtpSession.cpp
@@ -139,8 +139,15 @@ void RtpSession::onRtpPacket(const char *data, size_t len) {
         } else {
             throw;
         }
-    } catch (...) {
-        throw;
+    } catch (std::exception &ex) {
+        if (!_is_udp) {
+            // tcp情况下立即断开连接
+            throw;
+        }
+        // udp情况下延时断开连接(等待超时自动关闭)，防止频繁创建销毁RtpSession对象
+        WarnP(this) << ex.what();
+        _delay_close = true;
+        return;
     }
     _ticker.resetTime();
 }


### PR DESCRIPTION
udp情况下延时断开连接，等待超时自动关闭，防止频繁创建销毁RtpSession对象。