### PR TITLE
fix: SrtCaller and SrtSession crash

### DIFF
--- a/src/Srt/SrtCaller.cpp
+++ b/src/Srt/SrtCaller.cpp
@@ -80,21 +80,23 @@ SrtCaller::~SrtCaller(void) {
 void SrtCaller::onConnect() {
     //DebugL;
 
-    auto peer_addr = SockUtil::make_sockaddr(_url._host.c_str(), (_url._port));
-    _socket = Socket::createSocket(_poller, false);
-    _socket->bindUdpSock(0, SockUtil::is_ipv4(_url._host.data()) ? "0.0.0.0" : "::");
-    _socket->bindPeerAddr((struct sockaddr *)&peer_addr, 0, true);
+    getPoller()->async([&]() {
+        auto peer_addr = SockUtil::make_sockaddr(_url._host.c_str(), (_url._port));
+        _socket = Socket::createSocket(_poller, false);
+        _socket->bindUdpSock(0, SockUtil::is_ipv4(_url._host.data()) ? "0.0.0.0" : "::");
+        _socket->bindPeerAddr((struct sockaddr *)&peer_addr, 0, true);
 
-    weak_ptr<SrtCaller> weak_self = shared_from_this();
-    _socket->setOnRead([weak_self](const Buffer::Ptr &buf, struct sockaddr *addr, int addr_len) mutable {
-        auto strong_self = weak_self.lock();
-        if (!strong_self) {
-            return;
-        }
-        strong_self->inputSockData((uint8_t*)buf->data(), buf->size(), addr);
+        weak_ptr<SrtCaller> weak_self = shared_from_this();
+        _socket->setOnRead([weak_self](const Buffer::Ptr &buf, struct sockaddr *addr, int addr_len) mutable {
+            auto strong_self = weak_self.lock();
+            if (!strong_self) {
+                return;
+            }
+            strong_self->inputSockData((uint8_t*)buf->data(), buf->size(), addr);
+        });
+
+        doHandshake();
     });
-
-    doHandshake();
 }
 
 void SrtCaller::onResult(const SockException &ex) {
@@ -757,6 +759,11 @@ void SrtCaller::handleACKACK(uint8_t *buf, int len, struct sockaddr *addr) {
 }
 
 void SrtCaller::handleNAK(uint8_t *buf, int len, struct sockaddr *addr) {
+    if (isPlayer()) {
+        //player should not handle nak 
+        return;
+    }
+
     //TraceL;
     NAKPacket pkt;
     pkt.loadFromData(buf, len);
@@ -783,6 +790,11 @@ void SrtCaller::handleNAK(uint8_t *buf, int len, struct sockaddr *addr) {
 }
 
 void SrtCaller::handleDropReq(uint8_t *buf, int len, struct sockaddr *addr) {
+    if (!isPlayer()) {
+        //pusher should not handle drop req
+        return;
+    }
+
     MsgDropReqPacket pkt;
     pkt.loadFromData(buf, len);
     std::list<DataPacket::Ptr> list;

--- a/srt/HSExt.cpp
+++ b/srt/HSExt.cpp
@@ -83,8 +83,10 @@ bool HSExtStreamID::loadFromData(uint8_t *buf, size_t len) {
         ptr += 4;
     }
     char zero = 0x00;
-    if (streamid.back() == zero) {
-        streamid.erase(streamid.find_first_of(zero), streamid.size());
+    if (!streamid.empty()) {
+        if (streamid.back() == zero) {
+            streamid.erase(streamid.find_first_of(zero), streamid.size());
+        }
     }
     return true;
 }


### PR DESCRIPTION
1.修改SrtCaller 多线程发送造成的crash
2.修改SrtCaller 接收的期望外的控制包可能造成的空指针引用
3.修改异常的streamid ext可能造成的crash