### PR TITLE
Accelerate the Ready speed of certain media that actually only have a single video track but the metadata contains an audio track, such as GB28181 PS streams[加快某些实际上只有单视频track但是metadata包含音频track的媒体Ready速度，比如GB28181 PS流]

### DIFF
--- a/conf/config.ini
+++ b/conf/config.ini
@@ -121,6 +121,9 @@ mediaServerId=your_server_id
 
 #最多等待未初始化的Track时间，单位毫秒，超时之后会忽略未初始化的Track
 wait_track_ready_ms=10000
+#最多等待音频Track收到数据时间，单位毫秒，超时且完全没收到音频数据，忽略音频Track
+#加快某些带封装的流metadata说明有音频，但是实际上没有的流ready时间（比如很多厂商的GB28181 PS）
+wait_audio_track_data_ms=1000
 #如果流只有单Track，最多等待若干毫秒，超时后未收到其他Track的数据，则认为是单Track
 #如果协议元数据有声明特定track数，那么无此等待时间
 wait_add_track_ms=3000

--- a/src/Common/MediaSink.cpp
+++ b/src/Common/MediaSink.cpp
@@ -107,6 +107,27 @@ void MediaSink::checkTrackIfReady() {
         }
     }
 
+    // 等待音频超时时间
+    GET_CONFIG(uint32_t, kWaitAudioTrackDataMS, General::kWaitAudioTrackDataMS);
+    if( _max_track_size > 1 ){
+        for (auto it = _track_map.begin(); it != _track_map.end();++it) {
+            if(it->second.first->getTrackType() != TrackAudio){
+                continue;
+            }
+            if(_ticker.elapsedTime() > kWaitAudioTrackDataMS &&!it->second.second ){
+                // 音频超时且完全没收到音频数据，忽略音频
+                auto index = it->second.first->getIndex();
+                WarnL<<"audio track "<< "index "<<index<<" codec "<< it->second.first->getCodecName()
+                      <<" receive no data for long "<< _ticker.elapsedTime() <<"ms. Ignore it!";
+                it = _track_map.erase(it);
+                _max_track_size -= 1;
+                _track_ready_callback.erase(index);
+                continue;
+            }
+        }
+    }
+
+
     if (!_all_track_ready) {
         GET_CONFIG(uint32_t, kMaxWaitReadyMS, General::kWaitTrackReadyMS);
         if (_ticker.elapsedTime() > kMaxWaitReadyMS) {

--- a/src/Common/MediaSink.cpp
+++ b/src/Common/MediaSink.cpp
@@ -109,16 +109,16 @@ void MediaSink::checkTrackIfReady() {
 
     // 等待音频超时时间
     GET_CONFIG(uint32_t, kWaitAudioTrackDataMS, General::kWaitAudioTrackDataMS);
-    if( _max_track_size > 1 ){
-        for (auto it = _track_map.begin(); it != _track_map.end();++it) {
-            if(it->second.first->getTrackType() != TrackAudio){
+    if (_max_track_size > 1) {
+        for (auto it = _track_map.begin(); it != _track_map.end(); ++it) {
+            if (it->second.first->getTrackType() != TrackAudio) {
                 continue;
             }
-            if(_ticker.elapsedTime() > kWaitAudioTrackDataMS &&!it->second.second ){
+            if (_ticker.elapsedTime() > kWaitAudioTrackDataMS && !it->second.second) {
                 // 音频超时且完全没收到音频数据，忽略音频
                 auto index = it->second.first->getIndex();
-                WarnL<<"audio track "<< "index "<<index<<" codec "<< it->second.first->getCodecName()
-                      <<" receive no data for long "<< _ticker.elapsedTime() <<"ms. Ignore it!";
+                WarnL << "audio track " << "index " << index << " codec " << it->second.first->getCodecName() << " receive no data for long "
+                      << _ticker.elapsedTime() << "ms. Ignore it!";
                 it = _track_map.erase(it);
                 _max_track_size -= 1;
                 _track_ready_callback.erase(index);
@@ -126,7 +126,6 @@ void MediaSink::checkTrackIfReady() {
             }
         }
     }
-
 
     if (!_all_track_ready) {
         GET_CONFIG(uint32_t, kMaxWaitReadyMS, General::kWaitTrackReadyMS);

--- a/src/Common/config.cpp
+++ b/src/Common/config.cpp
@@ -81,6 +81,7 @@ const string kMergeWriteMS = GENERAL_FIELD "mergeWriteMS";
 const string kCheckNvidiaDev = GENERAL_FIELD "check_nvidia_dev";
 const string kEnableFFmpegLog = GENERAL_FIELD "enable_ffmpeg_log";
 const string kWaitTrackReadyMS = GENERAL_FIELD "wait_track_ready_ms";
+const string kWaitAudioTrackDataMS = GENERAL_FIELD "wait_audio_track_data_ms";
 const string kWaitAddTrackMS = GENERAL_FIELD "wait_add_track_ms";
 const string kUnreadyFrameCache = GENERAL_FIELD "unready_frame_cache";
 const string kBroadcastPlayerCountChanged = GENERAL_FIELD "broadcast_player_count_changed";
@@ -97,6 +98,7 @@ static onceToken token([]() {
     mINI::Instance()[kCheckNvidiaDev] = 1;
     mINI::Instance()[kEnableFFmpegLog] = 0;
     mINI::Instance()[kWaitTrackReadyMS] = 10000;
+    mINI::Instance()[kWaitAudioTrackDataMS] = 1000;
     mINI::Instance()[kWaitAddTrackMS] = 3000;
     mINI::Instance()[kUnreadyFrameCache] = 100;
     mINI::Instance()[kBroadcastPlayerCountChanged] = 0;

--- a/src/Common/config.h
+++ b/src/Common/config.h
@@ -195,6 +195,9 @@ extern const std::string kCheckNvidiaDev;
 extern const std::string kEnableFFmpegLog;
 // 最多等待未初始化的Track 10秒，超时之后会忽略未初始化的Track
 extern const std::string kWaitTrackReadyMS;
+//最多等待音频Track收到数据时间，单位毫秒，超时且完全没收到音频数据，忽略音频Track
+//加快某些带封装的流metadata说明有音频，但是实际上没有的流ready时间（比如很多厂商的GB28181 PS）
+extern const std::string kWaitAudioTrackDataMS;
 // 如果直播流只有单Track，最多等待3秒，超时后未收到其他Track的数据，则认为是单Track
 // 如果协议元数据有声明特定track数，那么无此等待时间
 extern const std::string kWaitAddTrackMS;


### PR DESCRIPTION
### Problem Analysis
#### ZLM Log Analysis:
![image](https://github.com/user-attachments/assets/dc8011b1-4be3-4636-824b-1745596d8fd8)
#### PS Stream Encapsulation Analysis:
![image](https://github.com/user-attachments/assets/68012194-46b4-4d93-82fb-fd7758fd3967)
- The PS container declares a system header with a video track stream_id of E0 and an audio track stream_id of C0.
![image](https://github.com/user-attachments/assets/9a04d7fe-7ce1-412a-9f16-0bf8f3447095)
- In fact, the entire PS stream only contains PES packets with a stream id of E0, without any audio data.

#### Cause
- ZLM uses an mpegps parsing library that parses the video track and audio track from the system header.
- The absence of audio causes a wait_track_ready_ms delay, which defaults to 10 seconds.
- Many manufacturers' single-video PS streams have this issue. Using ZLM to receive such PS streams will result in a long wait before playback.

#### Modified Result
![image](https://github.com/user-attachments/assets/c86fee46-57d2-41ce-85e0-e1d52e064720)

- After adding this judgment, if no audio track data is received within 1 second from the start of RTP reception, the audio is ignored, speeding up the Ready process.
- It can be seen that the single video GB28181 stream no longer needs to wait for wait_track_ready_ms to be Ready, and can quickly become Ready.

>### 问题分析
#### ZLM日志分析:
![image](https://github.com/user-attachments/assets/dc8011b1-4be3-4636-824b-1745596d8fd8)
#### PS流封装分析:
![image](https://github.com/user-attachments/assets/68012194-46b4-4d93-82fb-fd7758fd3967)
- PS容器内system header声明具有 视频track stream_id 为 E0 。音频track stream_id 为 C0 
![image](https://github.com/user-attachments/assets/9a04d7fe-7ce1-412a-9f16-0bf8f3447095)
- 实际上整个PS流内部只包含stream id 为 E0 的 PES包，不含音频数据

#### 原因
- ZLM 使用的mpegps解析库会从system header里面解析到视频 track和音频track
- 由于不存在音频会引起wait_track_ready_ms等待，默认10S
- 很多厂商的单视频PS都存在这种情况。使用ZLM接收这种PS流都会经历长时间的等待才能观看

#### 修改后结果
![image](https://github.com/user-attachments/assets/c86fee46-57d2-41ce-85e0-e1d52e064720)

- 增加此判断后，如果从addTrack开始计算，超过1S都完全收不到音频Track数据，忽略音频。加快Ready速度
- 可见单视频的GB28181流Ready不再需要等待wait_track_ready_ms，迅速Ready


`TRANS_BY_GITHUB_AI_ASSISTANT`