### PR TITLE
feat: 新增代理信息列表 HTTP API

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+build
+release

--- a/postman/ZLMediaKit.postman_collection.json
+++ b/postman/ZLMediaKit.postman_collection.json
@@ -2226,6 +2226,31 @@
 			"response": []
 		},
 		{
+			"name": "拉流代理信息列表(getProxyList)",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{ZLMediaKit_URL}}/index/api/getProxyList?secret={{ZLMediaKit_secret}}",
+					"host": [
+						"{{ZLMediaKit_URL}}"
+					],
+					"path": [
+						"index",
+						"api",
+						"getProxyList"
+					],
+					"query": [
+						{
+							"key": "secret",
+							"value": "{{ZLMediaKit_secret}}"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "获取推流代理信息(getProxyPusherInfo)",
 			"request": {
 				"method": "GET",
@@ -2248,6 +2273,31 @@
 						{
 							"key": "key",
 							"value": "rtmp/__defaultVhost__/live/test/f40a8ab006cac16ecc0858409e890491"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "推流代理信息列表(getProxyPusherList)",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{ZLMediaKit_URL}}/index/api/getProxyPusherList?secret={{ZLMediaKit_secret}}&key=rtmp/__defaultVhost__/live/test/f40a8ab006cac16ecc0858409e890491",
+					"host": [
+						"{{ZLMediaKit_URL}}"
+					],
+					"path": [
+						"index",
+						"api",
+						"getProxyPusherList"
+					],
+					"query": [
+						{
+							"key": "secret",
+							"value": "{{ZLMediaKit_secret}}"
 						}
 					]
 				}

--- a/server/WebApi.cpp
+++ b/server/WebApi.cpp
@@ -1747,6 +1747,19 @@ void installWebApi() {
         invoker(200, headerOut, val.toStyledString());
     });
 
+    api_regist("/index/api/getProxyPusherList", [](API_ARGS_MAP_ASYNC) {
+        CHECK_SECRET();
+        for (auto &pr : s_pusher_proxy._map) {
+            Value obj;
+            obj["key"] = pr.first;
+            obj["status"] = pr.second->getStatus();
+            obj["liveSecs"] = pr.second->getLiveSecs();
+            obj["rePublishCount"] = pr.second->getRePublishCount();
+            val["data"].append(obj);
+        }
+        invoker(200, headerOut, val.toStyledString());
+    });
+
     api_regist("/index/api/getProxyInfo", [](API_ARGS_MAP_ASYNC) {
         CHECK_SECRET();
         CHECK_ARGS("key");
@@ -1758,6 +1771,19 @@ void installWebApi() {
         val["data"]["status"] = proxy->getStatus();
         val["data"]["liveSecs"] = proxy->getLiveSecs();
         val["data"]["rePullCount"] = proxy->getRePullCount();
+        invoker(200, headerOut, val.toStyledString());
+    });
+
+    api_regist("/index/api/getProxyList", [](API_ARGS_MAP_ASYNC) {
+        CHECK_SECRET();
+        for (auto &pr : s_player_proxy._map) {
+            Value obj;
+            obj["key"] = pr.first;
+            obj["status"] = pr.second->getStatus();
+            obj["liveSecs"] = pr.second->getLiveSecs();
+            obj["rePullCount"] = pr.second->getRePullCount();
+            val["data"].append(obj);
+        }
         invoker(200, headerOut, val.toStyledString());
     });
 

--- a/server/WebApi.cpp
+++ b/server/WebApi.cpp
@@ -1749,6 +1749,7 @@ void installWebApi() {
 
     api_regist("/index/api/getProxyPusherList", [](API_ARGS_MAP_ASYNC) {
         CHECK_SECRET();
+        std::lock_guard<std::recursive_mutex> lck(s_pusher_proxy._mtx);
         for (auto &pr : s_pusher_proxy._map) {
             Value obj;
             obj["key"] = pr.first;
@@ -1776,6 +1777,7 @@ void installWebApi() {
 
     api_regist("/index/api/getProxyList", [](API_ARGS_MAP_ASYNC) {
         CHECK_SECRET();
+        std::lock_guard<std::recursive_mutex> lck(s_player_proxy._mtx);
         for (auto &pr : s_player_proxy._map) {
             Value obj;
             obj["key"] = pr.first;

--- a/www/swagger/openapi.json
+++ b/www/swagger/openapi.json
@@ -4163,6 +4163,32 @@
                 }
             }
         },
+        "/index/api/getProxyList": {
+            "get": {
+                "tags": [
+                    "GET"
+                ],
+                "summary": "\u62c9\u6d41\u4ee3\u7406\u4fe1\u606f\u5217\u8868(getProxyList)",
+                "parameters": [
+                    {
+                        "name": "secret",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "example": "FTRaFEWs08KeTxKEEO25ePDKuV3CjOqp"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application/json": {}
+                        }
+                    }
+                }
+            }
+        },
         "/index/api/getProxyPusherInfo": {
             "get": {
                 "tags": [
@@ -4217,6 +4243,32 @@
                             "type": "string"
                         },
                         "example": "rtmp/__defaultVhost__/live/test/f40a8ab006cac16ecc0858409e890491"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "/index/api/getProxyPusherList": {
+            "get": {
+                "tags": [
+                    "GET"
+                ],
+                "summary": "\u63a8\u6d41\u4ee3\u7406\u4fe1\u606f\u5217\u8868(getProxyPusherList)",
+                "parameters": [
+                    {
+                        "name": "secret",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "example": "FTRaFEWs08KeTxKEEO25ePDKuV3CjOqp"
                     }
                 ],
                 "responses": {


### PR DESCRIPTION
新增以下 HTTP API：
- /index/api/getProxyList
- /index/api/getProxyPusherList

原因：
當 pull proxy 因為 upstream 中斷連線後自動會進行重試。此時雖然使用 getMediaList 是沒有串流的，但該 proxy 仍舊存在。

新增此 API 可以檢查目前仍在活躍中的所有 proxy。