### PR TITLE
解决帧率解析错误问题

### DIFF
--- a/ext-codec/SPSParser.c
+++ b/ext-codec/SPSParser.c
@@ -306,13 +306,12 @@ static int getBits(void *pvHandle, int iN)
     uint8_t u8Nbyte;
     uint8_t u8Shift;
     uint32_t u32Result = 0;
-    int iRet = 0;
+    uint32_t iRet = 0;
     int iResoLen = 0;
 
     if(NULL == ptPtr)
     {
         RPT(RPT_ERR, "NULL pointer");
-        iRet = -1;
         goto exit;
     }
 
@@ -324,7 +323,6 @@ static int getBits(void *pvHandle, int iN)
     iResoLen = getBitsLeft(ptPtr);
     if(iResoLen < iN)
     {
-        iRet = -1;
         goto exit;
     }
 


### PR DESCRIPTION
有时解析H265的sps，帧率会出错，例如QgEBAWAAAAMAAAMAAAMAAAMAlqABQCAFof4qtO6JLuaAgAg9YADN/mAE  帧率会解析成3971