### PR TITLE
fix: 当出现dts回退时,应该取frame->dts(), 即MIN

### DIFF
--- a/src/Record/MP4Recorder.cpp
+++ b/src/Record/MP4Recorder.cpp
@@ -126,7 +126,7 @@ bool MP4Recorder::inputFrame(const Frame::Ptr &frame) {
         if (_last_dts == 0 || _last_dts > frame->dts()) {
             // b帧情况下dts时间戳可能回退  [AUTO-TRANSLATED:1de38f77]
             // In the case of b-frames, the dts timestamp may regress
-            _last_dts = MAX(frame->dts(), _last_dts);
+            _last_dts = MIN(frame->dts(), _last_dts);
         }
         auto duration = 5u; // 默认至少一帧5ms
         if (frame->dts() > 0 && frame->dts() > _last_dts) {


### PR DESCRIPTION
当出现dts回退时,应该取frame->dts(), 即MIN, 非MAX