### PR TITLE
Implement size limits on HTTP header number, header size and body size

### DIFF
--- a/conf/config.ini
+++ b/conf/config.ini
@@ -225,6 +225,12 @@ charSet=utf-8
 keepAliveSecond=30
 #http请求体最大字节数，如果post的body太大，则不适合缓存body在内存
 maxReqSize=40960
+#http header请求最大个数，大于0才校验
+maxReqHeaderNumber=0
+#http header请求最大字节数，大于0才校验
+maxReqHeaderSize=0
+#http body请求最大字节数，大于0才校验
+maxReqBodySize=0
 #404网页内容，用户可以自定义404网页
 #notFound=<html><head><title>404 Not Found</title></head><body bgcolor="white"><center><h1>您访问的资源不存在！</h1></center><hr><center>ZLMediaKit-4.0</center></body></html>
 #http服务器监听端口

--- a/src/Common/config.cpp
+++ b/src/Common/config.cpp
@@ -164,6 +164,9 @@ namespace Http {
 #define HTTP_FIELD "http."
 const string kSendBufSize = HTTP_FIELD "sendBufSize";
 const string kMaxReqSize = HTTP_FIELD "maxReqSize";
+const string kMaxReqHeaderNumber = HTTP_FIELD "maxReqHeaderNumber";
+const string kMaxReqHeaderSize = HTTP_FIELD "maxReqHeaderSize";
+const string kMaxReqBodySize = HTTP_FIELD "maxReqBodySize";
 const string kKeepAliveSecond = HTTP_FIELD "keepAliveSecond";
 const string kCharSet = HTTP_FIELD "charSet";
 const string kRootPath = HTTP_FIELD "rootPath";

--- a/src/Common/config.h
+++ b/src/Common/config.h
@@ -254,6 +254,12 @@ namespace Http {
 extern const std::string kSendBufSize;
 // http 最大请求字节数
 extern const std::string kMaxReqSize;
+// header最大请求个数
+extern const std::string kMaxReqHeaderNumber;
+// header最大请求字节数
+extern const std::string kMaxReqHeaderSize;
+// body最大请求字节数
+extern const std::string kMaxReqBodySize;
 // http keep-alive秒数
 extern const std::string kKeepAliveSecond;
 // http 字符编码

--- a/src/Http/HttpRequestSplitter.cpp
+++ b/src/Http/HttpRequestSplitter.cpp
@@ -65,6 +65,10 @@ void HttpRequestSplitter::input(const char *data,size_t len) {
         _content_len = onRecvHeader(header_ptr, header_size);
     }
 
+    if (_content_len == 0 && _remain_data_size > 0) {
+        onCheckHeader(ptr,_remain_data_size);
+    }
+
     if(_remain_data_size <= 0){
         //没有剩余数据，清空缓存
         _remain_data.clear();

--- a/src/Http/HttpRequestSplitter.h
+++ b/src/Http/HttpRequestSplitter.h
@@ -68,7 +68,7 @@ protected:
      * @param data content分片或全部数据
      * @param len 数据长度
      */
-    virtual void onRecvContent(const char *data,size_t len) {};
+    virtual void onRecvContent(const char *data, size_t len) {};
 
     /**
      * 判断数据中是否有包尾
@@ -77,6 +77,13 @@ protected:
      * @return nullptr代表未找到包位，否则返回包尾指针
      */
     virtual const char *onSearchPacketTail(const char *data, size_t len);
+
+    /**
+     * 判断请求头是否有效
+     * @param data 请求头数据
+     * @param len 请求头长度
+     */
+    virtual void onCheckHeader(const char *data, size_t len) {};
 
     /**
      * 设置content len

--- a/src/Http/HttpSession.h
+++ b/src/Http/HttpSession.h
@@ -49,6 +49,9 @@ public:
     static std::string urlDecodeComponent(const std::string &str);
     void setTimeoutSec(size_t second);
     void setMaxReqSize(size_t max_req_size);
+    void setMaxReqHeaderNumber(size_t max_req_header_number);
+    void setMaxReqHeaderSize(size_t max_req_header_size);
+    void setMaxReqBodySize(size_t max_req_body_size);
 
 protected:
     //FlvMuxer override
@@ -57,8 +60,9 @@ protected:
     std::shared_ptr<FlvMuxer> getSharedPtr() override;
 
     //HttpRequestSplitter override
-    ssize_t onRecvHeader(const char *data,size_t len) override;
-    void onRecvContent(const char *data,size_t len) override;
+    ssize_t onRecvHeader(const char *data, size_t len) override;
+    void onRecvContent(const char *data, size_t len) override;
+    void onCheckHeader(const char *data, size_t len) override;
 
     /**
      * 重载之用于处理不定长度的content
@@ -126,6 +130,9 @@ private:
     //设置socket标志
     void setSocketFlags();
 
+    ssize_t onSearchHeaderNumber(const char *data, size_t len);
+    void onCheckHeader(size_t len, size_t number);
+
 protected:
     MediaInfo _media_info;
 
@@ -136,6 +143,9 @@ private:
     size_t _keep_alive_sec = 0;
     //最大http请求字节大小
     size_t _max_req_size = 0;
+    size_t _max_req_header_number = 0;
+    size_t _max_req_header_size = 0;
+    size_t _max_req_body_size = 0;
     //消耗的总流量
     uint64_t _total_bytes_usage = 0;
     // http请求中的 Origin字段


### PR DESCRIPTION
新增配置：http.maxReqHeaderNumber, http.maxReqHeaderSize, http.maxReqBodySize；
可根据需要配置，预防缓慢的HTTP拒绝服务攻击，例如Slow headers攻击