### PR TITLE
feat(cmake): add macro ZLMediaKit_PARENT_DIR / ZLMediaKit_PARENT_DIR_LENGTH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,11 @@ set(CMAKE_VERBOSE_MAKEFILE ON CACHE INTERNAL "" FORCE)
 # TODO: include 当前目录会导致 server 编译出错, 待排除
 set(CMAKE_INCLUDE_CURRENT_DIR OFF)
 
+get_filename_component(ZLMediaKit_PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY)
+string(LENGTH "${ZLMediaKit_PARENT_DIR}" ZLMediaKit_PREFIX_LENGTH)
+add_definitions(-DZLMediaKit_PARENT_DIR=\"${ZLMediaKit_PARENT_DIR}\")
+add_definitions(-DZLMediaKit_PARENT_DIR_LENGTH=${ZLMediaKit_PREFIX_LENGTH})
+
 # 安装路径
 # Install path
 if(NOT CMAKE_INSTALL_PREFIX)


### PR DESCRIPTION
ref link: https://github.com/ZLMediaKit/ZLToolKit/pull/257

update assert message format in Assert_Throw

like:

Assertion failed: (false), at ZLMediaKit/ext-codec/H264Rtmp.cpp#42@foobar