### PR TITLE
修复当源析构时组播对象偶现析构不了的问题

### DIFF
--- a/src/Rtsp/RtpMultiCaster.cpp
+++ b/src/Rtsp/RtpMultiCaster.cpp
@@ -144,7 +144,16 @@ RtpMultiCaster::RtpMultiCaster(SocketHelper &helper, const string &local_ip, con
         });
     });
 
+    string strKey = StrPrinter << local_ip << " " << vhost << " " << app << " " << stream << endl;
     _rtp_reader->setDetachCB([this]() {
+        {
+            lock_guard<recursive_mutex> lck(g_mtx);
+            auto it = g_multi_caster_map.find(strKey);
+            if (it != g_multi_caster_map.end()) {
+                g_multi_caster_map.erase(it);
+            }
+        }
+
         unordered_map<void *, onDetach> _detach_map_copy;
         {
             lock_guard<recursive_mutex> lck(_mtx);

--- a/src/Rtsp/RtpMultiCaster.cpp
+++ b/src/Rtsp/RtpMultiCaster.cpp
@@ -145,7 +145,7 @@ RtpMultiCaster::RtpMultiCaster(SocketHelper &helper, const string &local_ip, con
     });
 
     string strKey = StrPrinter << local_ip << " " << vhost << " " << app << " " << stream << endl;
-    _rtp_reader->setDetachCB([this]() {
+    _rtp_reader->setDetachCB([this, strKey]() {
         {
             lock_guard<recursive_mutex> lck(g_mtx);
             auto it = g_multi_caster_map.find(strKey);


### PR DESCRIPTION
当多个客户端拉同一个组播源时，如果此时源被析构，会偶现使用该源的组播对象没有被析构的情况，在RtpMultiCaster的_rtp_reader->setDetachCB回调函数中，先移除该组播对象再通知上层session可以解决此问题