### PR TITLE
新增兼容whip接口http头的 Authorization 的Bearer令牌

### DIFF
--- a/server/WebApi.cpp
+++ b/server/WebApi.cpp
@@ -1845,8 +1845,9 @@ void installWebApi() {
             auto &allArgs = _args;
             CHECK_ARGS("app", "stream");
 
-            return StrPrinter << "rtc://" << _args["Host"] << "/" << _args["app"] << "/"
-                              << _args["stream"] << "?" << _args.parser.params() + "&session=" + _session_id;
+            string auth = _args["Authorization"]; // Authorization  Bearer
+            return StrPrinter << "rtc://" << _args["Host"] << "/" << _args["app"] << "/" << _args["stream"] << "?"
+                              << _args.parser.params() + "&session=" + _session_id + (auth.empty() ? "" : ("&Authorization=" + auth));
         }
 
     private:


### PR DESCRIPTION
新增兼容whip接口http头的 Authorization 的Bearer令牌 转成 webhook 的 params的参数 , 即也支持rtc应用业务层回调推流 Authorization Bearer鉴权