### PR TITLE
增加firstTSOneGOP配置,解决当GOP小于segDur时，可提高首屏播放的速度

### DIFF
--- a/conf/config.ini
+++ b/conf/config.ini
@@ -140,6 +140,8 @@ deleteDelaySec=10
 #0为不保留，不起作用
 #1为保留，则不删除hls文件，如果开启此功能，注意磁盘大小，或者定期手动清理hls文件
 segKeep=0
+#如果设置为1，则第一个切片长度强制设置为1个GOP。当GOP小于segDur，可以提高首屏速度
+firstTSOneGOP=0
 
 [hook]
 #是否启用hook事件，启用后，推拉流都将进行鉴权

--- a/src/Common/config.cpp
+++ b/src/Common/config.cpp
@@ -305,6 +305,7 @@ const string kSegmentRetain = HLS_FIELD "segRetain";
 const string kFileBufSize = HLS_FIELD "fileBufSize";
 const string kBroadcastRecordTs = HLS_FIELD "broadcastRecordTs";
 const string kDeleteDelaySec = HLS_FIELD "deleteDelaySec";
+const string kFirstTSOneGOP = HLS_FIELD "firstTSOneGOP";
 
 static onceToken token([]() {
     mINI::Instance()[kSegmentDuration] = 2;
@@ -314,6 +315,7 @@ static onceToken token([]() {
     mINI::Instance()[kFileBufSize] = 64 * 1024;
     mINI::Instance()[kBroadcastRecordTs] = false;
     mINI::Instance()[kDeleteDelaySec] = 10;
+    mINI::Instance()[kFirstTSOneGOP] = false;
 });
 } // namespace Hls
 

--- a/src/Common/config.h
+++ b/src/Common/config.h
@@ -350,6 +350,8 @@ extern const std::string kFileBufSize;
 extern const std::string kBroadcastRecordTs;
 // hls直播文件删除延时，单位秒
 extern const std::string kDeleteDelaySec;
+// 如果设置为1，则第一个切片长度强制设置为1个GOP
+extern const std::string kFirstTSOneGOP;
 } // namespace Hls
 
 ////////////Rtp代理相关配置///////////

--- a/src/Record/HlsMaker.cpp
+++ b/src/Record/HlsMaker.cpp
@@ -111,11 +111,18 @@ void HlsMaker::delOldSegment() {
 }
 
 void HlsMaker::addNewSegment(uint64_t stamp) {
-    if (!_last_file_name.empty() && stamp - _last_seg_timestamp < _seg_duration * 1000) {
-        //存在上个切片，并且未到分片时间
-        return;
+    GET_CONFIG(bool, firstTSOneGOP, Hls::kFirstTSOneGOP);
+    if (!firstTSOneGOP) {   
+    	if (!_last_file_name.empty() && stamp - _last_seg_timestamp < _seg_duration * 1000) {
+            //存在上个切片，并且未到分片时间
+            return;
+    	}
     }
-
+    else {
+        if (!_last_file_name.empty() && _file_index>1 && stamp - _last_seg_timestamp < _seg_duration * 1000) {
+	    return;
+	}
+    }
     //关闭并保存上一个切片，如果_seg_number==0,那么是点播。
     flushLastSegment(false);
     //新增切片


### PR DESCRIPTION
1、如GOP=2秒，segDur=4秒
推流后要等至少4秒，第一个ts才会生成，画面才能起播。修改此配置可以快速起播。
2、又或者是GOP=2秒，segDur=2秒
有的推流会出现GOP不均等，首次推流的GOP会小于2秒（如1.68秒），导致第一个ts需要等3.68秒才能起播。加入此配置，也可对此情况做兼容。

下图为修改后的对比（其他参数使用默认配置）
修改前：
![image](https://github.com/ZLMediaKit/ZLMediaKit/assets/26242895/58adae86-c175-4356-89f2-d3809001d64a)

修改后：
![image](https://github.com/ZLMediaKit/ZLMediaKit/assets/26242895/9f9a2cda-9193-4770-bca4-83ffac2887ae)


提交的修改中判断当配置firstTSOneGOP=1时，_file_index 大于1 才进行 时间戳和segDur的判断。