### PR TITLE
bugfix: 修复所有Player的删除器使用同一个线程进行析构导致崩溃的问题

### DIFF
--- a/src/Player/PlayerBase.cpp
+++ b/src/Player/PlayerBase.cpp
@@ -24,7 +24,7 @@ namespace mediakit {
 PlayerBase::Ptr PlayerBase::createPlayer(const EventPoller::Ptr &in_poller, const string &url_in) {
     auto poller = in_poller ? in_poller : EventPollerPool::Instance().getPoller();
     std::weak_ptr<EventPoller> weak_poller = poller;
-    static auto release_func = [weak_poller](PlayerBase *ptr) {
+    auto release_func = [weak_poller](PlayerBase *ptr) {
         if (auto poller = weak_poller.lock()) {
             poller->async([ptr]() {
                 onceToken token(nullptr, [&]() { delete ptr; });


### PR DESCRIPTION
Player的删除器release_func是static类型，weak_poller不会更新了。后面析构使用的就不是正确的poller线程了。 