### PR TITLE
C API添加拉流代理更都参数配置

### DIFF
--- a/api/include/mk_proxyplayer.h
+++ b/api/include/mk_proxyplayer.h
@@ -12,6 +12,7 @@
 #define MK_PROXY_PLAYER_H_
 
 #include "mk_common.h"
+#include "mk_util.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,6 +31,17 @@ typedef struct mk_proxy_player_t *mk_proxy_player;
  * @return 对象指针
  */
 API_EXPORT mk_proxy_player API_CALL mk_proxy_player_create(const char *vhost, const char *app, const char *stream, int hls_enabled, int mp4_enabled);
+
+/**
+ * 创建一个代理播放器
+ * @param vhost 虚拟主机名，一般为__defaultVhost__
+ * @param app 应用名
+ * @param stream 流名
+ * @param option ProtocolOption相关配置
+ * @return 对象指针
+ */
+API_EXPORT mk_proxy_player API_CALL mk_proxy_player_create2(const char *vhost, const char *app, const char *stream, mk_ini option);
+
 
 /**
  * 销毁代理播放器

--- a/api/source/mk_proxyplayer.cpp
+++ b/api/source/mk_proxyplayer.cpp
@@ -10,6 +10,7 @@
 
 #include "mk_proxyplayer.h"
 #include "Player/PlayerProxy.h"
+#include "mk_util.h"
 
 using namespace toolkit;
 using namespace mediakit;
@@ -22,6 +23,14 @@ API_EXPORT mk_proxy_player API_CALL mk_proxy_player_create(const char *vhost, co
     PlayerProxy::Ptr *obj(new PlayerProxy::Ptr(new PlayerProxy(vhost, app, stream, option)));
     return (mk_proxy_player) obj;
 }
+
+API_EXPORT mk_proxy_player API_CALL mk_proxy_player_create2(const char *vhost, const char *app, const char *stream, mk_ini ini) {
+    assert(vhost && app && stream);
+    ProtocolOption option(*((mINI *)ini));
+    PlayerProxy::Ptr *obj(new PlayerProxy::Ptr(new PlayerProxy(vhost, app, stream, option)));
+    return (mk_proxy_player)obj;
+}
+
 
 API_EXPORT void API_CALL mk_proxy_player_release(mk_proxy_player ctx) {
     assert(ctx);


### PR DESCRIPTION
目前mk_proxy_player_create只能配置hls_enabled、mp4_enabled，和addStreamProxy接口对比缺少很多配置项目，故添加mk_proxy_player_create2实现这一功能