### PR TITLE
player_opencv.c中brg24变量的内存对齐

### DIFF
--- a/api/tests/player_opencv.c
+++ b/api/tests/player_opencv.c
@@ -30,7 +30,13 @@ void API_CALL on_frame_decode(void *user_data, mk_frame_pix frame) {
     int h = mk_get_av_frame_height(mk_frame_pix_get_av_frame(frame));
 
 #if 1
-    uint8_t *brg24 = malloc(w * h * 3);
+    int align = 32; 
+    size_t pixel_size = 3;
+    size_t raw_linesize = w * pixel_size;
+    // 对齐后的宽度
+    size_t aligned_linesize = (raw_linesize + align - 1) & ~(align - 1);
+    size_t total_size = aligned_linesize * h;
+    uint8_t* brg24 = malloc(total_size);
     mk_swscale_input_frame(ctx->swscale, frame, brg24);
     free(brg24);
 #else


### PR DESCRIPTION
在本地测试时发现，player_opencv.c程序如果不事先对brg24变量进行内存对齐，之后传入函数，运行到src/Codec/Transcode.cpp:FFmpegSws::inputFrame:sws_scale时可能会出现段错误