### PR TITLE
 修复http代理的两个问题，原http代理功能提交（#2988）：d593267

### DIFF
--- a/src/Http/HlsPlayer.cpp
+++ b/src/Http/HlsPlayer.cpp
@@ -133,6 +133,10 @@ void HlsPlayer::fetchSegment() {
         if (!(*this)[Client::kNetAdapter].empty()) {
             _http_ts_player->setNetAdapter((*this)[Client::kNetAdapter]);
         }
+    } else {
+        // 每次请求新的ts片段时重置HttpTSPlayer状态
+        _http_ts_player->clear();
+        _http_ts_player->setProxyUrl((*this)[Client::kProxyUrl]);
     }
 
     Ticker ticker;


### PR DESCRIPTION
    1. CONNECT请求添加Host字段， 解决400 bad request问题；
    2. HLS拉取第2个ts分片时，重新设置http代理，解决第2个分片及后续分片未走代理的问题。