### PR TITLE
修复拉取指定流时丢掉时长信息的问题

### DIFF
--- a/src/Rtsp/RtspPlayer.cpp
+++ b/src/Rtsp/RtspPlayer.cpp
@@ -210,7 +210,8 @@ void RtspPlayer::handleResDESCRIBE(const Parser &parser) {
     if (play_track != TrackInvalid) {
         auto track = sdpParser.getTrack(play_track);
         _sdp_track.emplace_back(track);
-        sdp = track->toString();
+        auto title_track = sdpParser.getTrack(TrackTitle);
+        sdp = title_track ? title_track->toString() : "" + track->toString();
     } else {
         _sdp_track = sdpParser.getAvailableTrack();
         sdp = sdpParser.toString();


### PR DESCRIPTION
当指定只拉取视频流时，获取时长时为0，丢失了相关信息