### PR TITLE
BUG修正：loadMP4File播放文件时，无人观看触发关闭，导致程序崩溃

### DIFF
--- a/src/Common/MediaSource.cpp
+++ b/src/Common/MediaSource.cpp
@@ -700,7 +700,7 @@ void MediaSourceEvent::onReaderChanged(MediaSource &sender, int size){
             strong_sender->close(false);
         }
         return false;
-    }, nullptr);
+    }, this->getOwnerPoller(sender));
 }
 
 string MediaSourceEvent::getOriginUrl(MediaSource &sender) const {


### PR DESCRIPTION
关闭文件播放的处理与文件播放动作不在一个线程，导致崩溃。