### PR TITLE
1. 配合zltoolkit自定义socket缓冲区大小.2. 修复http keepalive引发的bug

### DIFF
--- a/3rdpart/CMakeLists.txt
+++ b/3rdpart/CMakeLists.txt
@@ -151,6 +151,17 @@ if(HAVE_RECVMMSG_API)
   list(APPEND COMPILE_DEFINITIONS HAVE_RECVMMSG_API)
 endif()
 
+# check the socket buffer size set by the upper cmake project, if it is set, use the setting of the upper cmake project, otherwise set it to 256K
+# if the socket buffer size is set to 0, it means that the socket buffer size is not set, and the kernel default value is used(just for linux)
+if(DEFINED SOCKET_DEFAULT_BUF_SIZE)
+  if (SOCKET_DEFAULT_BUF_SIZE EQUAL 0)
+    message(STATUS "Socket default buffer size is not set, use the kernel default value")
+  else()
+    message(STATUS "Socket default buffer size is set to ${SOCKET_DEFAULT_BUF_SIZE}")
+  endif ()
+  add_definitions(-DSOCKET_DEFAULT_BUF_SIZE=${SOCKET_DEFAULT_BUF_SIZE})
+endif()
+
 set(ToolKit_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/ZLToolKit)
 # 收集源代码
 file(GLOB ToolKit_SRC_LIST

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,11 +24,13 @@
 cmake_minimum_required(VERSION 3.1.3)
 
 # 加载自定义模块
+# Load custom modules
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 project(ZLMediaKit LANGUAGES C CXX)
 
 # 使能 C++11
+# Enable C++11
 set(CMAKE_CXX_STANDARD 11)
 
 option(ENABLE_API "Enable C API SDK" ON)
@@ -58,8 +60,11 @@ option(ENABLE_X264 "Enable x264" OFF)
 option(ENABLE_WEPOLL "Enable wepoll" ON)
 option(DISABLE_REPORT "Disable report to report.zlmediakit.com" off)
 option(USE_SOLUTION_FOLDERS "Enable solution dir supported" ON)
-
 ##############################################################################
+# 设置socket默认缓冲区大小为256k.如果设置为0则不设置socket的默认缓冲区大小,使用系统内核默认值(设置为0仅对linux有效)
+# Set the default buffer size of the socket to 256k. If set to 0, the default buffer size of the socket will not be set,
+# and the system kernel default value will be used (setting to 0 is only valid for linux)
+set(SOCKET_DEFAULT_BUF_SIZE 262144 CACHE STRING "Default buffer size for socket" FORCE)
 
 if("${CMAKE_BUILD_TYPE}" STREQUAL "")
   set(CMAKE_BUILD_TYPE "Debug")
@@ -68,12 +73,14 @@ endif()
 message(STATUS "编译类型: ${CMAKE_BUILD_TYPE}")
 
 # 方便排查编译问题, 需要 FORCE CACHE, 否则需要命令行设置才生效
+# To facilitate the troubleshooting of compilation problems, you need to FORCE CACHE, otherwise you need to set it on the command line to take effect
 set(CMAKE_VERBOSE_MAKEFILE ON CACHE INTERNAL "" FORCE)
 
 # TODO: include 当前目录会导致 server 编译出错, 待排除
 set(CMAKE_INCLUDE_CURRENT_DIR OFF)
 
 # 安装路径
+# Install path
 if(NOT CMAKE_INSTALL_PREFIX)
   if(UNIX)
     set(INSTALL_PATH_LIB     lib${LIB_SUFFIX})
@@ -81,6 +88,7 @@ if(NOT CMAKE_INSTALL_PREFIX)
     set(INSTALL_PATH_RUNTIME bin)
   elseif(WIN32)
     # Windows 下安装到了用户主目录下?
+    # Install to the user's home directory under Windows?
     set(INSTALL_PATH_LIB     $ENV{HOME}/${CMAKE_PROJECT_NAME}/lib)
     set(INSTALL_PATH_INCLUDE $ENV{HOME}/${CMAKE_PROJECT_NAME}/include)
   else()
@@ -95,11 +103,14 @@ endif()
 string(TOLOWER ${CMAKE_SYSTEM_NAME} SYSTEM_NAME_LOWER)
 # 设置输出目录, 包括 bin, lib 以及其他文件
 # Windows 也不再区分 32/64
+# Set the output directory, including bin, lib and other files
+# Windows no longer distinguishes 32/64
 set(OUTPUT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/release/${SYSTEM_NAME_LOWER}/${CMAKE_BUILD_TYPE})
 set(LIBRARY_OUTPUT_PATH    ${OUTPUT_DIR})
 set(EXECUTABLE_OUTPUT_PATH ${OUTPUT_DIR})
 
 # 添加 git 版本信息
+# Add git version information
 set(COMMIT_HASH "Git_Unkown_commit")
 set(COMMIT_TIME "Git_Unkown_time")
 set(BRANCH_NAME "Git_Unkown_branch")
@@ -140,6 +151,7 @@ message(STATUS "Git version is ${BRANCH_NAME} ${COMMIT_HASH}/${COMMIT_TIME} ${BU
 ##############################################################################
 
 # 方便修改全局变量
+# Convenient to modify global variables
 function(update_cached name value)
   set("${name}" "${value}" CACHE INTERNAL "*** Internal ***" FORCE)
 endfunction()
@@ -202,6 +214,7 @@ if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
 endif()
 
 # mediakit 以及各个 runtime 依赖
+# mediakit and various runtime dependencies
 update_cached(MK_LINK_LIBRARIES "")
 update_cached(MK_COMPILE_DEFINITIONS ENABLE_VERSION)
 
@@ -226,9 +239,11 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 endif()
 
 # 多个模块依赖 ffmpeg 相关库, 统一查找
+# Multiple modules depend on ffmpeg related libraries, unified search
 if(ENABLE_FFMPEG)
   find_package(PkgConfig QUIET)
   # 查找 ffmpeg/libutil 是否安装
+  # find ffmpeg/libutil installed
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(AVUTIL QUIET IMPORTED_TARGET libavutil)
     if(AVUTIL_FOUND)
@@ -238,6 +253,7 @@ if(ENABLE_FFMPEG)
   endif()
 
   # 查找 ffmpeg/libavcodec 是否安装
+  # find ffmpeg/libavcodec installed
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(AVCODEC QUIET IMPORTED_TARGET libavcodec)
     if(AVCODEC_FOUND)
@@ -247,6 +263,7 @@ if(ENABLE_FFMPEG)
   endif()
 
   # 查找 ffmpeg/libswscale 是否安装
+  # find ffmpeg/libswscale installed
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(SWSCALE QUIET IMPORTED_TARGET libswscale)
     if(SWSCALE_FOUND)
@@ -256,6 +273,7 @@ if(ENABLE_FFMPEG)
   endif()
 
   # 查找 ffmpeg/libswresample 是否安装
+  # find ffmpeg/libswresample installed
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(SWRESAMPLE QUIET IMPORTED_TARGET libswresample)
     if(SWRESAMPLE_FOUND)
@@ -265,6 +283,7 @@ if(ENABLE_FFMPEG)
   endif()
 
   # 查找 ffmpeg/libutil 是否安装
+  # find ffmpeg/libutil installed
   if(NOT AVUTIL_FOUND)
     find_package(AVUTIL QUIET)
     if(AVUTIL_FOUND)
@@ -275,6 +294,7 @@ if(ENABLE_FFMPEG)
   endif ()
 
   # 查找 ffmpeg/libavcodec 是否安装
+  # find ffmpeg/libavcodec installed
   if(NOT AVCODEC_FOUND)
     find_package(AVCODEC QUIET)
     if(AVCODEC_FOUND)
@@ -285,6 +305,7 @@ if(ENABLE_FFMPEG)
   endif()
 
   # 查找 ffmpeg/libswscale 是否安装
+  # find ffmpeg/libswscale installed
   if(NOT SWSCALE_FOUND)
     find_package(SWSCALE QUIET)
     if(SWSCALE_FOUND)
@@ -295,6 +316,7 @@ if(ENABLE_FFMPEG)
   endif()
 
   # 查找 ffmpeg/libswresample 是否安装
+  # find ffmpeg/libswresample installed
   if(NOT SWRESAMPLE_FOUND)
     find_package(SWRESAMPLE QUIET)
     if(SWRESAMPLE_FOUND)
@@ -309,7 +331,7 @@ if(ENABLE_FFMPEG)
     update_cached_list(MK_LINK_LIBRARIES ${CMAKE_DL_LIBS})
   else()
     set(ENABLE_FFMPEG OFF)
-    message(WARNING "ffmpeg 相关功能未找到")
+    message(WARNING "ffmpeg related functions not found")
   endif()
 endif()
 
@@ -317,7 +339,7 @@ if(ENABLE_MEM_DEBUG)
   update_cached_list(MK_LINK_LIBRARIES
     "-Wl,-wrap,free;-Wl,-wrap,malloc;-Wl,-wrap,realloc;-Wl,-wrap,calloc")
   update_cached_list(MK_COMPILE_DEFINITIONS ENABLE_MEM_DEBUG)
-  message(STATUS "已启用内存调试功能")
+  message(STATUS "Memory debugging enabled")
 endif()
 
 if(ENABLE_ASAN)
@@ -327,10 +349,11 @@ if(ENABLE_ASAN)
   # > In order to use AddressSanitizer you will need to
   # > compile and link your program using clang with the -fsanitize=address switch.
   update_cached_list(MK_LINK_LIBRARIES "-fsanitize=address")
-  message(STATUS "已启用 Address Sanitize")
+  message(STATUS "Address Sanitize enabled")
 endif()
 
-# TODO: 下载静态编译 jemalloc 后静态编译链接?
+# 下载jemalloc后静态编译
+# Static compilation after downloading jemalloc
 set(DEP_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/3rdpart/external-${CMAKE_SYSTEM_NAME})
 if(ENABLE_JEMALLOC_STATIC)
   if(NOT EXISTS ${DEP_ROOT_DIR})
@@ -345,10 +368,12 @@ if(ENABLE_JEMALLOC_STATIC)
   include_directories(SYSTEM ${DEP_ROOT_DIR}/${JEMALLOC_NAME}/include/jemalloc)
   link_directories(${DEP_ROOT_DIR}/${JEMALLOC_NAME}/lib)
   # 用于影响后续查找过程
+  # Used to affect subsequent lookup process
   set(JEMALLOC_ROOT_DIR "${DEP_ROOT_DIR}/${JEMALLOC_NAME}")
 endif()
 
 # 默认链接 jemalloc 库避免内存碎片
+# Link the jemalloc library by default to avoid memory fragmentation
 find_package(JEMALLOC QUIET)
 if(JEMALLOC_FOUND)
   message(STATUS "found library: ${JEMALLOC_LIBRARIES}")
@@ -363,6 +388,7 @@ if(JEMALLOC_FOUND)
 endif()
 
 # 查找 openssl 是否安装
+# find openssl installed
 find_package(OpenSSL QUIET)
 if(OPENSSL_FOUND AND ENABLE_OPENSSL)
   message(STATUS "found library: ${OPENSSL_LIBRARIES}, ENABLE_OPENSSL defined")
@@ -379,6 +405,7 @@ else()
 endif()
 
 # 查找 mysql 是否安装
+# find mysql installed
 find_package(MYSQL QUIET)
 if(MYSQL_FOUND AND ENABLE_MYSQL)
   message(STATUS "found library: ${MYSQL_LIBRARIES}, ENABLE_MYSQL defined")
@@ -391,6 +418,7 @@ if(MYSQL_FOUND AND ENABLE_MYSQL)
 endif()
 
 # 查找 x264 是否安装
+# find x264 installed
 find_package(X264 QUIET)
 if(X264_FOUND AND ENABLE_X264)
   message(STATUS "found library: ${X264_LIBRARIES}, ENABLE_X264 defined")
@@ -401,6 +429,7 @@ if(X264_FOUND AND ENABLE_X264)
 endif()
 
 # 查找 faac 是否安装
+# find faac installed
 find_package(FAAC QUIET)
 if(FAAC_FOUND AND ENABLE_FAAC)
   message(STATUS "found library:${FAAC_LIBRARIES}, ENABLE_FAAC defined")
@@ -468,26 +497,31 @@ if(ENABLE_PLAYER AND ENABLE_FFMPEG)
 endif()
 
 #MediaServer主程序
+#MediaServer main program
 if(ENABLE_SERVER)
   add_subdirectory(server)
 endif()
 
 # Android 会 add_subdirectory 并依赖该变量
+# Android will add_subdirectory and depend on this variable
 if(ENABLE_SERVER_LIB AND NOT CMAKE_PARENT_LIST_FILE STREQUAL CMAKE_CURRENT_LIST_FILE)
   set(MK_LINK_LIBRARIES ${MK_LINK_LIBRARIES} PARENT_SCOPE)
 endif()
 
 # IOS 不编译可执行程序
+# IOS does not compile executable programs
 if(IOS)
   return()
 endif()
 
 #cpp测试demo程序
+#cpp test demo program
 if (ENABLE_TESTS)
   add_subdirectory(tests)
 endif ()
 
 # 拷贝www文件夹、配置文件、默认证书
+# Copy www folder, configuration file, default certificate
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/www" DESTINATION ${EXECUTABLE_OUTPUT_PATH})
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/conf/config.ini" DESTINATION ${EXECUTABLE_OUTPUT_PATH})
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/default.pem" DESTINATION ${EXECUTABLE_OUTPUT_PATH})

--- a/src/Http/HttpClient.cpp
+++ b/src/Http/HttpClient.cpp
@@ -58,7 +58,7 @@ void HttpClient::sendRequest(const string &url) {
     _header.emplace("User-Agent", kServerName);
     _header.emplace("Accept", "*/*");
     _header.emplace("Accept-Language", "zh-CN,zh;q=0.8");
-    if(_http_persistent) {
+    if (_http_persistent) {
         _header.emplace("Connection", "keep-alive");
     } else {
         _header.emplace("Connection", "close");
@@ -191,7 +191,7 @@ void HttpClient::onRecv(const Buffer::Ptr &pBuf) {
 }
 
 void HttpClient::onError(const SockException &ex) {
-    if(ex.getErrCode() == Err_reset && _http_persistent){
+    if (ex.getErrCode() == Err_reset && _http_persistent) {
         // 连接被重置，可能是服务器主动断开了连接, 或者服务器内核参数或防火墙的持久连接空闲时间超时或不一致.
         // 如果是持久化连接，那么我们可以通过重连来解决这个问题
         // The connection was reset, possibly because the server actively disconnected the connection,

--- a/src/Http/HttpClient.h
+++ b/src/Http/HttpClient.h
@@ -201,6 +201,7 @@ private:
     //for http response
     bool _complete = false;
     bool _header_recved = false;
+    bool _http_persistent = true;
     size_t _recved_body_size;
     ssize_t _total_body_size;
     Parser _parser;


### PR DESCRIPTION
需要先通过zltoolkit的pr, 增加了一个新的Err_reset.
这种情况其实并不少见.
主要是一些服务器为了提高并发减少资源占用, 会不允许http协议的keepalive.
另外就是一些服务器的keepalive和前置防火墙的设置的时间不一致也会导致这样的问题.
触发场景应该常见于hls拉流的场景, 至于http-ts/http-flv相对比较少见.
一般CDN业务这种情况会遇到很多, 普通用户估计很少会遇到.

