### PR TITLE
feat:webrtc adapt duplicate ssrc situation

### DIFF
--- a/webrtc/Sdp.cpp
+++ b/webrtc/Sdp.cpp
@@ -267,16 +267,24 @@ void RtcSessionSdp::parse(const string &str) {
     static auto flag = registerAllItem();
     RtcSdpBase *media = nullptr;
     auto lines = split(str, "\n");
-    for(auto &line : lines){
+    std::set<std::string> line_set;
+    for (auto &line : lines) {
         trim(line);
-        if(line.size() < 3 || line[1] != '='){
+        if (line.size() < 3 || line[1] != '=') {
             continue;
         }
+
+        if (line_set.find(line) != line_set.end()) {
+            continue;
+        }
+        line_set.emplace(line);
+
         auto key = line.substr(0, 1);
         auto value = line.substr(2);
         if (!strcasecmp(key.data(), "m")) {
             medias.emplace_back(RtcSdpBase());
             media = &medias.back();
+            line_set.clear();
         }
 
         SdpItem::Ptr item;


### PR DESCRIPTION
Here the example below :

# request:
POST /index/api/whip?app=live&stream=test
# header:
Accept : application/json, text/plain, */*
Cache-Control : no-cache
Connection : close
Content-Length : 1588
Content-Type : text/plain;charset=utf-8
Forwarded : for=xxx.xxx.xxx.xxx
Host : zlm.xxx.com
Pragma : no-cache
user-agent : GZNSCY-WEBRTC-AGENT/UNKNOWN/UNKNOWN GCC/11.4.0 Linux/6.2.0-37-generic x86_64
X-Forwarded-For : xxx.xxx.xxx.xxx
X-Forwarded-Host : zlm.xxx.com
X-Forwarded-Port : 443
X-Forwarded-Proto : https
X-Real-IP : xxx.xxx.xxx.xxx
# content:
v=0
o=- 324636371 2 IN IP4 127.0.0.1
s=-
t=0 0
a=group:BUNDLE 0 1
a=msid-semantic: WMS myKvsVideoStream
m=audio 9 UDP/TLS/RTP/SAVPF 8
c=IN IP4 127.0.0.1
a=msid:zlmVideoStream zlmAudioTrack
a=ssrc:1656574039 cname:frfeRUfyjGcxAQBc
a=ssrc:1656574039 msid:zlmVideoStream zlmAudioTrack
a=ssrc:1656574039 mslabel:zlmVideoStream
a=ssrc:1656574039 label:zlmAudioTrack
a=rtcp:9 IN IP4 0.0.0.0
a=ice-ufrag:/br1
a=ice-pwd:XEcgEwqGSC4/b8DY4T1Aq+2c
a=ice-options:trickle
a=fingerprint:sha-256 FE:7B:66:1A:52:90:A9:8C:88:32:84:57:81:5B:AE:76:AD:B2:69:DB:29:FB:94:26:9D:CA:7C:5C:95:DD:60:E8
a=setup:actpass
a=mid:0
a=sendrecv
a=rtcp-mux
a=rtpmap:8 PCMA/8000
a=ssrc:1656574039 cname:frfeRUfyjGcxAQBc
a=ssrc:1656574039 msid:zlmVideoStream zlmAudioTrack
a=rtcp-fb:8 goog-remb
m=video 9 UDP/TLS/RTP/SAVPF 125
c=IN IP4 127.0.0.1
a=msid:zlmVideoStream zlmVideoTrack
a=ssrc:1375305769 cname:frfeRUfyjGcxAQBc
a=ssrc:1375305769 msid:zlmVideoStream zlmVideoTrack
a=ssrc:1375305769 mslabel:zlmVideoStream
a=ssrc:1375305769 label:zlmVideoTrack
a=rtcp:9 IN IP4 0.0.0.0
a=ice-ufrag:/br1
a=ice-pwd:XEcgEwqGSC4/b8DY4T1Aq+2c
a=ice-options:trickle
a=fingerprint:sha-256 FE:7B:66:1A:52:90:A9:8C:88:32:84:57:81:5B:AE:76:AD:B2:69:DB:29:FB:94:26:9D:CA:7C:5C:95:DD:60:E8
a=setup:actpass
a=mid:1
a=sendonly
a=rtcp-mux
a=rtcp-rsize
a=rtpmap:125 H264/90000
a=rtcp-fb:125 nack pli
a=fmtp:125 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f
a=ssrc:1375305769 cname:frfeRUfyjGcxAQBc
a=ssrc:1375305769 msid:zlmVideoStream zlmVideoTrack
a=rtcp-fb:125 goog-remb

# response:
v=0
o=- 324636371 2 IN IP4 xxx.xxx.xxx.xxx
s=-
t=0 0
a=group:BUNDLE 0 1
a=msid-semantic: WMS myKvsVideoStream
a=ice-lite
m=audio 8000 UDP/TLS/RTP/SAVPF 8
c=IN IP4 xxx.xxx.xxx.xxx
a=rtcp:8000 IN IP4 xxx.xxx.xxx.xxx
a=ice-ufrag:zlm1
a=ice-pwd:WUmDSS78Ylui4bq6xg3qT9u9
a=ice-options:trickle
a=fingerprint:sha-256 5D:43:0F:2C:BD:82:BB:C5:B4:77:42:D3:8C:2B:D5:1A:32:59:39:1D:78:7A:BB:88:E2:EF:2A:60:37:AD:6E:A3
a=setup:passive
a=mid:0
a=ice-lite
a=recvonly
a=rtcp-mux
a=rtpmap:8 PCMA/8000/1
a=rtcp-fb:8 goog-remb
a=candidate:udpcandidate 1 udp 110 xxx.xxx.xxx.xxx 8000 typ host
a=candidate:tcpcandidate 1 tcp 105 xxx.xxx.xxx.xxx 8000 typ host tcptype passive
m=video 8000 UDP/TLS/RTP/SAVPF 125
c=IN IP4 xxx.xxx.xxx.xxx
a=rtcp:8000 IN IP4 xxx.xxx.xxx.xxx
a=ice-ufrag:zlm1
a=ice-pwd:WUmDSS78Ylui4bq6xg3qT9u9
a=ice-options:trickle
a=fingerprint:sha-256 5D:43:0F:2C:BD:82:BB:C5:B4:77:42:D3:8C:2B:D5:1A:32:59:39:1D:78:7A:BB:88:E2:EF:2A:60:37:AD:6E:A3
a=setup:passive
a=mid:1
a=ice-lite
a=recvonly
a=rtcp-mux
a=rtpmap:125 H264/90000
a=rtcp-fb:125 goog-remb
a=rtcp-fb:125 nack pli
a=fmtp:125 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f
a=candidate:udpcandidate 1 udp 110 xxx.xxx.xxx.xxx 8000 typ host
a=candidate:tcpcandidate 1 tcp 105 xxx.xxx.xxx.xxx 8000 typ host tcptype passive
