### PR TITLE
fix: 提前判断操作的是否为目录,避免对目录进行mmap操作，导致程序崩溃。

### DIFF
--- a/src/Http/HttpBody.cpp
+++ b/src/Http/HttpBody.cpp
@@ -194,6 +194,13 @@ static std::shared_ptr<char> getSharedMmap(const string &file_path, int64_t &fil
 }
 
 HttpFileBody::HttpFileBody(const string &file_path, bool use_mmap) {
+
+    // 判断是否为目录，避免对目录进行mmap操作，导致程序崩溃。
+    if (File::is_dir(file_path)) {
+        _read_to = -1;
+        return;
+    }
+
     if (use_mmap ) {
         _map_addr = getSharedMmap(file_path, _read_to);       
     }


### PR DESCRIPTION
## 根本原因
在`HttpBody.cpp`中，`getSharedMmap`函数直接尝试对所有路径进行mmap操作，没有进行文件类型检查。

## 修复方案
 添加目录检查