### PR TITLE
compatible for ffmpeg 5 above default merge frame fix  the issue #3794

### DIFF
--- a/src/Codec/Transcode.cpp
+++ b/src/Codec/Transcode.cpp
@@ -439,6 +439,7 @@ FFmpegDecoder::FFmpegDecoder(const Track::Ptr &track, int thread_num, const std:
         if (codec->capabilities & AV_CODEC_CAP_TRUNCATED) {
             /* we do not send complete frames */
             _context->flags |= AV_CODEC_FLAG_TRUNCATED;
+            _do_merger = false;
         } else {
             // 此时业务层应该需要合帧
             _do_merger = true;

--- a/src/Codec/Transcode.h
+++ b/src/Codec/Transcode.h
@@ -114,7 +114,8 @@ private:
     bool decodeFrame(const char *data, size_t size, uint64_t dts, uint64_t pts, bool live, bool key_frame);
 
 private:
-    bool _do_merger = false;
+    // default merge frame
+    bool _do_merger = true;
     toolkit::Ticker _ticker;
     onDec _cb;
     std::shared_ptr<AVCodecContext> _context;


### PR DESCRIPTION
FFmpegDecoder 默认合并帧，ffmpeg 5以上不支持将不完整的帧送入解码器中，根据 issue #3794 做出修改