### PR TITLE
/index/api/stack/reset Calling channel destructor multiple times with the same URL and different resolutions does not render the image

### DIFF
--- a/server/VideoStack.cpp
+++ b/server/VideoStack.cpp
@@ -23,7 +23,11 @@
 
 INSTANCE_IMP(VideoStackManager)
 
-Param::~Param() { VideoStackManager::Instance().unrefChannel(id, width, height, pixfmt); }
+Param::~Param() {
+    auto strongChn= weak_chn.lock();
+    if (!strongChn) { return; }
+    VideoStackManager::Instance().unrefChannel(id, width, height, pixfmt); 
+}
 
 Channel::Channel(const std::string& id, int width, int height, AVPixelFormat pixfmt)
     : _id(id), _width(width), _height(height), _pixfmt(pixfmt) {

--- a/server/VideoStack.cpp
+++ b/server/VideoStack.cpp
@@ -282,7 +282,9 @@ void VideoStack::start() {
 
                 _dev->inputYUV((char**)_buffer->get()->data, _buffer->get()->linesize, pts);
                 pts += frameInterval;
-            }
+            } else {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }  
         }
     });
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/598b5d70-dd13-4b0e-b9b3-3de828d15328)
/index/api/stack/reset The issue of calling channel destructor multiple times with the same URL and resolution without rendering a frame
is in the VideoStackManager::parseParams function where multiple (*params)[i * cols + j] = nullptr; causes the channel counter to be 0, resulting in no frame being rendered when the destructor is called

>![image](https://github.com/user-attachments/assets/598b5d70-dd13-4b0e-b9b3-3de828d15328)
/index/api/stack/reset 在相同url和通分辨率多次调用channel析构没画面的问题
是在 VideoStackManager::parseParams 函数里 多次 (*params)[i * cols + j] = nullptr; 导致 channel 计数器为0，析构没画面

`TRANS_BY_GITHUB_AI_ASSISTANT`