### PR TITLE
修复弱网丢包场景下rtp解码器可能不会输出配置帧的问题

### DIFF
--- a/ext-codec/H264Rtp.cpp
+++ b/ext-codec/H264Rtp.cpp
@@ -184,7 +184,7 @@ void H264RtpDecoder::outputFrame(const RtpPacket::Ptr &rtp, const H264Frame::Ptr
         _gop_dropped = false;
         InfoL << "new gop received, rtp:\r\n" << rtp->dumpString();
     }
-    if (!_gop_dropped) {
+    if (!_gop_dropped || frame->configFrame()) {
         RtpCodec::inputFrame(frame);
     }
     _frame = obtainFrame();

--- a/ext-codec/H265Rtp.cpp
+++ b/ext-codec/H265Rtp.cpp
@@ -240,7 +240,7 @@ void H265RtpDecoder::outputFrame(const RtpPacket::Ptr &rtp, const H265Frame::Ptr
         _gop_dropped = false;
         InfoL << "new gop received, rtp:\r\n" << rtp->dumpString();
     }
-    if (!_gop_dropped) {
+    if (!_gop_dropped || frame->configFrame()) {
         RtpCodec::inputFrame(frame);
     }
     _frame = obtainFrame();


### PR DESCRIPTION
在弱网丢包场景下，rtp解码器很可能进入gop dropped状态，需要等到idr到来才能继续输出帧, 这会导致idr前面的sps/pps无法被输出, 进而可能导致播放器渲染失败