### PR TITLE
完善相对时间戳逻辑, 完善同步机制, 解决相对时间戳不同步的问题

### DIFF
--- a/src/Common/Stamp.cpp
+++ b/src/Common/Stamp.cpp
@@ -20,8 +20,13 @@ using namespace toolkit;
 
 namespace mediakit {
 
-int64_t DeltaStamp::relativeStamp(int64_t stamp) {
-    _relative_stamp += deltaStamp(stamp);
+DeltaStamp::DeltaStamp() {
+    // 时间戳最大允许跳跃300ms
+    _max_delta = 300;
+}
+
+int64_t DeltaStamp::relativeStamp(int64_t stamp, bool enable_rollback) {
+    _relative_stamp += deltaStamp(stamp, enable_rollback);
     return _relative_stamp;
 }
 
@@ -29,7 +34,7 @@ int64_t DeltaStamp::relativeStamp() {
     return _relative_stamp;
 }
 
-int64_t DeltaStamp::deltaStamp(int64_t stamp) {
+int64_t DeltaStamp::deltaStamp(int64_t stamp, bool enable_rollback) {
     if (!_last_stamp) {
         // 第一次计算时间戳增量,时间戳增量为0
         if (stamp) {
@@ -43,14 +48,25 @@ int64_t DeltaStamp::deltaStamp(int64_t stamp) {
         // 时间戳增量为正，返回之
         _last_stamp = stamp;
         // 在直播情况下，时间戳增量不得大于MAX_DELTA_STAMP，否则强制相对时间戳加1
-        return ret < MAX_DELTA_STAMP ? ret : 1;
+        if (ret > _max_delta) {
+            needSync();
+            return 1;
+        }
+        return ret;
     }
 
     // 时间戳增量为负，说明时间戳回环了或回退了
     _last_stamp = stamp;
+    if (!enable_rollback || -ret > _max_delta) {
+        // 不允许回退或者回退太多了, 强制时间戳加1
+        needSync();
+        return 1;
+    }
+    return ret;
+}
 
-    // 如果时间戳回退不多，那么返回负值，否则返回加1
-    return -ret < MAX_DELTA_STAMP ? ret : 1;
+void DeltaStamp::setMaxDelta(size_t max_delta) {
+    _max_delta = max_delta;
 }
 
 void Stamp::setPlayBack(bool playback) {
@@ -58,7 +74,16 @@ void Stamp::setPlayBack(bool playback) {
 }
 
 void Stamp::syncTo(Stamp &other) {
+    _need_sync = true;
     _sync_master = &other;
+}
+
+void Stamp::needSync() {
+    _need_sync = true;
+}
+
+void Stamp::enableRollback(bool flag) {
+    _enable_rollback = flag;
 }
 
 // 限制dts回退
@@ -87,15 +112,26 @@ void Stamp::revise_l(int64_t dts, int64_t pts, int64_t &dts_out, int64_t &pts_ou
         return;
     }
 
-    if (_sync_master && _sync_master->_last_dts_in) {
+    // 需要同步时间戳
+    if (_sync_master && _sync_master->_last_dts_in && (_need_sync || _sync_master->_need_sync)) {
         // 音视频dts当前时间差
         int64_t dts_diff = _last_dts_in - _sync_master->_last_dts_in;
         if (ABS(dts_diff) < 5000) {
             // 如果绝对时间戳小于5秒，那么说明他们的起始时间戳是一致的，那么强制同步
-            _relative_stamp = _sync_master->_relative_stamp + dts_diff;
+            auto target_stamp = _sync_master->_relative_stamp + dts_diff;
+            if (target_stamp > _relative_stamp || _enable_rollback) {
+                // 强制同步后，时间戳增加跳跃了，或允许回退
+                TraceL << "Relative stamp changed: " << _relative_stamp << " -> " << target_stamp;
+                _relative_stamp = target_stamp;
+            } else {
+                // 不允许回退, 则让另外一个Track的时间戳增长
+                target_stamp = _relative_stamp - dts_diff;
+                TraceL << "Relative stamp changed: " << _sync_master->_relative_stamp << " -> " << target_stamp;
+                _sync_master->_relative_stamp = target_stamp;
+            }
         }
-        // 下次不用再强制同步
-        _sync_master = nullptr;
+        _need_sync = false;
+        _sync_master->_need_sync = false;
     }
 }
 
@@ -124,7 +160,7 @@ void Stamp::revise_l2(int64_t dts, int64_t pts, int64_t &dts_out, int64_t &pts_o
             // 内部自己生产时间戳
             _relative_stamp = _ticker.elapsedTime();
         } else {
-            _relative_stamp += deltaStamp(dts);
+            _relative_stamp += deltaStamp(dts, _enable_rollback);
         }
         _last_dts_in = dts;
     }

--- a/src/Rtsp/RtspMuxer.cpp
+++ b/src/Rtsp/RtspMuxer.cpp
@@ -14,7 +14,7 @@
 using namespace std;
 using namespace toolkit;
 
-#define ENABLE_NTP_STAMP 0
+#define ENABLE_NTP_STAMP 1
 
 namespace mediakit {
 
@@ -78,6 +78,10 @@ bool RtspMuxer::addTrack(const Track::Ptr &track) {
     //添加其sdp
     _sdp.append(sdp->getSdp());
     trySyncTrack();
+
+    // rtp的时间戳是pts，允许回退
+    _stamp[TrackAudio].enableRollback(true);
+    _stamp[TrackVideo].enableRollback(true);
     return true;
 }
 

--- a/src/Rtsp/RtspPusher.cpp
+++ b/src/Rtsp/RtspPusher.cpp
@@ -358,7 +358,10 @@ void RtspPusher::updateRtcpContext(const RtpPacket::Ptr &rtp){
     auto &ticker = _rtcp_send_ticker[track_index];
     auto &rtcp_ctx = _rtcp_context[track_index];
     rtcp_ctx->onRtp(rtp->getSeq(), rtp->getStamp(), rtp->ntp_stamp, rtp->sample_rate, rtp->size() - RtpPacket::kRtpTcpHeaderSize);
-
+    if (!rtp->ntp_stamp && !rtp->getStamp()) {
+        // 忽略时间戳都为0的rtp
+        return;
+    }
     //send rtcp every 5 second
     if (ticker.elapsedTime() > 5 * 1000) {
         ticker.resetTime();

--- a/src/Rtsp/RtspSession.cpp
+++ b/src/Rtsp/RtspSession.cpp
@@ -1193,6 +1193,10 @@ void RtspSession::updateRtcpContext(const RtpPacket::Ptr &rtp){
     int track_index = getTrackIndexByTrackType(rtp->type);
     auto &rtcp_ctx = _rtcp_context[track_index];
     rtcp_ctx->onRtp(rtp->getSeq(), rtp->getStamp(), rtp->ntp_stamp, rtp->sample_rate, rtp->size() - RtpPacket::kRtpTcpHeaderSize);
+    if (!rtp->ntp_stamp && !rtp->getStamp()) {
+        // 忽略时间戳都为0的rtp
+        return;
+    }
 
     auto &ticker = _rtcp_send_tickers[track_index];
     //send rtcp every 5 second


### PR DESCRIPTION
默认禁止时间戳回退并设置最大跳跃幅度为300毫秒
rtsp恢复产生ntp时间戳
由于绝对时间戳可能跳跃回退，之前在求相对时间戳时会导致音视频不同步。
现在求相对时间戳逻辑经过修改，已经支持同步功能，所以恢复rtp ntp时间戳逻辑