### PR TITLE
enable video stack individually

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ option(ENABLE_SCTP "Enable SCTP" ON)
 option(ENABLE_WEBRTC "Enable WebRTC" ON)
 option(ENABLE_X264 "Enable x264" OFF)
 option(ENABLE_WEPOLL "Enable wepoll" ON)
+option(ENABLE_VIDEOSTACK "Enable video stack" OFF)
 option(DISABLE_REPORT "Disable report to report.zlmediakit.com" off)
 option(USE_SOLUTION_FOLDERS "Enable solution dir supported" ON)
 ##############################################################################
@@ -535,6 +536,6 @@ file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/default.pem" DESTINATION ${EXECUTABLE_OUT
 
 # 拷贝VideoStack 无视频流时默认填充的背景图片
 # Copy the default background image used by VideoStack when there is no video stream
-if (ENABLE_FFMPEG AND ENABLE_X264)
+if (ENABLE_VIDEOSTACK AND ENABLE_FFMPEG AND ENABLE_X264)
   file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/conf/novideo.yuv" DESTINATION ${EXECUTABLE_OUTPUT_PATH})
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ option(ENABLE_WEBRTC "Enable WebRTC" ON)
 option(ENABLE_X264 "Enable x264" OFF)
 option(ENABLE_WEPOLL "Enable wepoll" ON)
 option(ENABLE_VIDEOSTACK "Enable video stack" OFF)
-option(DISABLE_REPORT "Disable report to report.zlmediakit.com" off)
+option(DISABLE_REPORT "Disable report to report.zlmediakit.com" OFF)
 option(USE_SOLUTION_FOLDERS "Enable solution dir supported" ON)
 ##############################################################################
 # 设置socket默认缓冲区大小为256k.如果设置为0则不设置socket的默认缓冲区大小,使用系统内核默认值(设置为0仅对linux有效)

--- a/server/VideoStack.cpp
+++ b/server/VideoStack.cpp
@@ -1,4 +1,4 @@
-﻿#if defined(ENABLE_X264) && defined(ENABLE_FFMPEG)
+﻿#if defined(ENABLE_VIDEOSTACK) && defined(ENABLE_X264) && defined(ENABLE_FFMPEG)
 #include "VideoStack.h"
 #include "Codec/Transcode.h"
 #include "Common/Device.h"

--- a/server/VideoStack.h
+++ b/server/VideoStack.h
@@ -1,5 +1,5 @@
 ﻿#pragma once
-#if defined(ENABLE_X264) && defined(ENABLE_FFMPEG)
+#if defined(ENABLE_VIDEOSTACK) && defined(ENABLE_X264) && defined(ENABLE_FFMPEG)
 #include "Codec/Transcode.h"
 #include "Common/Device.h"
 #include "Player/MediaPlayer.h"

--- a/server/WebApi.cpp
+++ b/server/WebApi.cpp
@@ -62,7 +62,7 @@
 #include "ZLMVersion.h"
 #endif
 
-#if defined(ENABLE_X264) && defined (ENABLE_FFMPEG)
+#if defined(ENABLE_VIDEOSTACK) && defined(ENABLE_X264) && defined (ENABLE_FFMPEG)
 #include "VideoStack.h"
 #endif
 
@@ -1910,7 +1910,7 @@ void installWebApi() {
         }
     });
 
-#if defined(ENABLE_X264) && defined(ENABLE_FFMPEG)
+#if defined(ENABLE_VIDEOSTACK) && defined(ENABLE_X264) && defined(ENABLE_FFMPEG)
     VideoStackManager::Instance().loadBgImg("novideo.yuv");
     NoticeCenter::Instance().addListener(nullptr, Broadcast::kBroadcastStreamNoneReader, [](BroadcastStreamNoneReaderArgs) {
         auto id = sender.getMediaTuple().stream;


### PR DESCRIPTION
Hi,
Supposing that I only want to compile the test projects with ffmpeg,
then I made ffmpeg and x264 enabled, 
but I don't want the main program compiled with video stack feature,
this would lead to the main program referencing the huge ffmpeg library,
so make this PR.
