### PR TITLE
`src/Record/Recorder.h` 引入 `<cstdint>` 头文件

### DIFF
--- a/src/Record/Recorder.h
+++ b/src/Record/Recorder.h
@@ -13,6 +13,7 @@
 
 #include <memory>
 #include <string>
+#include <cstdint>
 
 namespace mediakit {
 class MediaSinkInterface;


### PR DESCRIPTION
CMake 构建编译报错，需要在 `src/Record/Recorder.h` 中引入 `<cstdint>` 头文件。