### PR TITLE
修复编译 rpm 时获取调试信息失败问题

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,12 @@ if(UNIX)
     "-Wall;-Wextra"
     "-Wno-unused-function;-Wno-unused-parameter;-Wno-unused-variable"
     "-Wno-error=extra;-Wno-error=missing-field-initializers;-Wno-error=type-limits")
+
+  if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+    set(COMPILE_OPTIONS_DEFAULT ${COMPILE_OPTIONS_DEFAULT} "-g3")
+  else()
+    set(COMPILE_OPTIONS_DEFAULT ${COMPILE_OPTIONS_DEFAULT} "-g0")
+  endif()
 elseif(WIN32)
   if (MSVC)
     set(COMPILE_OPTIONS_DEFAULT

--- a/package/rpm/ZLMediaKit.spec
+++ b/package/rpm/ZLMediaKit.spec
@@ -18,7 +18,7 @@
 %bcond_with cxx_api
 
 Name:		ZLMediaKit
-Version:	5.0.0
+Version:	8.0.0
 Release:	1%{?dist}
 Summary:	A lightweight, high performance and stable stream server and client framework based on C++11.
 


### PR DESCRIPTION
Release 8.0 之后, 编译 rpm 会出现获取调试信息失败问题,  导致 rpm 打包失败

虽然说可以禁用调试包生成来规避问题, 但个人认为在编译 DEBUG 版本时生成调试信息包还是有必要的