### PR TITLE
RTC: 修复一组丢包分多次nack发送时blp-vector没有被重置的问题

### DIFF
--- a/webrtc/Nack.cpp
+++ b/webrtc/Nack.cpp
@@ -258,7 +258,7 @@ uint64_t NackContext::reSendNack() {
     for (auto it = nack_rtp.begin(); it != nack_rtp.end();) {
         if (pid == -1) {
             pid = *it;
-            vec.resize(FCI_NACK::kBitSize, false);
+            vec.assign(FCI_NACK::kBitSize, false);
             ++it;
             continue;
         }


### PR DESCRIPTION
如果一组丢包，通过多个nack发送，那么多次执行blp_vec.resize(16, false)并不会重置元素值，这会导致blp_vec的丢包状态错乱，从而产生一些不必要的重传请求。