### PR TITLE
addxxx接口和onpublish保存用户上下文数据，回调中回传

### DIFF
--- a/server/FFmpegSource.h
+++ b/server/FFmpegSource.h
@@ -11,17 +11,17 @@
 #ifndef FFMPEG_SOURCE_H
 #define FFMPEG_SOURCE_H
 
-#include <mutex>
-#include <memory>
-#include <functional>
+#include "Common/MediaSource.h"
 #include "Process.h"
 #include "Util/TimeTicker.h"
-#include "Common/MediaSource.h"
+#include <functional>
+#include <memory>
+#include <mutex>
 
 namespace FFmpeg {
-    extern const std::string kSnap;
-    extern const std::string kBin;
-}
+extern const std::string kSnap;
+extern const std::string kBin;
+} // namespace FFmpeg
 
 class FFmpegSnap {
 public:
@@ -46,7 +46,9 @@ private:
     ~FFmpegSnap() = delete;
 };
 
-class FFmpegSource : public std::enable_shared_from_this<FFmpegSource> , public mediakit::MediaSourceEventInterceptor{
+class FFmpegSource
+    : public std::enable_shared_from_this<FFmpegSource>
+    , public mediakit::MediaSourceEventInterceptor {
 public:
     using Ptr = std::shared_ptr<FFmpegSource>;
     using onPlay = std::function<void(const toolkit::SockException &ex)>;
@@ -57,7 +59,7 @@ public:
     /**
      * 设置主动关闭回调
      * Set the active close callback
-     
+
      * [AUTO-TRANSLATED:2134a5b3]
      */
     void setOnClose(const std::function<void()> &cb);
@@ -70,21 +72,22 @@ public:
      * @param timeout_ms 等待结果超时时间，单位毫秒
      * @param cb 成功与否回调
      * Start playing the URL
-     * @param ffmpeg_cmd_key FFmpeg stream command configuration item key, users can set multiple command parameter templates in the configuration file at the same time
+     * @param ffmpeg_cmd_key FFmpeg stream command configuration item key, users can set multiple command parameter templates in the configuration file at the
+     same time
      * @param src_url FFmpeg stream address
      * @param dst_url FFmpeg push stream address
      * @param timeout_ms Timeout for waiting for the result, in milliseconds
      * @param cb Success or failure callback
-     
+
      * [AUTO-TRANSLATED:2c35789e]
      */
     void play(const std::string &ffmpeg_cmd_key, const std::string &src_url, const std::string &dst_url, int timeout_ms, const onPlay &cb);
 
-    const std::string& getSrcUrl() const { return _src_url; }
-    const std::string& getDstUrl() const { return _dst_url; }
-    const std::string& getCmd() const { return _cmd; }
-    const std::string& getCmdKey() const { return _ffmpeg_cmd_key; }
-    const mediakit::MediaInfo& getMediaInfo() const { return _media_info; }
+    const std::string &getSrcUrl() const { return _src_url; }
+    const std::string &getDstUrl() const { return _dst_url; }
+    const std::string &getCmd() const { return _cmd; }
+    const std::string &getCmdKey() const { return _ffmpeg_cmd_key; }
+    const mediakit::MediaInfo &getMediaInfo() const { return _media_info; }
 
     /**
      * 设置录制
@@ -93,13 +96,19 @@ public:
      * Set recording
      * @param enable_hls Whether to enable HLS live streaming or recording
      * @param enable_mp4 Whether to record MP4
-     
+
      * [AUTO-TRANSLATED:9f28d5c2]
      */
     void setupRecordFlag(bool enable_hls, bool enable_mp4);
 
+    /**
+     * 设置用户调用时保存的上下文数据
+     * @param userdata 用户调用保存的上下文数据
+     */
+    void setMediaInfoUserdata(const std::string &userdata);
+
 private:
-    void findAsync(int maxWaitMS ,const std::function<void(const mediakit::MediaSource::Ptr &src)> &cb);
+    void findAsync(int maxWaitMS, const std::function<void(const mediakit::MediaSource::Ptr &src)> &cb);
     void startTimer(int timeout_ms);
     void onGetMediaSource(const mediakit::MediaSource::Ptr &src);
 
@@ -129,5 +138,4 @@ private:
     toolkit::Ticker _replay_ticker;
 };
 
-
-#endif //FFMPEG_SOURCE_H
+#endif // FFMPEG_SOURCE_H

--- a/server/WebApi.cpp
+++ b/server/WebApi.cpp
@@ -9,9 +9,9 @@
  */
 
 #include <exception>
-#include <sys/stat.h>
 #include <math.h>
 #include <signal.h>
+#include <sys/stat.h>
 
 #ifdef _WIN32
 #include <io.h>
@@ -19,51 +19,51 @@
 #include <tchar.h>
 #endif // _WIN32
 
-#include <functional>
-#include <unordered_map>
-#include <regex>
-#include "Util/MD5.h"
-#include "Util/util.h"
-#include "Util/File.h"
-#include "Util/logger.h"
-#include "Util/onceToken.h"
-#include "Util/NoticeCenter.h"
 #include "Network/TcpServer.h"
 #include "Network/UdpServer.h"
 #include "Thread/WorkThreadPool.h"
+#include "Util/File.h"
+#include "Util/MD5.h"
+#include "Util/NoticeCenter.h"
+#include "Util/logger.h"
+#include "Util/onceToken.h"
+#include "Util/util.h"
+#include <functional>
+#include <regex>
+#include <unordered_map>
 
 #ifdef ENABLE_MYSQL
 #include "Util/SqlPool.h"
-#endif //ENABLE_MYSQL
+#endif // ENABLE_MYSQL
 
+#include "FFmpegSource.h"
 #include "WebApi.h"
 #include "WebHook.h"
-#include "FFmpegSource.h"
 
-#include "Common/config.h"
 #include "Common/MediaSource.h"
-#include "Http/HttpSession.h"
+#include "Common/config.h"
 #include "Http/HttpRequester.h"
+#include "Http/HttpSession.h"
 #include "Player/PlayerProxy.h"
 #include "Pusher/PusherProxy.h"
-#include "Rtp/RtpProcess.h"
 #include "Record/MP4Reader.h"
+#include "Rtp/RtpProcess.h"
 
 #if defined(ENABLE_RTPPROXY)
 #include "Rtp/RtpServer.h"
 #endif
 
 #ifdef ENABLE_WEBRTC
+#include "../webrtc/WebRtcEchoTest.h"
 #include "../webrtc/WebRtcPlayer.h"
 #include "../webrtc/WebRtcPusher.h"
-#include "../webrtc/WebRtcEchoTest.h"
 #endif
 
 #if defined(ENABLE_VERSION)
 #include "ZLMVersion.h"
 #endif
 
-#if defined(ENABLE_VIDEOSTACK) && defined(ENABLE_X264) && defined (ENABLE_FFMPEG)
+#if defined(ENABLE_VIDEOSTACK) && defined(ENABLE_X264) && defined(ENABLE_FFMPEG)
 #include "VideoStack.h"
 #endif
 
@@ -74,11 +74,11 @@ using namespace mediakit;
 
 namespace API {
 #define API_FIELD "api."
-const string kApiDebug = API_FIELD"apiDebug";
-const string kSecret = API_FIELD"secret";
-const string kSnapRoot = API_FIELD"snapRoot";
-const string kDefaultSnap = API_FIELD"defaultSnap";
-const string kDownloadRoot = API_FIELD"downloadRoot";
+const string kApiDebug = API_FIELD "apiDebug";
+const string kSecret = API_FIELD "secret";
+const string kSnapRoot = API_FIELD "snapRoot";
+const string kDefaultSnap = API_FIELD "defaultSnap";
+const string kDownloadRoot = API_FIELD "downloadRoot";
 
 static onceToken token([]() {
     mINI::Instance()[kApiDebug] = "1";
@@ -87,21 +87,21 @@ static onceToken token([]() {
     mINI::Instance()[kDefaultSnap] = "./www/logo.png";
     mINI::Instance()[kDownloadRoot] = "./www";
 });
-}//namespace API
+} // namespace API
 
 using HttpApi = function<void(const Parser &parser, const HttpSession::HttpResponseInvoker &invoker, SockInfo &sender)>;
 // http api列表  [AUTO-TRANSLATED:a05e9d9d]
 // http api list
 static map<string, HttpApi, StrCaseCompare> s_map_api;
 
-static void responseApi(const Json::Value &res, const HttpSession::HttpResponseInvoker &invoker){
+static void responseApi(const Json::Value &res, const HttpSession::HttpResponseInvoker &invoker) {
     GET_CONFIG(string, charSet, Http::kCharSet);
     HttpSession::KeyValue headerOut;
     headerOut["Content-Type"] = string("application/json; charset=") + charSet;
     invoker(200, headerOut, res.toStyledString());
 };
 
-static void responseApi(int code, const string &msg, const HttpSession::HttpResponseInvoker &invoker){
+static void responseApi(int code, const string &msg, const HttpSession::HttpResponseInvoker &invoker) {
     Json::Value res;
     res["code"] = code;
     res["msg"] = msg;
@@ -198,11 +198,11 @@ void api_regist(const string &api_path, const function<void(API_ARGS_JSON_ASYNC)
     s_map_api.emplace(api_path, toApi(func));
 }
 
-void api_regist(const string &api_path, const function<void(API_ARGS_STRING)> &func){
+void api_regist(const string &api_path, const function<void(API_ARGS_STRING)> &func) {
     s_map_api.emplace(api_path, toApi(func));
 }
 
-void api_regist(const string &api_path, const function<void(API_ARGS_STRING_ASYNC)> &func){
+void api_regist(const string &api_path, const function<void(API_ARGS_STRING_ASYNC)> &func) {
     s_map_api.emplace(api_path, toApi(func));
 }
 
@@ -231,7 +231,7 @@ static ApiArgsType getAllArgs(const Parser &parser) {
         WarnL << "invalid Content-Type:" << parser["Content-Type"];
     }
 
-    for (auto &pr :  parser.getUrlArgs()) {
+    for (auto &pr : parser.getUrlArgs()) {
         allArgs[pr.first] = pr.second;
     }
     return allArgs;
@@ -243,11 +243,11 @@ extern uint64_t getThisThreadMemUsage();
 extern uint64_t getThisThreadMemBlock();
 extern std::vector<size_t> getBlockTypeSize();
 extern uint64_t getTotalMemBlockByType(int type);
-extern uint64_t getThisThreadMemBlockByType(int type) ;
+extern uint64_t getThisThreadMemBlockByType(int type);
 
 static void *web_api_tag = nullptr;
 
-static inline void addHttpListener(){
+static inline void addHttpListener() {
     GET_CONFIG(bool, api_debug, API::kApiDebug);
     // 注册监听kBroadcastHttpRequest事件  [AUTO-TRANSLATED:4af22c90]
     // Register to listen for the kBroadcastHttpRequest event
@@ -260,7 +260,7 @@ static inline void addHttpListener(){
         // This API has been consumed
         consumed = true;
 
-        if(api_debug){
+        if (api_debug) {
             auto newInvoker = [invoker, parser](int code, const HttpSession::KeyValue &headerOut, const HttpBody::Ptr &body) {
                 // body默认为空  [AUTO-TRANSLATED:4fd4ecc8]
                 // The body is empty by default
@@ -291,26 +291,28 @@ static inline void addHttpListener(){
                     invoker(code, headerOut, body);
                 }
             };
-            ((HttpSession::HttpResponseInvoker &) invoker) = newInvoker;
+            ((HttpSession::HttpResponseInvoker &)invoker) = newInvoker;
         }
         auto helper = static_cast<SocketHelper &>(sender).shared_from_this();
         // 在本poller线程下一次事件循环时执行http api，防止占用NoticeCenter的锁
-        helper->getPoller()->async([it, parser, invoker, helper]() {
-            try {
-                it->second(parser, invoker, *helper);
-            } catch (ApiRetException &ex) {
-                responseApi(ex.code(), ex.what(), invoker);
-                helper->getPoller()->async([helper, ex]() { helper->shutdown(SockException(Err_shutdown, ex.what())); }, false);
-            }
+        helper->getPoller()->async(
+            [it, parser, invoker, helper]() {
+                try {
+                    it->second(parser, invoker, *helper);
+                } catch (ApiRetException &ex) {
+                    responseApi(ex.code(), ex.what(), invoker);
+                    helper->getPoller()->async([helper, ex]() { helper->shutdown(SockException(Err_shutdown, ex.what())); }, false);
+                }
 #ifdef ENABLE_MYSQL
-            catch (SqlException &ex) {
-                responseApi(API::SqlFailed, StrPrinter << "操作数据库失败:" << ex.what() << ":" << ex.getSql(), invoker);
-            }
+                catch (SqlException &ex) {
+                    responseApi(API::SqlFailed, StrPrinter << "操作数据库失败:" << ex.what() << ":" << ex.getSql(), invoker);
+                }
 #endif // ENABLE_MYSQL
-            catch (std::exception &ex) {
-                responseApi(API::Exception, ex.what(), invoker);
-            }
-        },false);
+                catch (std::exception &ex) {
+                    responseApi(API::Exception, ex.what(), invoker);
+                }
+            },
+            false);
     });
 }
 
@@ -334,7 +336,7 @@ public:
         return _map.erase(key);
     }
 
-    size_t size() { 
+    size_t size() {
         std::lock_guard<std::recursive_mutex> lck(_mtx);
         return _map.size();
     }
@@ -348,7 +350,7 @@ public:
         return it->second;
     }
 
-    void for_each(const std::function<void(const std::string&, const Pointer&)>& cb) {
+    void for_each(const std::function<void(const std::string &, const Pointer &)> &cb) {
         std::lock_guard<std::recursive_mutex> lck(_mtx);
         auto it = _map.begin();
         while (it != _map.end()) {
@@ -357,8 +359,8 @@ public:
         }
     }
 
-    template<class ..._Args>
-    Pointer make(const std::string &key, _Args&& ...__args) {
+    template <class... _Args>
+    Pointer make(const std::string &key, _Args &&...__args) {
         // assert(!find(key));
 
         auto server = std::make_shared<Type>(std::forward<_Args>(__args)...);
@@ -368,8 +370,8 @@ public:
         return server;
     }
 
-    template<class ..._Args>
-    Pointer makeWithAction(const std::string &key, function<void(Pointer)> action, _Args&& ...__args) {
+    template <class... _Args>
+    Pointer makeWithAction(const std::string &key, function<void(Pointer)> action, _Args &&...__args) {
         // assert(!find(key));
 
         auto server = std::make_shared<Type>(std::forward<_Args>(__args)...);
@@ -399,13 +401,11 @@ static ServiceController<FFmpegSource> s_ffmpeg_src;
 static ServiceController<RtpServer> s_rtp_server;
 #endif
 
-
-static inline string getPusherKey(const string &schema, const string &vhost, const string &app, const string &stream,
-                                  const string &dst_url) {
+static inline string getPusherKey(const string &schema, const string &vhost, const string &app, const string &stream, const string &dst_url) {
     return schema + "/" + vhost + "/" + app + "/" + stream + "/" + MD5(dst_url).hexdigest();
 }
 
-static void fillSockInfo(Value& val, SockInfo* info) {
+static void fillSockInfo(Value &val, SockInfo *info) {
     val["peer_ip"] = info->get_peer_ip();
     val["peer_port"] = info->get_peer_port();
     val["local_port"] = info->get_local_port();
@@ -413,21 +413,22 @@ static void fillSockInfo(Value& val, SockInfo* info) {
     val["identifier"] = info->getIdentifier();
 }
 
-void dumpMediaTuple(const MediaTuple &tuple, Json::Value& item) {
+void dumpMediaTuple(const MediaTuple &tuple, Json::Value &item) {
     item[VHOST_KEY] = tuple.vhost;
     item["app"] = tuple.app;
     item["stream"] = tuple.stream;
     item["params"] = tuple.params;
+    item["userdata"] = tuple.userdata;
 }
 
-Value ToJson(const PusherProxy::Ptr& p) {
+Value ToJson(const PusherProxy::Ptr &p) {
     Value item;
     item["url"] = p->getUrl();
     item["status"] = p->getStatus();
     item["liveSecs"] = p->getLiveSecs();
-    item["rePublishCount"] = p->getRePublishCount();    
-    item["bytesSpeed"] = (Json::UInt64) p->getSendSpeed();
-    item["totalBytes"] =(Json::UInt64) p->getSendTotalBytes();
+    item["rePublishCount"] = p->getRePublishCount();
+    item["bytesSpeed"] = (Json::UInt64)p->getSendSpeed();
+    item["totalBytes"] = (Json::UInt64)p->getSendTotalBytes();
 
     if (auto src = p->getSrc()) {
         dumpMediaTuple(src->getMediaTuple(), item["src"]);
@@ -435,31 +436,31 @@ Value ToJson(const PusherProxy::Ptr& p) {
     return item;
 }
 
-Value ToJson(const PlayerProxy::Ptr& p) {
+Value ToJson(const PlayerProxy::Ptr &p) {
     Value item;
     item["url"] = p->getUrl();
     item["status"] = p->getStatus();
     item["liveSecs"] = p->getLiveSecs();
     item["rePullCount"] = p->getRePullCount();
     item["totalReaderCount"] = p->totalReaderCount();
-    item["bytesSpeed"] = (Json::UInt64) p->getRecvSpeed();
-    item["totalBytes"] = (Json::UInt64) p->getRecvTotalBytes();
+    item["bytesSpeed"] = (Json::UInt64)p->getRecvSpeed();
+    item["totalBytes"] = (Json::UInt64)p->getRecvTotalBytes();
 
     dumpMediaTuple(p->getMediaTuple(), item["src"]);
     return item;
 }
 
-Value makeMediaSourceJson(MediaSource &media){
+Value makeMediaSourceJson(MediaSource &media) {
     Value item;
     item["schema"] = media.getSchema();
     dumpMediaTuple(media.getMediaTuple(), item);
-    item["createStamp"] = (Json::UInt64) media.getCreateStamp();
-    item["aliveSecond"] = (Json::UInt64) media.getAliveSecond();
-    item["bytesSpeed"] = (Json::UInt64) media.getBytesSpeed();
-    item["totalBytes"] = (Json::UInt64) media.getTotalBytes();
+    item["createStamp"] = (Json::UInt64)media.getCreateStamp();
+    item["aliveSecond"] = (Json::UInt64)media.getAliveSecond();
+    item["bytesSpeed"] = (Json::UInt64)media.getBytesSpeed();
+    item["totalBytes"] = (Json::UInt64)media.getTotalBytes();
     item["readerCount"] = media.readerCount();
     item["totalReaderCount"] = media.totalReaderCount();
-    item["originType"] = (int) media.getOriginType();
+    item["originType"] = (int)media.getOriginType();
     item["originTypeStr"] = getOriginTypeString(media.getOriginType());
     item["originUrl"] = media.getOriginUrl();
     item["isRecordingMP4"] = media.isRecording(Recorder::type_mp4);
@@ -472,11 +473,15 @@ Value makeMediaSourceJson(MediaSource &media){
     }
 
     // getLossRate有线程安全问题；使用getMediaInfo接口才能获取丢包率；getMediaList接口将忽略丢包率  [AUTO-TRANSLATED:b2e927c6]
-    // getLossRate has thread safety issues; use the getMediaInfo interface to get the packet loss rate; the getMediaList interface will ignore the packet loss rate
+    // getLossRate has thread safety issues; use the getMediaInfo interface to get the packet loss rate; the getMediaList interface will ignore the packet loss
+    // rate
     auto current_thread = false;
-    try { current_thread = media.getOwnerPoller()->isCurrentThread();} catch (...) {}
+    try {
+        current_thread = media.getOwnerPoller()->isCurrentThread();
+    } catch (...) {
+    }
     float last_loss = -1;
-    for(auto &track : media.getTracks(false)){
+    for (auto &track : media.getTracks(false)) {
         Value obj;
         auto codec_type = track->getTrackType();
         obj["codec_id"] = track->getCodecId();
@@ -485,7 +490,8 @@ Value makeMediaSourceJson(MediaSource &media){
         obj["codec_type"] = codec_type;
         if (current_thread) {
             // rtp推流只有一个统计器，但是可能有多个track，如果短时间多次获取间隔丢包率，第二次会获取为-1  [AUTO-TRANSLATED:5bfbc951]
-            // RTP push stream has only one statistics, but may have multiple tracks. If you get the interval packet loss rate multiple times in a short time, the second time will get -1
+            // RTP push stream has only one statistics, but may have multiple tracks. If you get the interval packet loss rate multiple times in a short time,
+            // the second time will get -1
             auto loss = media.getLossRate(codec_type);
             if (loss == -1) {
                 loss = last_loss;
@@ -496,15 +502,15 @@ Value makeMediaSourceJson(MediaSource &media){
         }
         obj["frames"] = track->getFrames();
         obj["duration"] = track->getDuration();
-        switch(codec_type){
-            case TrackAudio : {
+        switch (codec_type) {
+            case TrackAudio: {
                 auto audio_track = dynamic_pointer_cast<AudioTrack>(track);
                 obj["sample_rate"] = audio_track->getAudioSampleRate();
                 obj["channels"] = audio_track->getAudioChannel();
                 obj["sample_bit"] = audio_track->getAudioSampleBit();
                 break;
             }
-            case TrackVideo : {
+            case TrackVideo: {
                 auto video_track = dynamic_pointer_cast<VideoTrack>(track);
                 obj["width"] = video_track->getVideoWidth();
                 obj["height"] = video_track->getVideoHeight();
@@ -520,8 +526,7 @@ Value makeMediaSourceJson(MediaSource &media){
                 obj["gop_interval_ms"] = gop_interval_ms;
                 break;
             }
-            default:
-                break;
+            default: break;
         }
         item["tracks"].append(obj);
     }
@@ -529,7 +534,9 @@ Value makeMediaSourceJson(MediaSource &media){
 }
 
 #if defined(ENABLE_RTPPROXY)
-uint16_t openRtpServer(uint16_t local_port, const mediakit::MediaTuple &tuple, int tcp_mode, const string &local_ip, bool re_use_port, uint32_t ssrc, int only_track, bool multiplex) {
+uint16_t openRtpServer(
+    uint16_t local_port, const mediakit::MediaTuple &tuple, int tcp_mode, const string &local_ip, bool re_use_port, uint32_t ssrc, int only_track,
+    bool multiplex) {
     auto key = tuple.shortUrl();
     if (s_rtp_server.find(key)) {
         // 为了防止RtpProcess所有权限混乱的问题，不允许重复添加相同的key  [AUTO-TRANSLATED:06c7b14c]
@@ -578,9 +585,9 @@ void getStatisticJson(const function<void(Value &val)> &cb) {
     val["RtmpPacket"] = (Json::UInt64)(ObjectStatistic<RtmpPacket>::count());
 #ifdef ENABLE_MEM_DEBUG
     auto bytes = getTotalMemUsage();
-    val["totalMemUsage"] = (Json::UInt64) bytes;
-    val["totalMemUsageMB"] = (int) (bytes >> 20);
-    val["totalMemBlock"] = (Json::UInt64) getTotalMemBlock();
+    val["totalMemUsage"] = (Json::UInt64)bytes;
+    val["totalMemUsageMB"] = (int)(bytes >> 20);
+    val["totalMemBlock"] = (Json::UInt64)getTotalMemBlock();
     static auto block_type_size = getBlockTypeSize();
     {
         int i = 0;
@@ -595,7 +602,7 @@ void getStatisticJson(const function<void(Value &val)> &cb) {
     }
 
     auto thread_size = EventPollerPool::Instance().getExecutorSize() + WorkThreadPool::Instance().getExecutorSize();
-    std::shared_ptr<vector<Value> > thread_mem_info = std::make_shared<vector<Value> >(thread_size);
+    std::shared_ptr<vector<Value>> thread_mem_info = std::make_shared<vector<Value>>(thread_size);
 
     shared_ptr<void> finished(nullptr, [thread_mem_info, cb, obj](void *) {
         for (auto &val : *thread_mem_info) {
@@ -612,9 +619,9 @@ void getStatisticJson(const function<void(Value &val)> &cb) {
         executor.async([finished, &val]() {
             auto bytes = getThisThreadMemUsage();
             val["threadName"] = getThreadName();
-            val["threadMemUsage"] = (Json::UInt64) bytes;
-            val["threadMemUsageMB"] = (Json::UInt64) (bytes >> 20);
-            val["threadMemBlock"] = (Json::UInt64) getThisThreadMemBlock();
+            val["threadMemUsage"] = (Json::UInt64)bytes;
+            val["threadMemUsageMB"] = (Json::UInt64)(bytes >> 20);
+            val["threadMemBlock"] = (Json::UInt64)getThisThreadMemBlock();
             {
                 int i = 0;
                 string str;
@@ -628,9 +635,7 @@ void getStatisticJson(const function<void(Value &val)> &cb) {
             }
         });
     };
-    auto lam1 = [lam0](const TaskExecutor::Ptr &executor) {
-        lam0(*executor);
-    };
+    auto lam1 = [lam0](const TaskExecutor::Ptr &executor) { lam0(*executor); };
     EventPollerPool::Instance().for_each(lam1);
     WorkThreadPool::Instance().for_each(lam1);
 #else
@@ -638,9 +643,9 @@ void getStatisticJson(const function<void(Value &val)> &cb) {
 #endif
 }
 
-void addStreamProxy(const MediaTuple &tuple, const string &url, int retry_count,
-                    const ProtocolOption &option, int rtp_type, float timeout_sec, const mINI &args,
-                    const function<void(const SockException &ex, const string &key)> &cb) {
+void addStreamProxy(
+    const MediaTuple &tuple, const string &url, int retry_count, const ProtocolOption &option, int rtp_type, float timeout_sec, const mINI &args,
+    const function<void(const SockException &ex, const string &key)> &cb) {
     auto key = tuple.shortUrl();
     if (s_player_proxy.find(key)) {
         // 已经在拉流了  [AUTO-TRANSLATED:e06c57d7]
@@ -679,23 +684,13 @@ void addStreamProxy(const MediaTuple &tuple, const string &url, int retry_count,
 
     // 被主动关闭拉流  [AUTO-TRANSLATED:41a19476]
     // The pull stream was actively closed
-    player->setOnClose([key](const SockException &ex) {
-        s_player_proxy.erase(key);
-    });
+    player->setOnClose([key](const SockException &ex) { s_player_proxy.erase(key); });
     player->play(url);
 };
 
-
-void addStreamPusherProxy(const string &schema,
-                          const string &vhost,
-                          const string &app,
-                          const string &stream,
-                          const string &url,
-                          int retry_count,
-                          int rtp_type,
-                          float timeout_sec,
-                          const mINI &args,
-                          const function<void(const SockException &ex, const string &key)> &cb) {
+void addStreamPusherProxy(
+    const string &schema, const string &vhost, const string &app, const string &stream, const string &url, int retry_count, int rtp_type, float timeout_sec,
+    const mINI &args, const function<void(const SockException &ex, const string &key)> &cb) {
     auto key = getPusherKey(schema, vhost, app, stream, url);
     auto src = MediaSource::find(schema, vhost, app, stream);
     if (!src) {
@@ -776,12 +771,12 @@ void getThreadsLoad(TaskExecutorGetterImp &getter, API_ARGS_MAP_ASYNC) {
  * Install api interface
  * All apis support GET and POST methods
  * POST method parameters support application/json and application/x-www-form-urlencoded methods
- 
+
  * [AUTO-TRANSLATED:62e68c43]
  */
 void installWebApi() {
     addHttpListener();
-    GET_CONFIG(string,api_secret,API::kSecret);
+    GET_CONFIG(string, api_secret, API::kSecret);
 
     // 获取线程负载  [AUTO-TRANSLATED:3b0ece5c]
     // Get thread load
@@ -805,11 +800,11 @@ void installWebApi() {
     // Get server configuration
     // 测试url http://127.0.0.1/index/api/getServerConfig  [AUTO-TRANSLATED:59cd0d71]
     // Test url http://127.0.0.1/index/api/getServerConfig
-    api_regist("/index/api/getServerConfig",[](API_ARGS_MAP){
+    api_regist("/index/api/getServerConfig", [](API_ARGS_MAP) {
         CHECK_SECRET();
         Value obj;
         for (auto &pr : mINI::Instance()) {
-            obj[pr.first] = (string &) pr.second;
+            obj[pr.first] = (string &)pr.second;
         }
         val["data"].append(obj);
     });
@@ -820,7 +815,7 @@ void installWebApi() {
     // Test url (e.g. disable http api debugging) http://127.0.0.1/index/api/setServerConfig?api.apiDebug=0
     // 你也可以通过http post方式传参，可以通过application/x-www-form-urlencoded或application/json方式传参  [AUTO-TRANSLATED:d493a7c0]
     // You can also pass parameters through http post method, you can pass parameters through application/x-www-form-urlencoded or application/json methods
-    api_regist("/index/api/setServerConfig",[](API_ARGS_MAP){
+    api_regist("/index/api/setServerConfig", [](API_ARGS_MAP) {
         CHECK_SECRET();
         auto &ini = mINI::Instance();
         int changed = API::Success;
@@ -858,10 +853,9 @@ void installWebApi() {
         val["changed"] = changed;
     });
 
-
-    static auto s_get_api_list = [](API_ARGS_MAP){
+    static auto s_get_api_list = [](API_ARGS_MAP) {
         CHECK_SECRET();
-        for(auto &pr : s_map_api){
+        for (auto &pr : s_map_api) {
             val["data"].append(pr.first);
         }
     };
@@ -870,33 +864,29 @@ void installWebApi() {
     // Get server api list
     // 测试url http://127.0.0.1/index/api/getApiList  [AUTO-TRANSLATED:df09e368]
     // Test url http://127.0.0.1/index/api/getApiList
-    api_regist("/index/api/getApiList",[](API_ARGS_MAP){
-        s_get_api_list(API_ARGS_VALUE);
-    });
+    api_regist("/index/api/getApiList", [](API_ARGS_MAP) { s_get_api_list(API_ARGS_VALUE); });
 
     // 获取服务器api列表  [AUTO-TRANSLATED:e4c0dd9d]
     // Get server api list
     // 测试url http://127.0.0.1/index/  [AUTO-TRANSLATED:76934dd3]
     // Test url http://127.0.0.1/index/
-    api_regist("/index/",[](API_ARGS_MAP){
-        s_get_api_list(API_ARGS_VALUE);
-    });
+    api_regist("/index/", [](API_ARGS_MAP) { s_get_api_list(API_ARGS_VALUE); });
 
 #if !defined(_WIN32)
     // 重启服务器,只有Daemon方式才能重启，否则是直接关闭！  [AUTO-TRANSLATED:9d8a1c32]
     // Restart server, only Daemon mode can restart, otherwise it will be closed directly!
     // 测试url http://127.0.0.1/index/api/restartServer  [AUTO-TRANSLATED:8beaaa8a]
     // Test url http://127.0.0.1/index/api/restartServer
-    api_regist("/index/api/restartServer",[](API_ARGS_MAP){
+    api_regist("/index/api/restartServer", [](API_ARGS_MAP) {
         CHECK_SECRET();
-        EventPollerPool::Instance().getPoller()->doDelayTask(1000,[](){
+        EventPollerPool::Instance().getPoller()->doDelayTask(1000, []() {
             // 尝试正常退出  [AUTO-TRANSLATED:93828d0f]
             // Try to exit normally
             ::kill(getpid(), SIGINT);
 
             // 3秒后强制退出  [AUTO-TRANSLATED:fdc82920]
             // Force exit after 3 seconds
-            EventPollerPool::Instance().getPoller()->doDelayTask(3000,[](){
+            EventPollerPool::Instance().getPoller()->doDelayTask(3000, []() {
                 exit(0);
                 return 0;
             });
@@ -913,7 +903,7 @@ void installWebApi() {
         // 创建重启批处理脚本文件  [AUTO-TRANSLATED:cc18c259]
         // Create a restart batch script file
         FILE *pf;
-        errno_t err = ::_wfopen_s(&pf, L"RestartServer.cmd", L"w"); //“w”如果该文件存在，其内容将被覆盖
+        errno_t err = ::_wfopen_s(&pf, L"RestartServer.cmd", L"w"); // “w”如果该文件存在，其内容将被覆盖
         if (err == 0) {
             char szExeName[1024];
             char drive[_MAX_DRIVE] = { 0 };
@@ -921,7 +911,7 @@ void installWebApi() {
             char fname[_MAX_FNAME] = { 0 };
             char ext[_MAX_EXT] = { 0 };
             char exeName[_MAX_FNAME] = { 0 };
-            GetModuleFileNameA(NULL, szExeName, 1024); //获取进程的全路径
+            GetModuleFileNameA(NULL, szExeName, 1024); // 获取进程的全路径
             _splitpath(szExeName, drive, dir, fname, ext);
             strcpy(exeName, fname);
             strcat(exeName, ext);
@@ -961,7 +951,7 @@ void installWebApi() {
             val["code"] = API::OtherFailed;
         }
     });
-#endif//#if !defined(_WIN32)
+#endif // #if !defined(_WIN32)
 
     // 获取流列表，可选筛选参数  [AUTO-TRANSLATED:68ffc6b6]
     // Get stream list, optional filtering parameters
@@ -971,28 +961,28 @@ void installWebApi() {
     // Test url1 (get streams with virtual host "__defaultVost__") http://127.0.0.1/index/api/getMediaList?vhost=__defaultVost__
     // 测试url2(获取rtsp类型的流) http://127.0.0.1/index/api/getMediaList?schema=rtsp  [AUTO-TRANSLATED:21c2c15d]
     // Test url2 (get rtsp type streams) http://127.0.0.1/index/api/getMediaList?schema=rtsp
-    api_regist("/index/api/getMediaList",[](API_ARGS_MAP){
+    api_regist("/index/api/getMediaList", [](API_ARGS_MAP) {
         CHECK_SECRET();
         // 获取所有MediaSource列表  [AUTO-TRANSLATED:7bf16dc2]
         // Get all MediaSource lists
-        MediaSource::for_each_media([&](const MediaSource::Ptr &media) {
-            val["data"].append(makeMediaSourceJson(*media));
-        }, allArgs["schema"], allArgs["vhost"], allArgs["app"], allArgs["stream"]);
+        MediaSource::for_each_media(
+            [&](const MediaSource::Ptr &media) { val["data"].append(makeMediaSourceJson(*media)); }, allArgs["schema"], allArgs["vhost"], allArgs["app"],
+            allArgs["stream"]);
     });
 
     // 测试url http://127.0.0.1/index/api/isMediaOnline?schema=rtsp&vhost=__defaultVhost__&app=live&stream=obs  [AUTO-TRANSLATED:126a75e8]
     // Test url http://127.0.0.1/index/api/isMediaOnline?schema=rtsp&vhost=__defaultVhost__&app=live&stream=obs
-    api_regist("/index/api/isMediaOnline",[](API_ARGS_MAP){
+    api_regist("/index/api/isMediaOnline", [](API_ARGS_MAP) {
         CHECK_SECRET();
-        CHECK_ARGS("schema","vhost","app","stream");
-        val["online"] = (bool) (MediaSource::find(allArgs["schema"],allArgs["vhost"],allArgs["app"],allArgs["stream"]));
+        CHECK_ARGS("schema", "vhost", "app", "stream");
+        val["online"] = (bool)(MediaSource::find(allArgs["schema"], allArgs["vhost"], allArgs["app"], allArgs["stream"]));
     });
 
     // 获取媒体流播放器列表  [AUTO-TRANSLATED:bcadf31c]
     // Get media stream player list
     // 测试url http://127.0.0.1/index/api/getMediaPlayerList?schema=rtsp&vhost=__defaultVhost__&app=live&stream=obs  [AUTO-TRANSLATED:2aab7522]
     // Test url http://127.0.0.1/index/api/getMediaPlayerList?schema=rtsp&vhost=__defaultVhost__&app=live&stream=obs
-    api_regist("/index/api/getMediaPlayerList",[](API_ARGS_MAP_ASYNC){
+    api_regist("/index/api/getMediaPlayerList", [](API_ARGS_MAP_ASYNC) {
         CHECK_SECRET();
         CHECK_ARGS("schema", "vhost", "app", "stream");
         auto src = MediaSource::find(allArgs["schema"], allArgs["vhost"], allArgs["app"], allArgs["stream"]);
@@ -1036,11 +1026,11 @@ void installWebApi() {
 
     // 测试url http://127.0.0.1/index/api/getMediaInfo?schema=rtsp&vhost=__defaultVhost__&app=live&stream=obs  [AUTO-TRANSLATED:9402e811]
     // Test url http://127.0.0.1/index/api/getMediaInfo?schema=rtsp&vhost=__defaultVhost__&app=live&stream=obs
-    api_regist("/index/api/getMediaInfo",[](API_ARGS_MAP_ASYNC){
+    api_regist("/index/api/getMediaInfo", [](API_ARGS_MAP_ASYNC) {
         CHECK_SECRET();
-        CHECK_ARGS("schema","vhost","app","stream");
-        auto src = MediaSource::find(allArgs["schema"],allArgs["vhost"],allArgs["app"],allArgs["stream"]);
-        if(!src){
+        CHECK_ARGS("schema", "vhost", "app", "stream");
+        auto src = MediaSource::find(allArgs["schema"], allArgs["vhost"], allArgs["app"], allArgs["stream"]);
+        if (!src) {
             throw ApiRetException("can not find the stream", API::NotFound);
         }
         src->getOwnerPoller()->async([=]() mutable {
@@ -1054,15 +1044,12 @@ void installWebApi() {
     // Actively close the stream, including closing the pull stream and push stream
     // 测试url http://127.0.0.1/index/api/close_stream?schema=rtsp&vhost=__defaultVhost__&app=live&stream=obs&force=1  [AUTO-TRANSLATED:c3831592]
     // Test url http://127.0.0.1/index/api/close_stream?schema=rtsp&vhost=__defaultVhost__&app=live&stream=obs&force=1
-    api_regist("/index/api/close_stream",[](API_ARGS_MAP_ASYNC){
+    api_regist("/index/api/close_stream", [](API_ARGS_MAP_ASYNC) {
         CHECK_SECRET();
-        CHECK_ARGS("schema","vhost","app","stream");
+        CHECK_ARGS("schema", "vhost", "app", "stream");
         // 踢掉推流器  [AUTO-TRANSLATED:61e39b14]
         // Kick out the pusher
-        auto src = MediaSource::find(allArgs["schema"],
-                                     allArgs["vhost"],
-                                     allArgs["app"],
-                                     allArgs["stream"]);
+        auto src = MediaSource::find(allArgs["schema"], allArgs["vhost"], allArgs["app"], allArgs["stream"]);
         if (!src) {
             throw ApiRetException("can not find the stream", API::NotFound);
         }
@@ -1081,17 +1068,19 @@ void installWebApi() {
     // Batch actively close the stream, including closing the pull stream and push stream
     // 测试url http://127.0.0.1/index/api/close_streams?schema=rtsp&vhost=__defaultVhost__&app=live&stream=obs&force=1  [AUTO-TRANSLATED:786933db]
     // Test url http://127.0.0.1/index/api/close_streams?schema=rtsp&vhost=__defaultVhost__&app=live&stream=obs&force=1
-    api_regist("/index/api/close_streams",[](API_ARGS_MAP){
+    api_regist("/index/api/close_streams", [](API_ARGS_MAP) {
         CHECK_SECRET();
         // 筛选命中个数  [AUTO-TRANSLATED:6db1e8c7]
         // Filter hit count
         int count_hit = 0;
         int count_closed = 0;
         list<MediaSource::Ptr> media_list;
-        MediaSource::for_each_media([&](const MediaSource::Ptr &media) {
-            ++count_hit;
-            media_list.emplace_back(media);
-        }, allArgs["schema"], allArgs["vhost"], allArgs["app"], allArgs["stream"]);
+        MediaSource::for_each_media(
+            [&](const MediaSource::Ptr &media) {
+                ++count_hit;
+                media_list.emplace_back(media);
+            },
+            allArgs["schema"], allArgs["vhost"], allArgs["app"], allArgs["stream"]);
 
         bool force = allArgs["force"].as<bool>();
         for (auto &media : media_list) {
@@ -1109,17 +1098,17 @@ void installWebApi() {
     // You can filter by local port and remote ip
     // 测试url(筛选某端口下的tcp会话) http://127.0.0.1/index/api/getAllSession?local_port=1935  [AUTO-TRANSLATED:ef845193]
     // Test url (filter tcp session under a certain port) http://127.0.0.1/index/api/getAllSession?local_port=1935
-    api_regist("/index/api/getAllSession",[](API_ARGS_MAP){
+    api_regist("/index/api/getAllSession", [](API_ARGS_MAP) {
         CHECK_SECRET();
         Value jsession;
         uint16_t local_port = allArgs["local_port"].as<uint16_t>();
         string peer_ip = allArgs["peer_ip"];
 
-        SessionMap::Instance().for_each_session([&](const string &id,const Session::Ptr &session){
-            if(local_port != 0 && local_port != session->get_local_port()){
+        SessionMap::Instance().for_each_session([&](const string &id, const Session::Ptr &session) {
+            if (local_port != 0 && local_port != session->get_local_port()) {
                 return;
             }
-            if(!peer_ip.empty() && peer_ip != session->get_peer_ip()){
+            if (!peer_ip.empty() && peer_ip != session->get_peer_ip()) {
                 return;
             }
             fillSockInfo(jsession, session.get());
@@ -1133,18 +1122,17 @@ void installWebApi() {
     // Disconnect the tcp connection, for example, you can disconnect the rtsp, rtmp player, etc.
     // 测试url http://127.0.0.1/index/api/kick_session?id=123456  [AUTO-TRANSLATED:c2880cb5]
     // Test url http://127.0.0.1/index/api/kick_session?id=123456
-    api_regist("/index/api/kick_session",[](API_ARGS_MAP){
+    api_regist("/index/api/kick_session", [](API_ARGS_MAP) {
         CHECK_SECRET();
         CHECK_ARGS("id");
         // 踢掉tcp会话  [AUTO-TRANSLATED:f6f318bd]
         // Kick out the tcp session
         auto session = SessionMap::Instance().get(allArgs["id"]);
-        if(!session){
-            throw ApiRetException("can not find the target",API::OtherFailed);
+        if (!session) {
+            throw ApiRetException("can not find the target", API::OtherFailed);
         }
         session->safeShutdown();
     });
-
 
     // 批量断开tcp连接，比如说可以断开rtsp、rtmp播放器等  [AUTO-TRANSLATED:fef59eb8]
     // Batch disconnect tcp connections, for example, you can disconnect rtsp, rtmp players, etc.
@@ -1181,8 +1169,9 @@ void installWebApi() {
 
     // 动态添加rtsp/rtmp推流代理  [AUTO-TRANSLATED:2eb09bc9]
     // Dynamically add rtsp/rtmp push stream proxy
-    // 测试url http://127.0.0.1/index/api/addStreamPusherProxy?schema=rtmp&vhost=__defaultVhost__&app=proxy&stream=0&dst_url=rtmp://127.0.0.1/live/obs  [AUTO-TRANSLATED:25d7d4b0]
-    // Test url http://127.0.0.1/index/api/addStreamPusherProxy?schema=rtmp&vhost=__defaultVhost__&app=proxy&stream=0&dst_url=rtmp://127.0.0.1/live/obs
+    // 测试url http://127.0.0.1/index/api/addStreamPusherProxy?schema=rtmp&vhost=__defaultVhost__&app=proxy&stream=0&dst_url=rtmp://127.0.0.1/live/obs
+    // [AUTO-TRANSLATED:25d7d4b0] Test url
+    // http://127.0.0.1/index/api/addStreamPusherProxy?schema=rtmp&vhost=__defaultVhost__&app=proxy&stream=0&dst_url=rtmp://127.0.0.1/live/obs
     api_regist("/index/api/addStreamPusherProxy", [](API_ARGS_MAP_ASYNC) {
         CHECK_SECRET();
         CHECK_ARGS("schema", "vhost", "app", "stream", "dst_url");
@@ -1195,25 +1184,18 @@ void installWebApi() {
         auto dst_url = allArgs["dst_url"];
         auto retry_count = allArgs["retry_count"].empty() ? -1 : allArgs["retry_count"].as<int>();
         EventPollerPool::Instance().getPoller(false)->async([=]() mutable {
-            addStreamPusherProxy(allArgs["schema"],
-                                 allArgs["vhost"],
-                                 allArgs["app"],
-                                 allArgs["stream"],
-                                 allArgs["dst_url"],
-                                 retry_count,
-                                 allArgs["rtp_type"],
-                                 allArgs["timeout_sec"],
-                                 args,
-                                 [invoker, val, headerOut, dst_url](const SockException &ex, const string &key) mutable {
-                                     if (ex) {
-                                         val["code"] = API::OtherFailed;
-                                         val["msg"] = ex.what();
-                                     } else {
-                                         val["data"]["key"] = key;
-                                         InfoL << "Publish success, please play with player:" << dst_url;
-                                     }
-                                     invoker(200, headerOut, val.toStyledString());
-                                 });
+            addStreamPusherProxy(
+                allArgs["schema"], allArgs["vhost"], allArgs["app"], allArgs["stream"], allArgs["dst_url"], retry_count, allArgs["rtp_type"],
+                allArgs["timeout_sec"], args, [invoker, val, headerOut, dst_url](const SockException &ex, const string &key) mutable {
+                    if (ex) {
+                        val["code"] = API::OtherFailed;
+                        val["msg"] = ex.what();
+                    } else {
+                        val["data"]["key"] = key;
+                        InfoL << "Publish success, please play with player:" << dst_url;
+                    }
+                    invoker(200, headerOut, val.toStyledString());
+                });
         });
     });
 
@@ -1228,7 +1210,7 @@ void installWebApi() {
     });
     api_regist("/index/api/listStreamPusherProxy", [](API_ARGS_MAP) {
         CHECK_SECRET();
-        s_pusher_proxy.for_each([&val](const std::string& key, const PusherProxy::Ptr& p) {
+        s_pusher_proxy.for_each([&val](const std::string &key, const PusherProxy::Ptr &p) {
             Json::Value item = ToJson(p);
             item["key"] = key;
             val["data"].append(item);
@@ -1236,7 +1218,7 @@ void installWebApi() {
     });
     api_regist("/index/api/listStreamProxy", [](API_ARGS_MAP) {
         CHECK_SECRET();
-        s_player_proxy.for_each([&val](const std::string& key, const PlayerProxy::Ptr& p) {
+        s_player_proxy.for_each([&val](const std::string &key, const PlayerProxy::Ptr &p) {
             Json::Value item = ToJson(p);
             item["key"] = key;
             val["data"].append(item);
@@ -1244,11 +1226,12 @@ void installWebApi() {
     });
     // 动态添加rtsp/rtmp拉流代理  [AUTO-TRANSLATED:2616537c]
     // Dynamically add rtsp/rtmp pull stream proxy
-    // 测试url http://127.0.0.1/index/api/addStreamProxy?vhost=__defaultVhost__&app=proxy&enable_rtsp=1&enable_rtmp=1&stream=0&url=rtmp://127.0.0.1/live/obs  [AUTO-TRANSLATED:71ddce15]
-    // Test url http://127.0.0.1/index/api/addStreamProxy?vhost=__defaultVhost__&app=proxy&enable_rtsp=1&enable_rtmp=1&stream=0&url=rtmp://127.0.0.1/live/obs
-    api_regist("/index/api/addStreamProxy",[](API_ARGS_MAP_ASYNC){
+    // 测试url http://127.0.0.1/index/api/addStreamProxy?vhost=__defaultVhost__&app=proxy&enable_rtsp=1&enable_rtmp=1&stream=0&url=rtmp://127.0.0.1/live/obs
+    // [AUTO-TRANSLATED:71ddce15] Test url
+    // http://127.0.0.1/index/api/addStreamProxy?vhost=__defaultVhost__&app=proxy&enable_rtsp=1&enable_rtmp=1&stream=0&url=rtmp://127.0.0.1/live/obs
+    api_regist("/index/api/addStreamProxy", [](API_ARGS_MAP_ASYNC) {
         CHECK_SECRET();
-        CHECK_ARGS("vhost","app","stream","url");
+        CHECK_ARGS("vhost", "app", "stream", "url");
 
         mINI args;
         for (auto &pr : allArgs.args) {
@@ -1256,30 +1239,25 @@ void installWebApi() {
         }
 
         ProtocolOption option(allArgs);
-        auto retry_count = allArgs["retry_count"].empty()? -1: allArgs["retry_count"].as<int>();
+        auto retry_count = allArgs["retry_count"].empty() ? -1 : allArgs["retry_count"].as<int>();
 
         std::string vhost = DEFAULT_VHOST;
         if (!allArgs["vhost"].empty()) {
             vhost = allArgs["vhost"];
         }
-        auto tuple = MediaTuple { vhost, allArgs["app"], allArgs["stream"], "" };
+        auto tuple = MediaTuple { vhost, allArgs["app"], allArgs["stream"], "", allArgs["userdata"] };
         EventPollerPool::Instance().getPoller(false)->async([=]() mutable {
-            addStreamProxy(tuple,
-                           allArgs["url"],
-                           retry_count,
-                           option,
-                           allArgs["rtp_type"],
-                           allArgs["timeout_sec"],
-                           args,
-                           [invoker,val,headerOut](const SockException &ex,const string &key) mutable {
-                               if (ex) {
-                                   val["code"] = API::OtherFailed;
-                                   val["msg"] = ex.what();
-                               } else {
-                                   val["data"]["key"] = key;
-                               }
-                               invoker(200, headerOut, val.toStyledString());
-                           });
+            addStreamProxy(
+                tuple, allArgs["url"], retry_count, option, allArgs["rtp_type"], allArgs["timeout_sec"], args,
+                [invoker, val, headerOut](const SockException &ex, const string &key) mutable {
+                    if (ex) {
+                        val["code"] = API::OtherFailed;
+                        val["msg"] = ex.what();
+                    } else {
+                        val["data"]["key"] = key;
+                    }
+                    invoker(200, headerOut, val.toStyledString());
+                });
         });
     });
 
@@ -1287,19 +1265,14 @@ void installWebApi() {
     // Close the pull stream proxy
     // 测试url http://127.0.0.1/index/api/delStreamProxy?key=__defaultVhost__/proxy/0  [AUTO-TRANSLATED:2b0903ef]
     // Test url http://127.0.0.1/index/api/delStreamProxy?key=__defaultVhost__/proxy/0
-    api_regist("/index/api/delStreamProxy",[](API_ARGS_MAP){
+    api_regist("/index/api/delStreamProxy", [](API_ARGS_MAP) {
         CHECK_SECRET();
         CHECK_ARGS("key");
         val["data"]["flag"] = s_player_proxy.erase(allArgs["key"]) == 1;
     });
 
-    static auto addFFmpegSource = [](const string &ffmpeg_cmd_key,
-                                     const string &src_url,
-                                     const string &dst_url,
-                                     int timeout_ms,
-                                     bool enable_hls,
-                                     bool enable_mp4,
-                                     const function<void(const SockException &ex, const string &key)> &cb) {
+    static auto addFFmpegSource = [](const string &ffmpeg_cmd_key, const string &src_url, const string &dst_url, const string &userdata, int timeout_ms,
+                                     bool enable_hls, bool enable_mp4, const function<void(const SockException &ex, const string &key)> &cb) {
         auto key = MD5(dst_url).hexdigest();
         if (s_ffmpeg_src.find(key)) {
             // 已经在拉流了  [AUTO-TRANSLATED:e06c57d7]
@@ -1310,10 +1283,9 @@ void installWebApi() {
 
         auto ffmpeg = s_ffmpeg_src.make(key);
 
-        ffmpeg->setOnClose([key]() {
-            s_ffmpeg_src.erase(key);
-        });
+        ffmpeg->setOnClose([key]() { s_ffmpeg_src.erase(key); });
         ffmpeg->setupRecordFlag(enable_hls, enable_mp4);
+        ffmpeg->setMediaInfoUserdata(userdata);
         ffmpeg->play(ffmpeg_cmd_key, src_url, dst_url, timeout_ms, [cb, key](const SockException &ex) {
             if (ex) {
                 s_ffmpeg_src.erase(key);
@@ -1324,41 +1296,46 @@ void installWebApi() {
 
     // 动态添加rtsp/rtmp拉流代理  [AUTO-TRANSLATED:2616537c]
     // Dynamically add rtsp/rtmp pull stream proxy
-    // 测试url http://127.0.0.1/index/api/addFFmpegSource?src_url=http://live.hkstv.hk.lxdns.com/live/hks2/playlist.m3u8&dst_url=rtmp://127.0.0.1/live/hks2&timeout_ms=10000  [AUTO-TRANSLATED:501cdd89]
-    // // Test url http://127.0.0.1/index/api/addFFmpegSource?src_url=http://live.hkstv.hk.lxdns.com/live/hks2/playlist.m3u8&dst_url=rtmp://127.0.0.1/live/hks2&timeout_ms=10000
-    api_regist("/index/api/addFFmpegSource",[](API_ARGS_MAP_ASYNC){
+    // 测试url
+    // http://127.0.0.1/index/api/addFFmpegSource?src_url=http://live.hkstv.hk.lxdns.com/live/hks2/playlist.m3u8&dst_url=rtmp://127.0.0.1/live/hks2&timeout_ms=10000
+    // [AUTO-TRANSLATED:501cdd89]
+    // // Test url
+    // http://127.0.0.1/index/api/addFFmpegSource?src_url=http://live.hkstv.hk.lxdns.com/live/hks2/playlist.m3u8&dst_url=rtmp://127.0.0.1/live/hks2&timeout_ms=10000
+    api_regist("/index/api/addFFmpegSource", [](API_ARGS_MAP_ASYNC) {
         CHECK_SECRET();
-        CHECK_ARGS("src_url","dst_url","timeout_ms");
+        CHECK_ARGS("src_url", "dst_url", "timeout_ms");
         auto src_url = allArgs["src_url"];
         auto dst_url = allArgs["dst_url"];
+        auto userdata = allArgs["userdata"];
         int timeout_ms = allArgs["timeout_ms"];
         auto enable_hls = allArgs["enable_hls"].as<int>();
         auto enable_mp4 = allArgs["enable_mp4"].as<int>();
 
-        addFFmpegSource(allArgs["ffmpeg_cmd_key"], src_url, dst_url, timeout_ms, enable_hls, enable_mp4,
-                        [invoker, val, headerOut](const SockException &ex, const string &key) mutable{
-            if (ex) {
-                val["code"] = API::OtherFailed;
-                val["msg"] = ex.what();
-            } else {
-                val["data"]["key"] = key;
-            }
-            invoker(200, headerOut, val.toStyledString());
-        });
+        addFFmpegSource(
+            allArgs["ffmpeg_cmd_key"], src_url, dst_url, userdata, timeout_ms, enable_hls, enable_mp4,
+            [invoker, val, headerOut](const SockException &ex, const string &key) mutable {
+                if (ex) {
+                    val["code"] = API::OtherFailed;
+                    val["msg"] = ex.what();
+                } else {
+                    val["data"]["key"] = key;
+                }
+                invoker(200, headerOut, val.toStyledString());
+            });
     });
 
     // 关闭拉流代理  [AUTO-TRANSLATED:5204f128]
     // Close the pull stream proxy
     // 测试url http://127.0.0.1/index/api/delFFmepgSource?key=key  [AUTO-TRANSLATED:ed6fa147]
     // Test url http://127.0.0.1/index/api/delFFmepgSource?key=key
-    api_regist("/index/api/delFFmpegSource",[](API_ARGS_MAP){
+    api_regist("/index/api/delFFmpegSource", [](API_ARGS_MAP) {
         CHECK_SECRET();
         CHECK_ARGS("key");
         val["data"]["flag"] = s_ffmpeg_src.erase(allArgs["key"]) == 1;
     });
     api_regist("/index/api/listFFmpegSource", [](API_ARGS_MAP) {
         CHECK_SECRET();
-        s_ffmpeg_src.for_each([&val](const std::string& key, const FFmpegSource::Ptr& src) {
+        s_ffmpeg_src.for_each([&val](const std::string &key, const FFmpegSource::Ptr &src) {
             Json::Value item;
             item["src_url"] = src->getSrcUrl();
             item["dst_url"] = src->getDstUrl();
@@ -1372,13 +1349,13 @@ void installWebApi() {
     // Add a new http api to download executable files
     // 测试url http://127.0.0.1/index/api/downloadBin  [AUTO-TRANSLATED:9525e834]
     // Test url http://127.0.0.1/index/api/downloadBin
-    api_regist("/index/api/downloadBin",[](API_ARGS_MAP_ASYNC){
+    api_regist("/index/api/downloadBin", [](API_ARGS_MAP_ASYNC) {
         CHECK_SECRET();
         invoker.responseFile(allArgs.parser.getHeader(), StrCaseMap(), exePath());
     });
 
 #if defined(ENABLE_RTPPROXY)
-    api_regist("/index/api/getRtpInfo",[](API_ARGS_MAP){
+    api_regist("/index/api/getRtpInfo", [](API_ARGS_MAP) {
         CHECK_SECRET();
         CHECK_ARGS("stream_id");
         std::string vhost = DEFAULT_VHOST;
@@ -1399,7 +1376,7 @@ void installWebApi() {
         fillSockInfo(val, process.get());
     });
 
-    api_regist("/index/api/openRtpServer",[](API_ARGS_MAP){
+    api_regist("/index/api/openRtpServer", [](API_ARGS_MAP) {
         CHECK_SECRET();
         CHECK_ARGS("port", "stream_id");
         std::string vhost = DEFAULT_VHOST;
@@ -1411,7 +1388,7 @@ void installWebApi() {
             app = allArgs["app"];
         }
         auto stream_id = allArgs["stream_id"];
-        auto tuple = MediaTuple { vhost, app, stream_id, "" };
+        auto tuple = MediaTuple { vhost, app, stream_id, "", allArgs["userdata"] };
         auto tcp_mode = allArgs["tcp_mode"].as<int>();
         if (allArgs["enable_tcp"].as<int>() && !tcp_mode) {
             // 兼容老版本请求，新版本去除enable_tcp参数并新增tcp_mode参数  [AUTO-TRANSLATED:3b6a5ab5]
@@ -1428,8 +1405,7 @@ void installWebApi() {
         if (!allArgs["local_ip"].empty()) {
             local_ip = allArgs["local_ip"];
         }
-        auto port = openRtpServer(allArgs["port"], tuple, tcp_mode, local_ip, allArgs["re_use_port"].as<bool>(),
-                                  allArgs["ssrc"].as<uint32_t>(), only_track);
+        auto port = openRtpServer(allArgs["port"], tuple, tcp_mode, local_ip, allArgs["re_use_port"].as<bool>(), allArgs["ssrc"].as<uint32_t>(), only_track);
         if (port == 0) {
             throw InvalidArgsException("This stream already exists");
         }
@@ -1450,7 +1426,7 @@ void installWebApi() {
             app = allArgs["app"];
         }
         auto stream_id = allArgs["stream_id"];
-        auto tuple = MediaTuple { vhost, app, stream_id, "" };
+        auto tuple = MediaTuple { vhost, app, stream_id, "", allArgs["userdata"] };
         auto tcp_mode = allArgs["tcp_mode"].as<int>();
         if (allArgs["enable_tcp"].as<int>() && !tcp_mode) {
             // 兼容老版本请求，新版本去除enable_tcp参数并新增tcp_mode参数  [AUTO-TRANSLATED:b5f8f5df]
@@ -1506,7 +1482,7 @@ void installWebApi() {
         server->connectToServer(allArgs["dst_url"], allArgs["dst_port"], cb);
     });
 
-    api_regist("/index/api/closeRtpServer",[](API_ARGS_MAP){
+    api_regist("/index/api/closeRtpServer", [](API_ARGS_MAP) {
         CHECK_SECRET();
         CHECK_ARGS("stream_id");
 
@@ -1527,7 +1503,7 @@ void installWebApi() {
         val["hit"] = 1;
     });
 
-    api_regist("/index/api/updateRtpServerSSRC",[](API_ARGS_MAP){
+    api_regist("/index/api/updateRtpServerSSRC", [](API_ARGS_MAP) {
         CHECK_SECRET();
         CHECK_ARGS("stream_id", "ssrc");
 
@@ -1548,7 +1524,7 @@ void installWebApi() {
         server->updateSSRC(allArgs["ssrc"]);
     });
 
-    api_regist("/index/api/listRtpServer",[](API_ARGS_MAP){
+    api_regist("/index/api/listRtpServer", [](API_ARGS_MAP) {
         CHECK_SECRET();
 
         std::lock_guard<std::recursive_mutex> lck(s_rtp_server._mtx);
@@ -1558,7 +1534,7 @@ void installWebApi() {
             obj["vhost"] = vec[0];
             obj["app"] = vec[1];
             obj["stream_id"] = vec[2];
-            auto& rtps = pr.second;
+            auto &rtps = pr.second;
             obj["port"] = rtps->getPort();
             obj["ssrc"] = rtps->getSSRC();
             obj["tcp_mode"] = rtps->getTcpMode();
@@ -1567,7 +1543,7 @@ void installWebApi() {
         }
     });
 
-    static auto start_send_rtp = [] (bool passive, API_ARGS_MAP_ASYNC) {
+    static auto start_send_rtp = [](bool passive, API_ARGS_MAP_ASYNC) {
         auto src = MediaSource::find(allArgs["vhost"], allArgs["app"], allArgs["stream"], allArgs["from_mp4"].as<int>());
         if (!src) {
             throw ApiRetException("can not find the source stream", API::NotFound);
@@ -1580,9 +1556,11 @@ void installWebApi() {
         }
         MediaSourceEvent::SendRtpArgs args;
         if (passive) {
-            args.con_type = allArgs["is_udp"].as<bool>() ? mediakit::MediaSourceEvent::SendRtpArgs::kUdpPassive : mediakit::MediaSourceEvent::SendRtpArgs::kTcpPassive;
+            args.con_type
+                = allArgs["is_udp"].as<bool>() ? mediakit::MediaSourceEvent::SendRtpArgs::kUdpPassive : mediakit::MediaSourceEvent::SendRtpArgs::kTcpPassive;
         } else {
-            args.con_type = allArgs["is_udp"].as<bool>() ? mediakit::MediaSourceEvent::SendRtpArgs::kUdpActive : mediakit::MediaSourceEvent::SendRtpArgs::kTcpActive;
+            args.con_type
+                = allArgs["is_udp"].as<bool>() ? mediakit::MediaSourceEvent::SendRtpArgs::kUdpActive : mediakit::MediaSourceEvent::SendRtpArgs::kTcpActive;
         }
         args.dst_url = allArgs["dst_url"];
         args.dst_port = allArgs["dst_port"];
@@ -1618,19 +1596,19 @@ void installWebApi() {
         });
     };
 
-    api_regist("/index/api/startSendRtp",[](API_ARGS_MAP_ASYNC){
+    api_regist("/index/api/startSendRtp", [](API_ARGS_MAP_ASYNC) {
         CHECK_SECRET();
         CHECK_ARGS("vhost", "app", "stream", "ssrc", "dst_url", "dst_port", "is_udp");
         start_send_rtp(false, API_ARGS_VALUE, invoker);
     });
 
-    api_regist("/index/api/startSendRtpPassive",[](API_ARGS_MAP_ASYNC){
+    api_regist("/index/api/startSendRtpPassive", [](API_ARGS_MAP_ASYNC) {
         CHECK_SECRET();
         CHECK_ARGS("vhost", "app", "stream", "ssrc");
         start_send_rtp(true, API_ARGS_VALUE, invoker);
     });
 
-    api_regist("/index/api/startSendRtpTalk",[](API_ARGS_MAP_ASYNC){
+    api_regist("/index/api/startSendRtpTalk", [](API_ARGS_MAP_ASYNC) {
         CHECK_SECRET();
         CHECK_ARGS("vhost", "app", "stream", "ssrc", "recv_stream_id");
         auto src = MediaSource::find(allArgs["vhost"], allArgs["app"], allArgs["stream"], allArgs["from_mp4"].as<int>());
@@ -1666,7 +1644,7 @@ void installWebApi() {
         });
     });
 
-    api_regist("/index/api/listRtpSender",[](API_ARGS_MAP_ASYNC){
+    api_regist("/index/api/listRtpSender", [](API_ARGS_MAP_ASYNC) {
         CHECK_SECRET();
         CHECK_ARGS("vhost", "app", "stream");
 
@@ -1688,7 +1666,7 @@ void installWebApi() {
         });
     });
 
-    api_regist("/index/api/stopSendRtp",[](API_ARGS_MAP_ASYNC){
+    api_regist("/index/api/stopSendRtp", [](API_ARGS_MAP_ASYNC) {
         CHECK_SECRET();
         CHECK_ARGS("vhost", "app", "stream");
 
@@ -1722,7 +1700,8 @@ void installWebApi() {
             app = allArgs["app"];
         }
         // 只是暂停流的检查，流媒体服务器做为流负载服务，收流就转发，RTSP/RTMP有自己暂停协议  [AUTO-TRANSLATED:dda6ee31]
-        // Only pause the stream check, the media server acts as a stream load balancing service, receiving the stream and forwarding it, RTSP/RTMP has its own pause protocol
+        // Only pause the stream check, the media server acts as a stream load balancing service, receiving the stream and forwarding it, RTSP/RTMP has its own
+        // pause protocol
         auto src = MediaSource::find(vhost, app, allArgs["stream_id"]);
         auto process = src ? src->getRtpProcess() : nullptr;
         if (process) {
@@ -1752,15 +1731,15 @@ void installWebApi() {
         }
     });
 
-#endif//ENABLE_RTPPROXY
+#endif // ENABLE_RTPPROXY
 
     // 开始录制hls或MP4  [AUTO-TRANSLATED:0818775e]
     // Start recording hls or MP4
-    api_regist("/index/api/startRecord",[](API_ARGS_MAP_ASYNC){
+    api_regist("/index/api/startRecord", [](API_ARGS_MAP_ASYNC) {
         CHECK_SECRET();
-        CHECK_ARGS("type","vhost","app","stream");
+        CHECK_ARGS("type", "vhost", "app", "stream");
 
-        auto src = MediaSource::find(allArgs["vhost"], allArgs["app"], allArgs["stream"] );
+        auto src = MediaSource::find(allArgs["vhost"], allArgs["app"], allArgs["stream"]);
         if (!src) {
             throw ApiRetException("can not find the stream", API::NotFound);
         }
@@ -1769,12 +1748,12 @@ void installWebApi() {
             auto result = src->setupRecord((Recorder::type)allArgs["type"].as<int>(), true, allArgs["customized_path"], allArgs["max_second"].as<size_t>());
             val["result"] = result;
             val["code"] = result ? API::Success : API::OtherFailed;
-            val["msg"] = result ? "success" :  "start record failed";
+            val["msg"] = result ? "success" : "start record failed";
             invoker(200, headerOut, val.toStyledString());
         });
     });
 
-    api_regist("/index/api/startRecordTask",[](API_ARGS_MAP_ASYNC){
+    api_regist("/index/api/startRecordTask", [](API_ARGS_MAP_ASYNC) {
         CHECK_SECRET();
         CHECK_ARGS("vhost", "app", "stream", "path", "back_ms", "forward_ms");
 
@@ -1803,10 +1782,7 @@ void installWebApi() {
     api_regist("/index/api/setRecordSpeed", [](API_ARGS_MAP_ASYNC) {
         CHECK_SECRET();
         CHECK_ARGS("schema", "vhost", "app", "stream", "speed");
-        auto src = MediaSource::find(allArgs["schema"],
-                                     allArgs["vhost"],
-                                     allArgs["app"],
-                                     allArgs["stream"]);
+        auto src = MediaSource::find(allArgs["schema"], allArgs["vhost"], allArgs["app"], allArgs["stream"]);
         if (!src) {
             throw ApiRetException("can not find the stream", API::NotFound);
         }
@@ -1824,10 +1800,7 @@ void installWebApi() {
     api_regist("/index/api/seekRecordStamp", [](API_ARGS_MAP_ASYNC) {
         CHECK_SECRET();
         CHECK_ARGS("schema", "vhost", "app", "stream", "stamp");
-        auto src = MediaSource::find(allArgs["schema"],
-                                     allArgs["vhost"],
-                                     allArgs["app"],
-                                     allArgs["stream"]);
+        auto src = MediaSource::find(allArgs["schema"], allArgs["vhost"], allArgs["app"], allArgs["stream"]);
         if (!src) {
             throw ApiRetException("can not find the stream", API::NotFound);
         }
@@ -1844,11 +1817,11 @@ void installWebApi() {
 
     // 停止录制hls或MP4  [AUTO-TRANSLATED:24d11a0c]
     // Stop recording hls or MP4
-    api_regist("/index/api/stopRecord",[](API_ARGS_MAP_ASYNC){
+    api_regist("/index/api/stopRecord", [](API_ARGS_MAP_ASYNC) {
         CHECK_SECRET();
-        CHECK_ARGS("type","vhost","app","stream");
+        CHECK_ARGS("type", "vhost", "app", "stream");
 
-        auto src = MediaSource::find(allArgs["vhost"], allArgs["app"], allArgs["stream"] );
+        auto src = MediaSource::find(allArgs["vhost"], allArgs["app"], allArgs["stream"]);
         if (!src) {
             throw ApiRetException("can not find the stream", API::NotFound);
         }
@@ -1865,9 +1838,9 @@ void installWebApi() {
 
     // 获取hls或MP4录制状态  [AUTO-TRANSLATED:a08a2f1a]
     // Get the recording status of hls or MP4
-    api_regist("/index/api/isRecording",[](API_ARGS_MAP_ASYNC){
+    api_regist("/index/api/isRecording", [](API_ARGS_MAP_ASYNC) {
         CHECK_SECRET();
-        CHECK_ARGS("type","vhost","app","stream");
+        CHECK_ARGS("type", "vhost", "app", "stream");
 
         auto src = MediaSource::find(allArgs["vhost"], allArgs["app"], allArgs["stream"]);
         if (!src) {
@@ -1911,7 +1884,7 @@ void installWebApi() {
     api_regist("/index/api/deleteRecordDirectory", [](API_ARGS_MAP) {
         CHECK_SECRET();
         CHECK_ARGS("vhost", "app", "stream");
-        auto tuple = MediaTuple{allArgs["vhost"], allArgs["app"], allArgs["stream"], ""};
+        auto tuple = MediaTuple { allArgs["vhost"], allArgs["app"], allArgs["stream"], "" };
         auto record_path = Recorder::getRecordPath(Recorder::type_mp4, tuple, allArgs["customized_path"]);
         auto period = allArgs["period"];
         if (!period.empty()) {
@@ -1937,17 +1910,20 @@ void installWebApi() {
             val["code"] = File::delete_file(record_path, true);
             return;
         }
-        File::scanDir(record_path, [](const string &path, bool is_dir) {
-            if (is_dir) {
+        File::scanDir(
+            record_path,
+            [](const string &path, bool is_dir) {
+                if (is_dir) {
+                    return true;
+                }
+                if (path.find("/.") == std::string::npos) {
+                    File::delete_file(path);
+                } else {
+                    TraceL << "Ignore tmp mp4 file: " << path;
+                }
                 return true;
-            }
-            if (path.find("/.") == std::string::npos) {
-                File::delete_file(path);
-            } else {
-                TraceL << "Ignore tmp mp4 file: " << path;
-            }
-            return true;
-        }, true, true);
+            },
+            true, true);
         File::deleteEmptyDir(record_path);
     });
 
@@ -1962,11 +1938,11 @@ void installWebApi() {
 
     // 获取录像文件夹列表或mp4文件列表  [AUTO-TRANSLATED:f7e299bc]
     // Get the list of recording folders or mp4 files
-    //http://127.0.0.1/index/api/getMP4RecordFile?vhost=__defaultVhost__&app=live&stream=ss&period=2020-01
-    api_regist("/index/api/getMP4RecordFile", [](API_ARGS_MAP){
+    // http://127.0.0.1/index/api/getMP4RecordFile?vhost=__defaultVhost__&app=live&stream=ss&period=2020-01
+    api_regist("/index/api/getMP4RecordFile", [](API_ARGS_MAP) {
         CHECK_SECRET();
         CHECK_ARGS("vhost", "app", "stream");
-        auto tuple = MediaTuple{allArgs["vhost"], allArgs["app"], allArgs["stream"], ""};
+        auto tuple = MediaTuple { allArgs["vhost"], allArgs["app"], allArgs["stream"], "" };
         auto record_path = Recorder::getRecordPath(Recorder::type_mp4, tuple, allArgs["customized_path"]);
         auto period = allArgs["period"];
 
@@ -1980,63 +1956,65 @@ void installWebApi() {
         Json::Value paths(arrayValue);
         // 这是筛选日期，获取文件夹列表  [AUTO-TRANSLATED:786fa49d]
         // This is to filter the date and get the folder list
-        File::scanDir(record_path, [&](const string &path, bool isDir) {
-            auto pos = path.rfind('/');
-            if (pos != string::npos) {
-                string relative_path = path.substr(pos + 1);
-                if (search_mp4) {
-                    if (!isDir) {
-                        // 我们只收集mp4文件，对文件夹不感兴趣  [AUTO-TRANSLATED:254d9f25]
-                        // We only collect mp4 files, we are not interested in folders
+        File::scanDir(
+            record_path,
+            [&](const string &path, bool isDir) {
+                auto pos = path.rfind('/');
+                if (pos != string::npos) {
+                    string relative_path = path.substr(pos + 1);
+                    if (search_mp4) {
+                        if (!isDir) {
+                            // 我们只收集mp4文件，对文件夹不感兴趣  [AUTO-TRANSLATED:254d9f25]
+                            // We only collect mp4 files, we are not interested in folders
+                            paths.append(relative_path);
+                        }
+                    } else if (isDir && relative_path.find(period) == 0) {
+                        // 匹配到对应日期的文件夹  [AUTO-TRANSLATED:cd3d10b9]
+                        // Match the folder for the corresponding date
                         paths.append(relative_path);
                     }
-                } else if (isDir && relative_path.find(period) == 0) {
-                    // 匹配到对应日期的文件夹  [AUTO-TRANSLATED:cd3d10b9]
-                    // Match the folder for the corresponding date
-                    paths.append(relative_path);
                 }
-            }
-            return true;
-        }, false);
+                return true;
+            },
+            false);
 
         val["data"]["rootPath"] = record_path;
         val["data"]["paths"] = paths;
     });
 
-    static auto responseSnap = [](const string &snap_path,
-                                  const HttpSession::KeyValue &headerIn,
-                                  const HttpSession::HttpResponseInvoker &invoker,
-                                  const string &err_msg = "") {
-        static bool s_snap_success_once = false;
-        StrCaseMap headerOut;
-        GET_CONFIG(string, defaultSnap, API::kDefaultSnap);
-        if (!File::fileSize(snap_path)) {
-            if (!err_msg.empty() && (!s_snap_success_once || defaultSnap.empty())) {
-                // 重来没截图成功过或者默认截图图片为空，那么直接返回FFmpeg错误日志  [AUTO-TRANSLATED:5bde510f]
-                // If the screenshot has never been successful or the default screenshot image is empty, then directly return the FFmpeg error log
-                headerOut["Content-Type"] = HttpFileManager::getContentType(".txt");
-                invoker.responseFile(headerIn, headerOut, err_msg, false, false);
-                return;
-            }
-            // 截图成功过一次，那么认为配置无错误，截图失败时，返回预设默认图片  [AUTO-TRANSLATED:ffe4d807]
-            // If the screenshot has been successful once, then it is considered that the configuration is error-free, and when the screenshot fails, the preset default image is returned
-            const_cast<string &>(snap_path) = File::absolutePath("", defaultSnap);
-            headerOut["Content-Type"] = HttpFileManager::getContentType(snap_path.data());
-        } else {
-            s_snap_success_once = true;
-            // 之前生成的截图文件，我们默认为jpeg格式  [AUTO-TRANSLATED:5cc5c1ff]
-            // The previously generated screenshot file, we default to jpeg format
-            headerOut["Content-Type"] = HttpFileManager::getContentType(".jpeg");
-        }
-        // 返回图片给http客户端  [AUTO-TRANSLATED:58a1f64e]
-        // Return image to http client
-        invoker.responseFile(headerIn, headerOut, snap_path);
-    };
+    static auto responseSnap
+        = [](const string &snap_path, const HttpSession::KeyValue &headerIn, const HttpSession::HttpResponseInvoker &invoker, const string &err_msg = "") {
+              static bool s_snap_success_once = false;
+              StrCaseMap headerOut;
+              GET_CONFIG(string, defaultSnap, API::kDefaultSnap);
+              if (!File::fileSize(snap_path)) {
+                  if (!err_msg.empty() && (!s_snap_success_once || defaultSnap.empty())) {
+                      // 重来没截图成功过或者默认截图图片为空，那么直接返回FFmpeg错误日志  [AUTO-TRANSLATED:5bde510f]
+                      // If the screenshot has never been successful or the default screenshot image is empty, then directly return the FFmpeg error log
+                      headerOut["Content-Type"] = HttpFileManager::getContentType(".txt");
+                      invoker.responseFile(headerIn, headerOut, err_msg, false, false);
+                      return;
+                  }
+                  // 截图成功过一次，那么认为配置无错误，截图失败时，返回预设默认图片  [AUTO-TRANSLATED:ffe4d807]
+                  // If the screenshot has been successful once, then it is considered that the configuration is error-free, and when the screenshot fails, the
+                  // preset default image is returned
+                  const_cast<string &>(snap_path) = File::absolutePath("", defaultSnap);
+                  headerOut["Content-Type"] = HttpFileManager::getContentType(snap_path.data());
+              } else {
+                  s_snap_success_once = true;
+                  // 之前生成的截图文件，我们默认为jpeg格式  [AUTO-TRANSLATED:5cc5c1ff]
+                  // The previously generated screenshot file, we default to jpeg format
+                  headerOut["Content-Type"] = HttpFileManager::getContentType(".jpeg");
+              }
+              // 返回图片给http客户端  [AUTO-TRANSLATED:58a1f64e]
+              // Return image to http client
+              invoker.responseFile(headerIn, headerOut, snap_path);
+          };
 
     // 获取截图缓存或者实时截图  [AUTO-TRANSLATED:78e2fe1e]
     // Get screenshot cache or real-time screenshot
-    //http://127.0.0.1/index/api/getSnap?url=rtmp://127.0.0.1/record/robot.mp4&timeout_sec=10&expire_sec=3
-    api_regist("/index/api/getSnap", [](API_ARGS_MAP_ASYNC){
+    // http://127.0.0.1/index/api/getSnap?url=rtmp://127.0.0.1/record/robot.mp4&timeout_sec=10&expire_sec=3
+    api_regist("/index/api/getSnap", [](API_ARGS_MAP_ASYNC) {
         CHECK_SECRET();
         CHECK_ARGS("url", "timeout_sec", "expire_sec");
         GET_CONFIG(string, snap_root, API::kSnapRoot);
@@ -2085,7 +2063,8 @@ void installWebApi() {
             // 无过期截图，生成一个空文件，目的是顺便创建文件夹路径  [AUTO-TRANSLATED:bdbfdbcb]
             // No expired screenshot, generate an empty file, the purpose is to create the folder path by the way
             // 同时防止在FFmpeg生成截图途中不停的尝试调用该api多次启动FFmpeg进程  [AUTO-TRANSLATED:a04e1ee2]
-            // At the same time, prevent the FFmpeg process from being started multiple times by continuously trying to call this API during the FFmpeg screenshot generation process
+            // At the same time, prevent the FFmpeg process from being started multiple times by continuously trying to call this API during the FFmpeg
+            // screenshot generation process
             auto file = File::create_file(new_snap, "wb");
             if (file) {
                 fclose(file);
@@ -2095,24 +2074,26 @@ void installWebApi() {
         // 启动FFmpeg进程，开始截图，生成临时文件，截图成功后替换为正式文件  [AUTO-TRANSLATED:7d589e3f]
         // Start the FFmpeg process, start taking screenshots, generate temporary files, replace them with formal files after successful screenshots
         auto new_snap_tmp = new_snap + ".tmp";
-        FFmpegSnap::makeSnap(allArgs["async"], allArgs["url"], new_snap_tmp, allArgs["timeout_sec"], [invoker, allArgs, new_snap, new_snap_tmp](bool success, const string &err_msg) {
-            if (!success) {
-                // 生成截图失败，可能残留空文件  [AUTO-TRANSLATED:c96a4468]
-                // Screenshot generation failed, there may be residual empty files
-                File::delete_file(new_snap_tmp);
-            } else {
-                // 临时文件改成正式文件  [AUTO-TRANSLATED:eca24dfd]
-                // Temporary file changed to formal file
-                File::delete_file(new_snap);
-                rename(new_snap_tmp.data(), new_snap.data());
-            }
-            responseSnap(new_snap, allArgs.parser.getHeader(), invoker, err_msg);
-        });
+        FFmpegSnap::makeSnap(
+            allArgs["async"], allArgs["url"], new_snap_tmp, allArgs["timeout_sec"],
+            [invoker, allArgs, new_snap, new_snap_tmp](bool success, const string &err_msg) {
+                if (!success) {
+                    // 生成截图失败，可能残留空文件  [AUTO-TRANSLATED:c96a4468]
+                    // Screenshot generation failed, there may be residual empty files
+                    File::delete_file(new_snap_tmp);
+                } else {
+                    // 临时文件改成正式文件  [AUTO-TRANSLATED:eca24dfd]
+                    // Temporary file changed to formal file
+                    File::delete_file(new_snap);
+                    rename(new_snap_tmp.data(), new_snap.data());
+                }
+                responseSnap(new_snap, allArgs.parser.getHeader(), invoker, err_msg);
+            });
     });
 
-    api_regist("/index/api/getStatistic",[](API_ARGS_MAP_ASYNC){
+    api_regist("/index/api/getStatistic", [](API_ARGS_MAP_ASYNC) {
         CHECK_SECRET();
-        getStatisticJson([headerOut, val, invoker](const Value &data) mutable{
+        getStatisticJson([headerOut, val, invoker](const Value &data) mutable {
             val["data"] = data;
             invoker(200, headerOut, val.toStyledString());
         });
@@ -2134,7 +2115,7 @@ void installWebApi() {
         }
 
     private:
-        string getUrl() const{
+        string getUrl() const {
             auto &allArgs = _args;
             CHECK_ARGS("app", "stream");
 
@@ -2148,13 +2129,13 @@ void installWebApi() {
         std::string _session_id;
     };
 
-    api_regist("/index/api/webrtc",[](API_ARGS_STRING_ASYNC){
+    api_regist("/index/api/webrtc", [](API_ARGS_STRING_ASYNC) {
         CHECK_ARGS("type");
         auto type = allArgs["type"];
         auto offer = allArgs.args;
         CHECK(!offer.empty(), "http body(webrtc offer sdp) is empty");
 
-        auto &session = static_cast<Session&>(sender);
+        auto &session = static_cast<Session &>(sender);
         auto args = std::make_shared<WebRtcArgsImp>(allArgs, sender.getIdentifier());
         WebRtcPluginManager::Instance().negotiateSdp(session, type, *args, [invoker, val, offer, headerOut](const WebRtcInterface &exchanger) mutable {
             auto &handler = const_cast<WebRtcInterface &>(exchanger);
@@ -2171,12 +2152,12 @@ void installWebApi() {
         });
     });
 
-    static constexpr char delete_webrtc_url [] = "/index/api/delete_webrtc";
+    static constexpr char delete_webrtc_url[] = "/index/api/delete_webrtc";
     static auto whip_whep_func = [](const char *type, API_ARGS_STRING_ASYNC) {
         auto offer = allArgs.args;
         CHECK(!offer.empty(), "http body(webrtc offer sdp) is empty");
 
-        auto &session = static_cast<Session&>(sender);
+        auto &session = static_cast<Session &>(sender);
         auto location = std::string(session.overSsl() ? "https://" : "http://") + allArgs["host"] + delete_webrtc_url;
         auto args = std::make_shared<WebRtcArgsImp>(allArgs, sender.getIdentifier());
         WebRtcPluginManager::Instance().negotiateSdp(session, type, *args, [invoker, offer, headerOut, location](const WebRtcInterface &exchanger) mutable {
@@ -2215,7 +2196,7 @@ void installWebApi() {
 #endif
 
 #if defined(ENABLE_VERSION)
-    api_regist("/index/api/version",[](API_ARGS_MAP_ASYNC){
+    api_regist("/index/api/version", [](API_ARGS_MAP_ASYNC) {
         CHECK_SECRET();
         Value ver;
         ver["buildTime"] = BUILD_TIME;
@@ -2244,10 +2225,11 @@ void installWebApi() {
         // 强制无人观看时自动关闭  [AUTO-TRANSLATED:f7c85948]
         // Force automatic shutdown when no one is watching
         option.auto_close = true;
-        auto tuple = MediaTuple{allArgs["vhost"], allArgs["app"], allArgs["stream"], ""};
+        auto tuple = MediaTuple { allArgs["vhost"], allArgs["app"], allArgs["stream"], "" };
         auto reader = std::make_shared<MP4Reader>(tuple, allArgs["file_path"], option);
         // sample_ms设置为0，从配置文件加载；file_repeat可以指定，如果配置文件也指定循环解复用，那么强制开启  [AUTO-TRANSLATED:23e826b4]
-        // sample_ms is set to 0, loaded from the configuration file; file_repeat can be specified, if the configuration file also specifies loop demultiplexing, then force it to be enabled
+        // sample_ms is set to 0, loaded from the configuration file; file_repeat can be specified, if the configuration file also specifies loop
+        // demultiplexing, then force it to be enabled
         reader->startReadMP4(0, true, allArgs["file_repeat"]);
         val["data"]["duration_ms"] = (Json::UInt64)reader->getDemuxer()->getDurationMS();
     });
@@ -2268,7 +2250,7 @@ void installWebApi() {
         auto file_path = allArgs["file_path"];
 
         if (file_path.find("..") != std::string::npos) {
-            invoker(401, StrCaseMap{}, "You can not access parent directory");
+            invoker(401, StrCaseMap {}, "You can not access parent directory");
             return;
         }
         bool safe = false;
@@ -2279,15 +2261,16 @@ void installWebApi() {
             }
         }
         if (!safe) {
-            invoker(401, StrCaseMap{}, "You can not download files outside the root directory");
+            invoker(401, StrCaseMap {}, "You can not download files outside the root directory");
             return;
         }
 
         // 通过on_http_access完成文件下载鉴权，请务必确认访问鉴权url参数以及访问文件路径是否合法  [AUTO-TRANSLATED:73507988]
-        // File download authentication is completed through on_http_access. Please make sure that the access authentication URL parameters and the access file path are legal
+        // File download authentication is completed through on_http_access. Please make sure that the access authentication URL parameters and the access file
+        // path are legal
         HttpSession::HttpAccessPathInvoker file_invoker = [allArgs, invoker](const string &err_msg, const string &cookie_path_in, int life_second) mutable {
             if (!err_msg.empty()) {
-                invoker(401, StrCaseMap{}, err_msg);
+                invoker(401, StrCaseMap {}, err_msg);
             } else {
                 StrCaseMap res_header;
                 auto save_name = allArgs["save_name"];
@@ -2352,7 +2335,7 @@ void installWebApi() {
 #endif
 }
 
-void unInstallWebApi(){
+void unInstallWebApi() {
     s_player_proxy.clear();
     s_ffmpeg_src.clear();
     s_pusher_proxy.clear();

--- a/src/Common/MediaSource.h
+++ b/src/Common/MediaSource.h
@@ -11,14 +11,14 @@
 #ifndef ZLMEDIAKIT_MEDIASOURCE_H
 #define ZLMEDIAKIT_MEDIASOURCE_H
 
-#include <string>
-#include <atomic>
-#include <memory>
-#include <functional>
-#include "Util/mini.h"
-#include "Network/Socket.h"
 #include "Extension/Track.h"
+#include "Network/Socket.h"
 #include "Record/Recorder.h"
+#include "Util/mini.h"
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <string>
 
 namespace toolkit {
 class Session;
@@ -26,18 +26,7 @@ class Session;
 
 namespace mediakit {
 
-enum class MediaOriginType : uint8_t {
-    unknown = 0,
-    rtmp_push ,
-    rtsp_push,
-    rtp_push,
-    pull,
-    ffmpeg_pull,
-    mp4_vod,
-    device_chn,
-    rtc_push,
-    srt_push
-};
+enum class MediaOriginType : uint8_t { unknown = 0, rtmp_push, rtsp_push, rtp_push, pull, ffmpeg_pull, mp4_vod, device_chn, rtc_push, srt_push };
 
 std::string getOriginTypeString(MediaOriginType type);
 
@@ -50,8 +39,9 @@ public:
 
     class NotImplemented : public std::runtime_error {
     public:
-        template<typename ...T>
-        NotImplemented(T && ...args) : std::runtime_error(std::forward<T>(args)...) {}
+        template <typename... T>
+        NotImplemented(T &&...args)
+            : std::runtime_error(std::forward<T>(args)...) {}
     };
 
     virtual ~MediaSourceEvent() = default;
@@ -92,7 +82,9 @@ public:
     virtual float getLossRate(MediaSource &sender, TrackType type) { return -1; }
     // 获取所在线程, 此函数一般强制重载  [AUTO-TRANSLATED:71c99afb]
     // Get the current thread, this function is generally forced to overload
-    virtual toolkit::EventPoller::Ptr getOwnerPoller(MediaSource &sender) { throw NotImplemented(toolkit::demangle(typeid(*this).name()) + "::getOwnerPoller not implemented"); }
+    virtual toolkit::EventPoller::Ptr getOwnerPoller(MediaSource &sender) {
+        throw NotImplemented(toolkit::demangle(typeid(*this).name()) + "::getOwnerPoller not implemented");
+    }
 
     // //////////////////////仅供MultiMediaSourceMuxer对象继承////////////////////////  [AUTO-TRANSLATED:6e810d1f]
     // //////////////////////Only for MultiMediaSourceMuxer object inheritance////////////////////////
@@ -125,7 +117,7 @@ public:
             kUdpActive = 1, // udp主动模式，主动发送数据给对方
             kTcpPassive = 2, // tcp被动模式，tcp服务器，等待对方连接并回复rtp
             kUdpPassive = 3, // udp被动方式，等待对方发送nat打洞包，然后回复rtp至打洞包源地址
-            kVoiceTalk = 4,  // 语音对讲模式，对方必须先推流上来，通过他的推流链路再回复rtp数据
+            kVoiceTalk = 4, // 语音对讲模式，对方必须先推流上来，通过他的推流链路再回复rtp数据
         };
 
         // rtp类型  [AUTO-TRANSLATED:acca40ab]
@@ -182,15 +174,16 @@ public:
 
     // 开始发送ps-rtp  [AUTO-TRANSLATED:a51796fa]
     // Start sending ps-rtp
-    virtual void startSendRtp(MediaSource &sender, const SendRtpArgs &args, const std::function<void(uint16_t, const toolkit::SockException &)> cb) { cb(0, toolkit::SockException(toolkit::Err_other, "not implemented"));};
+    virtual void startSendRtp(MediaSource &sender, const SendRtpArgs &args, const std::function<void(uint16_t, const toolkit::SockException &)> cb) {
+        cb(0, toolkit::SockException(toolkit::Err_other, "not implemented"));
+    };
     // 停止发送ps-rtp  [AUTO-TRANSLATED:952d2b35]
     // Stop sending ps-rtp
-    virtual bool stopSendRtp(MediaSource &sender, const std::string &ssrc) {return false; }
+    virtual bool stopSendRtp(MediaSource &sender, const std::string &ssrc) { return false; }
 
 private:
     toolkit::Timer::Ptr _async_close_timer;
 };
-
 
 template <typename MAP, typename KEY, typename TYPE>
 static void getArgsValue(const MAP &allArgs, const KEY &key, TYPE &value) {
@@ -268,7 +261,8 @@ public:
     bool enable_fmp4;
 
     // hls协议是否按需生成，如果hls.segNum配置为0(意味着hls录制)，那么hls将一直生成(不管此开关)  [AUTO-TRANSLATED:4653b411]
-    // Whether to generate hls protocol on demand, if hls.segNum is configured to 0 (meaning hls recording), then hls will always be generated (regardless of this switch)
+    // Whether to generate hls protocol on demand, if hls.segNum is configured to 0 (meaning hls recording), then hls will always be generated (regardless of
+    // this switch)
     bool hls_demand;
     // rtsp[s]协议是否按需生成  [AUTO-TRANSLATED:1c3237b0]
     // Whether to generate rtsp[s] protocol on demand
@@ -305,8 +299,12 @@ public:
     // Maximum number of tracks
     size_t max_track = 2;
 
+    // 用于保存用户的上下文数据，在回调时回传给用户
+    std::string userdata;
+
     template <typename MAP>
-    ProtocolOption(const MAP &allArgs) : ProtocolOption() {
+    ProtocolOption(const MAP &allArgs)
+        : ProtocolOption() {
         load(allArgs);
     }
 
@@ -341,6 +339,7 @@ public:
         GET_OPT_VALUE(hls_save_path);
         GET_OPT_VALUE(stream_replace);
         GET_OPT_VALUE(max_track);
+        GET_OPT_VALUE(userdata);
     }
 };
 
@@ -356,7 +355,7 @@ public:
     std::shared_ptr<toolkit::SockInfo> getOriginSock(MediaSource &sender) const override;
 
     bool seekTo(MediaSource &sender, uint32_t stamp) override;
-    bool pause(MediaSource &sender,  bool pause) override;
+    bool pause(MediaSource &sender, bool pause) override;
     bool speed(MediaSource &sender, float speed) override;
     bool close(MediaSource &sender) override;
     int totalReaderCount(MediaSource &sender) override;
@@ -379,10 +378,10 @@ private:
 /**
  * 解析url获取媒体相关信息
  * Parse the url to get media information
- 
+
  * [AUTO-TRANSLATED:3b3cfde7]
  */
-class MediaInfo: public MediaTuple {
+class MediaInfo : public MediaTuple {
 public:
     MediaInfo() = default;
     MediaInfo(const std::string &url) { parse(url); }
@@ -397,20 +396,22 @@ public:
     std::string host;
 };
 
-bool equalMediaTuple(const MediaTuple& a, const MediaTuple& b);
+bool equalMediaTuple(const MediaTuple &a, const MediaTuple &b);
 
 /**
  * 媒体源，任何rtsp/rtmp的直播流都源自该对象
  * Media source, any rtsp/rtmp live stream originates from this object
- 
+
  * [AUTO-TRANSLATED:658077ad]
  */
-class MediaSource: public TrackSource, public std::enable_shared_from_this<MediaSource> {
+class MediaSource
+    : public TrackSource
+    , public std::enable_shared_from_this<MediaSource> {
 public:
-    static MediaSource& NullMediaSource();
+    static MediaSource &NullMediaSource();
     using Ptr = std::shared_ptr<MediaSource>;
 
-    MediaSource(const std::string &schema, const MediaTuple& tuple);
+    MediaSource(const std::string &schema, const MediaTuple &tuple);
     virtual ~MediaSource();
 
     // //////////////获取MediaSource相关信息////////////////  [AUTO-TRANSLATED:4a520f1f]
@@ -418,13 +419,9 @@ public:
 
     // 获取协议类型  [AUTO-TRANSLATED:d6b50c14]
     // Get protocol type
-    const std::string& getSchema() const {
-        return _schema;
-    }
+    const std::string &getSchema() const { return _schema; }
 
-    const MediaTuple& getMediaTuple() const {
-        return _tuple;
-    }
+    const MediaTuple &getMediaTuple() const { return _tuple; }
 
     std::string getUrl() const { return _schema + "://" + _tuple.shortUrl(); }
 
@@ -473,8 +470,8 @@ public:
     virtual int totalReaderCount();
     // 获取播放器列表  [AUTO-TRANSLATED:e7691d2b]
     // Get the player list
-    virtual void getPlayerList(const std::function<void(const std::list<toolkit::Any> &info_list)> &cb,
-                               const std::function<toolkit::Any(toolkit::Any &&info)> &on_change) {
+    virtual void
+    getPlayerList(const std::function<void(const std::list<toolkit::Any> &info_list)> &cb, const std::function<toolkit::Any(toolkit::Any &&info)> &on_change) {
         assert(cb);
         cb(std::list<toolkit::Any>());
     }
@@ -537,9 +534,7 @@ public:
     // 同步查找流  [AUTO-TRANSLATED:97048f1e]
     // Synchronously find the stream
     static Ptr find(const std::string &schema, const std::string &vhost, const std::string &app, const std::string &id, bool from_mp4 = false);
-    static Ptr find(const MediaInfo &info, bool from_mp4 = false) {
-        return find(info.schema, info.vhost, info.app, info.stream, from_mp4);
-    }
+    static Ptr find(const MediaInfo &info, bool from_mp4 = false) { return find(info.schema, info.vhost, info.app, info.stream, from_mp4); }
 
     // 忽略schema，同步查找流，可能返回rtmp/rtsp/hls类型  [AUTO-TRANSLATED:8c061cac]
     // Ignore schema, synchronously find the stream, may return rtmp/rtsp/hls type
@@ -550,10 +545,14 @@ public:
     static void findAsync(const MediaInfo &info, const std::shared_ptr<toolkit::Session> &session, const std::function<void(const Ptr &src)> &cb);
     // 遍历所有流  [AUTO-TRANSLATED:a39b2399]
     // Traverse all streams
-    static void for_each_media(const std::function<void(const Ptr &src)> &cb, const std::string &schema = "", const std::string &vhost = "", const std::string &app = "", const std::string &stream = "");
+    static void for_each_media(
+        const std::function<void(const Ptr &src)> &cb, const std::string &schema = "", const std::string &vhost = "", const std::string &app = "",
+        const std::string &stream = "");
     // 从mp4文件生成MediaSource  [AUTO-TRANSLATED:7df9762e]
     // Generate MediaSource from mp4 file
-    static MediaSource::Ptr createFromMP4(const std::string &schema, const std::string &vhost, const std::string &app, const std::string &stream, const std::string &file_path = "", bool check_app = true);
+    static MediaSource::Ptr createFromMP4(
+        const std::string &schema, const std::string &vhost, const std::string &app, const std::string &stream, const std::string &file_path = "",
+        bool check_app = true);
 
 protected:
     // 媒体注册  [AUTO-TRANSLATED:dbf5c730]
@@ -584,4 +583,4 @@ private:
 };
 
 } /* namespace mediakit */
-#endif //ZLMEDIAKIT_MEDIASOURCE_H
+#endif // ZLMEDIAKIT_MEDIASOURCE_H

--- a/src/Record/Recorder.h
+++ b/src/Record/Recorder.h
@@ -11,9 +11,9 @@
 #ifndef SRC_MEDIAFILE_RECORDER_H_
 #define SRC_MEDIAFILE_RECORDER_H_
 
+#include <cstdint>
 #include <memory>
 #include <string>
-#include <cstdint>
 
 namespace mediakit {
 class MediaSinkInterface;
@@ -24,23 +24,22 @@ struct MediaTuple {
     std::string app;
     std::string stream;
     std::string params;
-    std::string shortUrl() const {
-        return vhost + '/' + app + '/' + stream;
-    }
+    std::string userdata;
+    std::string shortUrl() const { return vhost + '/' + app + '/' + stream; }
 };
 
-class RecordInfo: public MediaTuple {
+class RecordInfo : public MediaTuple {
 public:
-    time_t start_time;  // GMT 标准时间，单位秒
-    float time_len;     // 录像长度，单位秒
-    uint64_t file_size;    // 文件大小，单位 BYTE
-    std::string file_path;   // 文件路径
-    std::string file_name;   // 文件名称
-    std::string folder;      // 文件夹路径
-    std::string url;         // 播放路径
+    time_t start_time; // GMT 标准时间，单位秒
+    float time_len; // 录像长度，单位秒
+    uint64_t file_size; // 文件大小，单位 BYTE
+    std::string file_path; // 文件路径
+    std::string file_name; // 文件名称
+    std::string folder; // 文件夹路径
+    std::string url; // 播放路径
 };
 
-class Recorder{
+class Recorder {
 public:
     typedef enum {
         // 录制hls  [AUTO-TRANSLATED:24a50dff]
@@ -75,10 +74,10 @@ public:
      * @param stream_id stream id
      * @param customized_path custom root directory for saving recording files, empty means using configuration file settings
      * @return  absolute path of the recording file
-     
+
      * [AUTO-TRANSLATED:2fd57fcd]
      */
-    static std::string getRecordPath(type type, const MediaTuple& tuple, const std::string &customized_path = "");
+    static std::string getRecordPath(type type, const MediaTuple &tuple, const std::string &customized_path = "");
 
     /**
      * 创建录制器对象
@@ -97,11 +96,11 @@ public:
      * @param customized_path custom root directory for saving recording files, empty means using configuration file settings
      * @param max_second maximum slice time for mp4 recording, in seconds, 0 means using configuration file settings
      * @return object pointer, may be nullptr
-     
-     
+
+
      * [AUTO-TRANSLATED:e0b6e43b]
      */
-    static std::shared_ptr<MediaSinkInterface> createRecorder(type type, const MediaTuple& tuple, const ProtocolOption &option);
+    static std::shared_ptr<MediaSinkInterface> createRecorder(type type, const MediaTuple &tuple, const ProtocolOption &option);
 
 private:
     Recorder() = delete;

--- a/src/Rtmp/RtmpSession.cpp
+++ b/src/Rtmp/RtmpSession.cpp
@@ -17,31 +17,29 @@ using namespace toolkit;
 
 namespace mediakit {
 
-RtmpSession::RtmpSession(const Socket::Ptr &sock) : Session(sock) {
-    GET_CONFIG(uint32_t,keep_alive_sec,Rtmp::kKeepAliveSecond);
+RtmpSession::RtmpSession(const Socket::Ptr &sock)
+    : Session(sock) {
+    GET_CONFIG(uint32_t, keep_alive_sec, Rtmp::kKeepAliveSecond);
     sock->setSendTimeOutSecond(keep_alive_sec);
 }
 
-void RtmpSession::onError(const SockException& err) {
+void RtmpSession::onError(const SockException &err) {
     bool is_player = !_push_src_ownership;
     uint64_t duration = _ticker.createdTime() / 1000;
-    WarnP(this) << (is_player ? "RTMP播放器(" : "RTMP推流器(")
-                << _media_info.shortUrl()
-                << ")断开:" << err.what()
-                << ",耗时(s):" << duration;
+    WarnP(this) << (is_player ? "RTMP播放器(" : "RTMP推流器(") << _media_info.shortUrl() << ")断开:" << err.what() << ",耗时(s):" << duration;
 
-    //流量统计事件广播
+    // 流量统计事件广播
     GET_CONFIG(uint32_t, iFlowThreshold, General::kFlowThreshold);
 
     if (_total_bytes >= iFlowThreshold * 1024) {
         NOTICE_EMIT(BroadcastFlowReportArgs, Broadcast::kBroadcastFlowReport, _media_info, _total_bytes, duration, is_player, *this);
     }
 
-    //如果是主动关闭的，那么不延迟注销
+    // 如果是主动关闭的，那么不延迟注销
     if (_push_src && _continue_push_ms && err.getErrCode() != Err_shutdown) {
-        //取消所有权
+        // 取消所有权
         _push_src_ownership = nullptr;
-        //延时10秒注销流
+        // 延时10秒注销流
         auto push_src = std::move(_push_src);
         getPoller()->doDelayTask(_continue_push_ms, [push_src]() { return 0; });
     }
@@ -130,7 +128,7 @@ void RtmpSession::onCmd_publish(AMFDecoder &dec) {
             DebugP(strong_self.get()) << "publish 回复时间:" << ticker->elapsedTime() << "ms";
         }
     }));
-    dec.load<AMFValue>();/* NULL */
+    dec.load<AMFValue>(); /* NULL */
     // 赋值为rtmp stream id 信息
     _media_info.stream = getStreamId(dec.load<std::string>());
     // 再解析url，切割url为app/stream_id (不一定符合rtmp url切割规范)
@@ -140,10 +138,7 @@ void RtmpSession::onCmd_publish(AMFDecoder &dec) {
     auto on_res = [this, token, now_stream_index](const string &err, const ProtocolOption &option) {
         _now_stream_index = now_stream_index;
         if (!err.empty()) {
-            sendStatus({ "level", "error",
-                         "code", "NetStream.Publish.BadAuth",
-                         "description", err,
-                         "clientid", "0" });
+            sendStatus({ "level", "error", "code", "NetStream.Publish.BadAuth", "description", err, "clientid", "0" });
             shutdown(SockException(Err_shutdown, StrPrinter << "Unauthorized:" << err));
             return;
         }
@@ -153,15 +148,15 @@ void RtmpSession::onCmd_publish(AMFDecoder &dec) {
         auto push_failed = (bool)src;
 
         while (src) {
-            //尝试断连后继续推流
+            // 尝试断连后继续推流
             auto rtmp_src = dynamic_pointer_cast<RtmpMediaSourceImp>(src);
             if (!rtmp_src) {
-                //源不是rtmp推流产生的
+                // 源不是rtmp推流产生的
                 break;
             }
             auto ownership = rtmp_src->getOwnership();
             if (!ownership) {
-                //获取推流源所有权失败
+                // 获取推流源所有权失败
                 break;
             }
             _push_src = std::move(rtmp_src);
@@ -171,33 +166,27 @@ void RtmpSession::onCmd_publish(AMFDecoder &dec) {
         }
 
         if (push_failed) {
-            sendStatus({"level", "error",
-                        "code", "NetStream.Publish.BadName",
-                        "description", "Already publishing.",
-                        "clientid", "0" });
+            sendStatus({ "level", "error", "code", "NetStream.Publish.BadName", "description", "Already publishing.", "clientid", "0" });
             shutdown(SockException(Err_shutdown, StrPrinter << "Already publishing:" << err));
             return;
         }
 
         if (!_push_src) {
             _push_src = std::make_shared<RtmpMediaSourceImp>(_media_info);
-            //获取所有权
+            // 获取所有权
             _push_src_ownership = _push_src->getOwnership();
             _push_src->setProtocolOption(option);
         }
 
         _push_src->setListener(static_pointer_cast<RtmpSession>(shared_from_this()));
         _continue_push_ms = option.continue_push_ms;
-        sendStatus({"level", "status",
-                    "code", "NetStream.Publish.Start",
-                    "description", "Started publishing stream.",
-                    "clientid", "0" });
+        sendStatus({ "level", "status", "code", "NetStream.Publish.Start", "description", "Started publishing stream.", "clientid", "0" });
 
         setSocketFlags();
     };
 
-    if(_media_info.app.empty() || _media_info.stream.empty()){
-        //不允许莫名其妙的推流url
+    if (_media_info.app.empty() || _media_info.stream.empty()) {
+        // 不允许莫名其妙的推流url
         on_res("rtmp推流url非法", ProtocolOption());
         return;
     }
@@ -212,22 +201,21 @@ void RtmpSession::onCmd_publish(AMFDecoder &dec) {
             if (!strong_self) {
                 return;
             }
+            strong_self->_media_info.userdata = option.userdata;
             on_res(err, option);
         });
     };
     auto flag = NOTICE_EMIT(BroadcastMediaPublishArgs, Broadcast::kBroadcastMediaPublish, MediaOriginType::rtmp_push, _media_info, invoker, *this);
-    if(!flag){
-        //该事件无人监听，默认鉴权成功
+    if (!flag) {
+        // 该事件无人监听，默认鉴权成功
         on_res("", ProtocolOption());
     }
 }
 
 void RtmpSession::onCmd_deleteStream(AMFDecoder &dec) {
     _push_src = nullptr;
-    //此时回复可能触发broken pipe事件，从而直接触发onError回调；所以需要先把_push_src置空，防止触发断流续推功能
-    sendStatus({ "level", "status",
-                 "code", "NetStream.Unpublish.Success",
-                 "description", "Stop publishing." });
+    // 此时回复可能触发broken pipe事件，从而直接触发onError回调；所以需要先把_push_src置空，防止触发断流续推功能
+    sendStatus({ "level", "status", "code", "NetStream.Unpublish.Success", "description", "Stop publishing." });
     throw std::runtime_error(StrPrinter << "Stop publishing" << endl);
 }
 
@@ -249,15 +237,14 @@ void RtmpSession::sendPlayResponse(const string &err, const RtmpMediaSource::Ptr
     bool auth_success = err.empty();
     bool ok = (src.operator bool() && auth_success);
     if (ok) {
-        //stream begin
+        // stream begin
         sendUserControl(CONTROL_STREAM_BEGIN, STREAM_MEDIA);
     }
     // onStatus(NetStream.Play.Reset)
-    sendStatus({ "level", (ok ? "status" : "error"),
-                 "code", (ok ? "NetStream.Play.Reset" : (auth_success ? "NetStream.Play.StreamNotFound" : "NetStream.Play.BadAuth")),
-                 "description", (ok ? "Resetting and playing." : (auth_success ? "No such stream." : err.data())),
-                 "details", _media_info.stream,
-                 "clientid", "0" });
+    sendStatus(
+        { "level", (ok ? "status" : "error"), "code",
+          (ok ? "NetStream.Play.Reset" : (auth_success ? "NetStream.Play.StreamNotFound" : "NetStream.Play.BadAuth")), "description",
+          (ok ? "Resetting and playing." : (auth_success ? "No such stream." : err.data())), "details", _media_info.stream, "clientid", "0" });
 
     if (!ok) {
         string err_msg = StrPrinter << (auth_success ? "no such stream:" : err.data()) << " " << _media_info.shortUrl();
@@ -267,30 +254,22 @@ void RtmpSession::sendPlayResponse(const string &err, const RtmpMediaSource::Ptr
 
     // onStatus(NetStream.Play.Start)
 
-    sendStatus({ "level", "status",
-                 "code", "NetStream.Play.Start",
-                 "description", "Started playing." ,
-                 "details", _media_info.stream,
-                 "clientid", "0"});
+    sendStatus({ "level", "status", "code", "NetStream.Play.Start", "description", "Started playing.", "details", _media_info.stream, "clientid", "0" });
 
     // |RtmpSampleAccess(true, true)
     AMFEncoder invoke;
     invoke << "|RtmpSampleAccess" << true << true;
     sendResponse(MSG_DATA, invoke.data());
 
-    //onStatus(NetStream.Data.Start)
+    // onStatus(NetStream.Data.Start)
     invoke.clear();
     AMFValue obj(AMF_OBJECT);
     obj.set("code", "NetStream.Data.Start");
     invoke << "onStatus" << obj;
     sendResponse(MSG_DATA, invoke.data());
 
-    //onStatus(NetStream.Play.PublishNotify)
-    sendStatus({ "level", "status",
-                 "code", "NetStream.Play.PublishNotify",
-                 "description", "Now published." ,
-                 "details", _media_info.stream,
-                 "clientid", "0"});
+    // onStatus(NetStream.Play.PublishNotify)
+    sendStatus({ "level", "status", "code", "NetStream.Play.PublishNotify", "description", "Now published.", "details", _media_info.stream, "clientid", "0" });
     // metadata
     src->getMetaData([&](const AMFValue &metadata) {
         invoke.clear();
@@ -299,9 +278,7 @@ void RtmpSession::sendPlayResponse(const string &err, const RtmpMediaSource::Ptr
     });
 
     // config frame
-    src->getConfigFrame([&](const RtmpPacket::Ptr &pkt) {
-        onSendMedia(pkt);
-    });
+    src->getConfigFrame([&](const RtmpPacket::Ptr &pkt) { onSendMedia(pkt); });
 
     src->pause(false);
     _ring_reader = src->getRing()->attach(getPoller());
@@ -319,8 +296,8 @@ void RtmpSession::sendPlayResponse(const string &err, const RtmpMediaSource::Ptr
         size_t i = 0;
         auto size = pkt->size();
         strong_self->setSendFlushFlag(false);
-        pkt->for_each([&](const RtmpPacket::Ptr &rtmp){
-            if(++i == size){
+        pkt->for_each([&](const RtmpPacket::Ptr &rtmp) {
+            if (++i == size) {
                 strong_self->setSendFlushFlag(true);
             }
             strong_self->onSendMedia(rtmp);
@@ -331,39 +308,39 @@ void RtmpSession::sendPlayResponse(const string &err, const RtmpMediaSource::Ptr
         if (!strong_self) {
             return;
         }
-        strong_self->sendUserControl(CONTROL_STREAM_EOF/*or CONTROL_STREAM_DRY ?*/, STREAM_MEDIA);
-        strong_self->shutdown(SockException(Err_shutdown,"rtmp ring buffer detached"));
+        strong_self->sendUserControl(CONTROL_STREAM_EOF /*or CONTROL_STREAM_DRY ?*/, STREAM_MEDIA);
+        strong_self->shutdown(SockException(Err_shutdown, "rtmp ring buffer detached"));
     });
     src->pause(false);
     _play_src = src;
-    //提高服务器发送性能
+    // 提高服务器发送性能
     setSocketFlags();
 }
 
-void RtmpSession::doPlayResponse(const string &err,const std::function<void(bool)> &cb){
-    if(!err.empty()){
-        //鉴权失败，直接返回播放失败
+void RtmpSession::doPlayResponse(const string &err, const std::function<void(bool)> &cb) {
+    if (!err.empty()) {
+        // 鉴权失败，直接返回播放失败
         sendPlayResponse(err, nullptr);
         cb(false);
         return;
     }
 
-    //鉴权成功，查找媒体源并回复
+    // 鉴权成功，查找媒体源并回复
     weak_ptr<RtmpSession> weak_self = static_pointer_cast<RtmpSession>(shared_from_this());
-    MediaSource::findAsync(_media_info, weak_self.lock(), [weak_self,cb](const MediaSource::Ptr &src){
+    MediaSource::findAsync(_media_info, weak_self.lock(), [weak_self, cb](const MediaSource::Ptr &src) {
         auto rtmp_src = dynamic_pointer_cast<RtmpMediaSource>(src);
         auto strong_self = weak_self.lock();
-        if(strong_self){
+        if (strong_self) {
             strong_self->sendPlayResponse("", rtmp_src);
         }
         cb(rtmp_src.operator bool());
     });
 }
 
-void RtmpSession::doPlay(AMFDecoder &dec){
+void RtmpSession::doPlay(AMFDecoder &dec) {
     std::shared_ptr<Ticker> ticker(new Ticker);
     weak_ptr<RtmpSession> weak_self = static_pointer_cast<RtmpSession>(shared_from_this());
-    std::shared_ptr<onceToken> token(new onceToken(nullptr, [ticker,weak_self](){
+    std::shared_ptr<onceToken> token(new onceToken(nullptr, [ticker, weak_self]() {
         auto strong_self = weak_self.lock();
         if (strong_self) {
             DebugP(strong_self.get()) << "play 回复时间:" << ticker->elapsedTime() << "ms";
@@ -396,26 +373,26 @@ void RtmpSession::onCmd_play2(AMFDecoder &dec) {
     doPlay(dec);
 }
 
-string RtmpSession::getStreamId(const string &str){
+string RtmpSession::getStreamId(const string &str) {
     string stream_id;
     string params;
     auto pos = str.find('?');
     if (pos != string::npos) {
-        //有url参数
+        // 有url参数
         stream_id = str.substr(0, pos);
-        //获取url参数
+        // 获取url参数
         params = str.substr(pos + 1);
     } else {
-        //没有url参数
+        // 没有url参数
         stream_id = str;
     }
 
     pos = stream_id.find(":");
     if (pos != string::npos) {
-        //vlc和ffplay在播放 rtmp://127.0.0.1/record/0.mp4时，
-        //传过来的url会是rtmp://127.0.0.1/record/mp4:0,
-        //我们在这里还原成0.mp4
-        //实际使用时发现vlc，mpv等会传过来rtmp://127.0.0.1/record/mp4:0.mp4,这里做个判断
+        // vlc和ffplay在播放 rtmp://127.0.0.1/record/0.mp4时，
+        // 传过来的url会是rtmp://127.0.0.1/record/mp4:0,
+        // 我们在这里还原成0.mp4
+        // 实际使用时发现vlc，mpv等会传过来rtmp://127.0.0.1/record/mp4:0.mp4,这里做个判断
         auto ext = stream_id.substr(0, pos);
         stream_id = stream_id.substr(pos + 1);
         if (stream_id.find(ext) == string::npos) {
@@ -424,11 +401,11 @@ string RtmpSession::getStreamId(const string &str){
     }
 
     if (params.empty()) {
-        //没有url参数
+        // 没有url参数
         return stream_id;
     }
 
-    //有url参数
+    // 有url参数
     return stream_id + '?' + params;
 }
 
@@ -442,15 +419,15 @@ void RtmpSession::onCmd_play(AMFDecoder &dec) {
 }
 
 void RtmpSession::onCmd_pause(AMFDecoder &dec) {
-    dec.load<AMFValue>();/* NULL */
+    dec.load<AMFValue>(); /* NULL */
     bool paused = dec.load<bool>();
     TraceP(this) << paused;
 
-    sendStatus({ "level", "status",
-                 "code", (paused ? "NetStream.Pause.Notify" : "NetStream.Unpause.Notify"),
-                 "description", (paused ? "Paused stream." : "Unpaused stream.")});
+    sendStatus(
+        { "level", "status", "code", (paused ? "NetStream.Pause.Notify" : "NetStream.Unpause.Notify"), "description",
+          (paused ? "Paused stream." : "Unpaused stream.") });
 
-    //streamBegin
+    // streamBegin
     sendUserControl(paused ? CONTROL_STREAM_EOF : CONTROL_STREAM_BEGIN, STREAM_MEDIA);
     auto strongSrc = _play_src.lock();
     if (strongSrc) {
@@ -464,11 +441,9 @@ void RtmpSession::onCmd_playCtrl(AMFDecoder &dec) {
     int ctrlType = ctrlObj["ctrlType"].as_integer();
     float speed = ctrlObj["speed"].as_number();
 
-    sendStatus({ "level", "status",
-                 "code", "NetStream.Speed.Notify",
-                 "description", "Speeding"});
+    sendStatus({ "level", "status", "code", "NetStream.Speed.Notify", "description", "Speeding" });
 
-    //streamBegin
+    // streamBegin
     sendUserControl(CONTROL_STREAM_EOF, STREAM_MEDIA);
 
     auto strong_src = _play_src.lock();
@@ -504,7 +479,7 @@ void RtmpSession::onProcessCmd(AMFDecoder &dec) {
     std::string method = dec.load<std::string>();
     auto it = s_cmd_functions.find(method);
     if (it == s_cmd_functions.end()) {
-//		TraceP(this) << "can not support cmd:" << method;
+        //		TraceP(this) << "can not support cmd:" << method;
         return;
     }
     _recv_req_id = dec.load<double>();
@@ -515,68 +490,64 @@ void RtmpSession::onProcessCmd(AMFDecoder &dec) {
 void RtmpSession::onRtmpChunk(RtmpPacket::Ptr packet) {
     auto &chunk_data = *packet;
     switch (chunk_data.type_id) {
-    case MSG_CMD:
-    case MSG_CMD3: {
-        AMFDecoder dec(chunk_data.buffer, chunk_data.type_id == MSG_CMD3 ? 3 : 0);
-        onProcessCmd(dec);
-        break;
-    }
-
-    case MSG_DATA:
-    case MSG_DATA3: {
-        AMFDecoder dec(chunk_data.buffer, chunk_data.type_id == MSG_DATA3 ? 3 : 0);
-        std::string type = dec.load<std::string>();
-        if (type == "@setDataFrame") {
-            setMetaData(dec);
-        } else if (type == "onMetaData") {
-            //兼容某些不规范的推流器
-            _push_metadata = dec.load<AMFValue>();
-            _set_meta_data = false;
-        } else {
-            TraceP(this) << "unknown notify:" << type;
+        case MSG_CMD:
+        case MSG_CMD3: {
+            AMFDecoder dec(chunk_data.buffer, chunk_data.type_id == MSG_CMD3 ? 3 : 0);
+            onProcessCmd(dec);
+            break;
         }
-        break;
-    }
 
-    case MSG_AUDIO:
-    case MSG_VIDEO: {
-        if (!_push_src) {
-            if (_ring_reader) {
-                throw std::runtime_error("Rtmp player send media packets");
+        case MSG_DATA:
+        case MSG_DATA3: {
+            AMFDecoder dec(chunk_data.buffer, chunk_data.type_id == MSG_DATA3 ? 3 : 0);
+            std::string type = dec.load<std::string>();
+            if (type == "@setDataFrame") {
+                setMetaData(dec);
+            } else if (type == "onMetaData") {
+                // 兼容某些不规范的推流器
+                _push_metadata = dec.load<AMFValue>();
+                _set_meta_data = false;
+            } else {
+                TraceP(this) << "unknown notify:" << type;
             }
-            if (packet->isConfigFrame()) {
-                auto id = packet->type_id;
-                _push_config_packets.emplace(id, std::move(packet));
-            }
-            WarnL << "Rtmp pusher send media packet before handshake completed!";
-            return;
+            break;
         }
 
-        if (!_set_meta_data) {
-            _set_meta_data = true;
-            _push_src->setMetaData(_push_metadata ? _push_metadata : TitleMeta().getMetadata());
-        }
-        if (!_push_config_packets.empty()) {
-            for (auto &pr : _push_config_packets) {
-                _push_src->onWrite(std::move(pr.second));
+        case MSG_AUDIO:
+        case MSG_VIDEO: {
+            if (!_push_src) {
+                if (_ring_reader) {
+                    throw std::runtime_error("Rtmp player send media packets");
+                }
+                if (packet->isConfigFrame()) {
+                    auto id = packet->type_id;
+                    _push_config_packets.emplace(id, std::move(packet));
+                }
+                WarnL << "Rtmp pusher send media packet before handshake completed!";
+                return;
             }
-            _push_config_packets.clear();
-        }
-        _push_src->onWrite(std::move(packet));
-        break;
-    }
 
-    default:
-        WarnP(this) << "unhandled message:" << (int) chunk_data.type_id << hexdump(chunk_data.buffer.data(), chunk_data.buffer.size());
-        break;
+            if (!_set_meta_data) {
+                _set_meta_data = true;
+                _push_src->setMetaData(_push_metadata ? _push_metadata : TitleMeta().getMetadata());
+            }
+            if (!_push_config_packets.empty()) {
+                for (auto &pr : _push_config_packets) {
+                    _push_src->onWrite(std::move(pr.second));
+                }
+                _push_config_packets.clear();
+            }
+            _push_src->onWrite(std::move(packet));
+            break;
+        }
+
+        default: WarnP(this) << "unhandled message:" << (int)chunk_data.type_id << hexdump(chunk_data.buffer.data(), chunk_data.buffer.size()); break;
     }
 }
 
 void RtmpSession::onCmd_seek(AMFDecoder &dec) {
-    dec.load<AMFValue>();/* NULL */
-    sendStatus({ "level", "status",
-                 "code", "NetStream.Seek.Notify",
-                 "description", "Seeking."});
+    dec.load<AMFValue>(); /* NULL */
+    sendStatus({ "level", "status", "code", "NetStream.Seek.Notify", "description", "Seeking." });
 
     auto milliSeconds = (uint32_t)(dec.load<AMFValue>().as_number());
     InfoP(this) << "rtmp seekTo(ms):" << milliSeconds;
@@ -591,7 +562,7 @@ void RtmpSession::onSendMedia(const RtmpPacket::Ptr &pkt) {
 }
 
 bool RtmpSession::close(MediaSource &sender) {
-    //此回调在其他线程触发
+    // 此回调在其他线程触发
     string err = StrPrinter << "close media: " << sender.getUrl();
     safeShutdown(SockException(Err_shutdown, err));
     return true;
@@ -601,7 +572,7 @@ int RtmpSession::totalReaderCount(MediaSource &sender) {
     return _push_src ? _push_src->totalReaderCount() : sender.readerCount();
 }
 
-MediaOriginType RtmpSession::getOriginType(MediaSource &sender) const{
+MediaOriginType RtmpSession::getOriginType(MediaSource &sender) const {
     return MediaOriginType::rtmp_push;
 }
 
@@ -617,12 +588,12 @@ toolkit::EventPoller::Ptr RtmpSession::getOwnerPoller(MediaSource &sender) {
     return getPoller();
 }
 
-void RtmpSession::setSocketFlags(){
+void RtmpSession::setSocketFlags() {
     GET_CONFIG(int, merge_write_ms, General::kMergeWriteMS);
     if (merge_write_ms > 0) {
-        //推流模式下，关闭TCP_NODELAY会增加推流端的延时，但是服务器性能将提高
+        // 推流模式下，关闭TCP_NODELAY会增加推流端的延时，但是服务器性能将提高
         SockUtil::setNoDelay(getSock()->rawFD(), false);
-        //播放模式下，开启MSG_MORE会增加延时，但是能提高发送性能
+        // 播放模式下，开启MSG_MORE会增加延时，但是能提高发送性能
         setSendFlags(SOCKET_DEFAULE_FLAGS | FLAG_MORE);
     }
 }
@@ -633,9 +604,7 @@ void RtmpSession::dumpMetadata(const AMFValue &metadata) {
         return;
     }
     _StrPrinter printer;
-    metadata.object_for_each([&](const string &key, const AMFValue &val) {
-        printer << "\r\n" << key << "\t:" << val.to_string();
-    });
-    InfoL << _media_info.shortUrl() << (string) printer;
+    metadata.object_for_each([&](const string &key, const AMFValue &val) { printer << "\r\n" << key << "\t:" << val.to_string(); });
+    InfoL << _media_info.shortUrl() << (string)printer;
 }
 } /* namespace mediakit */

--- a/src/Rtsp/RtspSession.cpp
+++ b/src/Rtsp/RtspSession.cpp
@@ -8,15 +8,15 @@
  * may be found in the AUTHORS file in the root of the source tree.
  */
 
-#include <atomic>
-#include <iomanip>
-#include "Common/config.h"
-#include "UDPServer.h"
 #include "RtspSession.h"
+#include "Common/config.h"
+#include "Rtcp/RtcpContext.h"
+#include "RtpMultiCaster.h"
+#include "UDPServer.h"
 #include "Util/MD5.h"
 #include "Util/base64.h"
-#include "RtpMultiCaster.h"
-#include "Rtcp/RtcpContext.h"
+#include <atomic>
+#include <iomanip>
 
 using namespace std;
 using namespace toolkit;
@@ -45,47 +45,44 @@ namespace mediakit {
  * zlmediakit在处理rtsp over http的请求时，会把http poster中的content数据base64解码后转发给http getter处理
  */
 
-
-//rtsp over http 情况下get请求实例，在请求实例用于接收rtp数据包
-static unordered_map<string, weak_ptr<RtspSession> > g_mapGetter;
-//对g_mapGetter上锁保护
+// rtsp over http 情况下get请求实例，在请求实例用于接收rtp数据包
+static unordered_map<string, weak_ptr<RtspSession>> g_mapGetter;
+// 对g_mapGetter上锁保护
 static recursive_mutex g_mtxGetter;
 
-RtspSession::RtspSession(const Socket::Ptr &sock) : Session(sock) {
-    GET_CONFIG(uint32_t,keep_alive_sec,Rtsp::kKeepAliveSecond);
+RtspSession::RtspSession(const Socket::Ptr &sock)
+    : Session(sock) {
+    GET_CONFIG(uint32_t, keep_alive_sec, Rtsp::kKeepAliveSecond);
     sock->setSendTimeOutSecond(keep_alive_sec);
 }
 
 void RtspSession::onError(const SockException &err) {
     bool is_player = !_push_src_ownership;
     uint64_t duration = _alive_ticker.createdTime() / 1000;
-    WarnP(this) << (is_player ? "RTSP播放器(" : "RTSP推流器(")
-                << _media_info.shortUrl()
-                << ")断开:" << err.what()
-                << ",耗时(s):" << duration;
+    WarnP(this) << (is_player ? "RTSP播放器(" : "RTSP推流器(") << _media_info.shortUrl() << ")断开:" << err.what() << ",耗时(s):" << duration;
 
     if (_rtp_type == Rtsp::RTP_MULTICAST) {
-        //取消UDP端口监听
+        // 取消UDP端口监听
         UDPServer::Instance().stopListenPeer(get_peer_ip().data(), this);
     }
 
     if (_http_x_sessioncookie.size() != 0) {
-        //移除http getter的弱引用记录
+        // 移除http getter的弱引用记录
         lock_guard<recursive_mutex> lock(g_mtxGetter);
         g_mapGetter.erase(_http_x_sessioncookie);
     }
 
-    //流量统计事件广播
+    // 流量统计事件广播
     GET_CONFIG(uint32_t, iFlowThreshold, General::kFlowThreshold);
     if (_bytes_usage >= iFlowThreshold * 1024) {
         NOTICE_EMIT(BroadcastFlowReportArgs, Broadcast::kBroadcastFlowReport, _media_info, _bytes_usage, duration, is_player, *this);
     }
 
-    //如果是主动关闭的，那么不延迟注销
-    if (_push_src && _continue_push_ms  && err.getErrCode() != Err_shutdown) {
-        //取消所有权
+    // 如果是主动关闭的，那么不延迟注销
+    if (_push_src && _continue_push_ms && err.getErrCode() != Err_shutdown) {
+        // 取消所有权
         _push_src_ownership = nullptr;
-        //延时10秒注销流
+        // 延时10秒注销流
         auto push_src = std::move(_push_src);
         getPoller()->doDelayTask(_continue_push_ms, [push_src]() { return 0; });
     }
@@ -97,19 +94,19 @@ void RtspSession::onManager() {
 
     if (_alive_ticker.createdTime() > handshake_sec * 1000) {
         if (_sessionid.size() == 0) {
-            shutdown(SockException(Err_timeout,"illegal connection"));
+            shutdown(SockException(Err_timeout, "illegal connection"));
             return;
         }
     }
 
     if (_push_src && _alive_ticker.elapsedTime() > keep_alive_sec * 1000) {
-        //推流超时
+        // 推流超时
         shutdown(SockException(Err_timeout, "pusher session timeout"));
         return;
     }
 
     if (!_push_src && _rtp_type == Rtsp::RTP_UDP && _alive_ticker.elapsedTime() > keep_alive_sec * 4000) {
-        //rtp over udp播放器超时
+        // rtp over udp播放器超时
         shutdown(SockException(Err_timeout, "rtp over udp player timeout"));
     }
 }
@@ -118,7 +115,7 @@ void RtspSession::onRecv(const Buffer::Ptr &buf) {
     _alive_ticker.resetTime();
     _bytes_usage += buf->size();
     if (_on_recv) {
-        //http poster的请求数据转发给http getter处理
+        // http poster的请求数据转发给http getter处理
         _on_recv(buf);
     } else {
         input(buf->data(), buf->size());
@@ -126,9 +123,9 @@ void RtspSession::onRecv(const Buffer::Ptr &buf) {
 }
 
 void RtspSession::onWholeRtspPacket(Parser &parser) {
-    string method = parser.method(); //提取出请求命令字
+    string method = parser.method(); // 提取出请求命令字
     _cseq = atoi(parser["CSeq"].data());
-    if (_content_base.empty() && method != "GET" && method != "POST" ) {
+    if (_content_base.empty() && method != "GET" && method != "POST") {
         RtspUrl rtsp;
         rtsp.parse(parser.url());
         _content_base = rtsp._url;
@@ -170,52 +167,54 @@ void RtspSession::onRtpPacket(const char *data, size_t len) {
         CHECK(len > RtpPacket::kRtpHeaderSize + RtpPacket::kRtpTcpHeaderSize);
         RtpHeader *header = (RtpHeader *)(data + RtpPacket::kRtpTcpHeaderSize);
         auto track_idx = getTrackIndexByPT(header->pt);
-        handleOneRtp(track_idx, _sdp_track[track_idx]->_type, _sdp_track[track_idx]->_samplerate, (uint8_t *) data + RtpPacket::kRtpTcpHeaderSize, len - RtpPacket::kRtpTcpHeaderSize);
+        handleOneRtp(
+            track_idx, _sdp_track[track_idx]->_type, _sdp_track[track_idx]->_samplerate, (uint8_t *)data + RtpPacket::kRtpTcpHeaderSize,
+            len - RtpPacket::kRtpTcpHeaderSize);
     } else {
         auto track_idx = getTrackIndexByInterleaved(interleaved - 1);
         onRtcpPacket(track_idx, _sdp_track[track_idx], data + RtpPacket::kRtpTcpHeaderSize, len - RtpPacket::kRtpTcpHeaderSize);
     }
 }
 
-void RtspSession::onRtcpPacket(int track_idx, SdpTrack::Ptr &track, const char *data, size_t len){
-    auto rtcp_arr = RtcpHeader::loadFromBytes((char *) data, len);
+void RtspSession::onRtcpPacket(int track_idx, SdpTrack::Ptr &track, const char *data, size_t len) {
+    auto rtcp_arr = RtcpHeader::loadFromBytes((char *)data, len);
     for (auto &rtcp : rtcp_arr) {
         _rtcp_context[track_idx]->onRtcp(rtcp);
-        if ((RtcpType) rtcp->pt == RtcpType::RTCP_SR) {
-            auto sr = (RtcpSR *) (rtcp);
-            //设置rtp时间戳与ntp时间戳的对应关系
+        if ((RtcpType)rtcp->pt == RtcpType::RTCP_SR) {
+            auto sr = (RtcpSR *)(rtcp);
+            // 设置rtp时间戳与ntp时间戳的对应关系
             setNtpStamp(track_idx, sr->rtpts, sr->getNtpUnixStampMS());
         }
     }
 }
 
 ssize_t RtspSession::getContentLength(Parser &parser) {
-    if(parser.method() == "POST"){
-        //http post请求的content数据部分是base64编码后的rtsp请求信令包
+    if (parser.method() == "POST") {
+        // http post请求的content数据部分是base64编码后的rtsp请求信令包
         return remainDataSize();
     }
     return RtspSplitter::getContentLength(parser);
 }
 
 void RtspSession::handleReq_Options(const Parser &parser) {
-    //支持这些命令
-    sendRtspResponse("200 OK",{"Public" , "OPTIONS, DESCRIBE, SETUP, TEARDOWN, PLAY, PAUSE, ANNOUNCE, RECORD, SET_PARAMETER, GET_PARAMETER"});
+    // 支持这些命令
+    sendRtspResponse("200 OK", { "Public", "OPTIONS, DESCRIBE, SETUP, TEARDOWN, PLAY, PAUSE, ANNOUNCE, RECORD, SET_PARAMETER, GET_PARAMETER" });
 }
 
 void RtspSession::handleReq_ANNOUNCE(const Parser &parser) {
     auto full_url = parser.fullUrl();
     _content_base = full_url;
     if (end_with(full_url, ".sdp")) {
-        //去除.sdp后缀，防止EasyDarwin推流器强制添加.sdp后缀
+        // 去除.sdp后缀，防止EasyDarwin推流器强制添加.sdp后缀
         full_url = full_url.substr(0, full_url.length() - 4);
         _media_info.parse(full_url);
         _media_info.protocol = overSsl() ? "rtsps" : "rtsp";
     }
 
     if (_media_info.app.empty() || _media_info.stream.empty()) {
-        //推流rtsp url必须最少两级(rtsp://host/app/stream_id)，不允许莫名其妙的推流url
+        // 推流rtsp url必须最少两级(rtsp://host/app/stream_id)，不允许莫名其妙的推流url
         static constexpr auto err = "rtsp推流url非法,最少确保两级rtsp url";
-        sendRtspResponse("403 Forbidden", {"Content-Type", "text/plain"}, err);
+        sendRtspResponse("403 Forbidden", { "Content-Type", "text/plain" }, err);
         throw SockException(Err_shutdown, StrPrinter << err << ":" << full_url);
     }
 
@@ -231,15 +230,15 @@ void RtspSession::handleReq_ANNOUNCE(const Parser &parser) {
         auto push_failed = (bool)src;
 
         while (src) {
-            //尝试断连后继续推流
+            // 尝试断连后继续推流
             auto rtsp_src = dynamic_pointer_cast<RtspMediaSourceImp>(src);
             if (!rtsp_src) {
-                //源不是rtsp推流产生的
+                // 源不是rtsp推流产生的
                 break;
             }
             auto ownership = rtsp_src->getOwnership();
             if (!ownership) {
-                //获取推流源所有权失败
+                // 获取推流源所有权失败
                 break;
             }
             _push_src = std::move(rtsp_src);
@@ -271,7 +270,7 @@ void RtspSession::handleReq_ANNOUNCE(const Parser &parser) {
 
         if (!_push_src) {
             _push_src = std::make_shared<RtspMediaSourceImp>(_media_info);
-            //获取所有权
+            // 获取所有权
             _push_src_ownership = _push_src->getOwnership();
             _push_src->setProtocolOption(option);
             _push_src->setSdp(parser.content());
@@ -293,19 +292,20 @@ void RtspSession::handleReq_ANNOUNCE(const Parser &parser) {
             if (!strong_self) {
                 return;
             }
+            strong_self->_media_info.userdata = option.userdata;
             onRes(err, option);
         });
     };
 
-    //rtsp推流需要鉴权
+    // rtsp推流需要鉴权
     auto flag = NOTICE_EMIT(BroadcastMediaPublishArgs, Broadcast::kBroadcastMediaPublish, MediaOriginType::rtsp_push, _media_info, invoker, *this);
     if (!flag) {
-        //该事件无人监听,默认不鉴权
+        // 该事件无人监听,默认不鉴权
         onRes("", ProtocolOption());
     }
 }
 
-void RtspSession::handleReq_RECORD(const Parser &parser){
+void RtspSession::handleReq_RECORD(const Parser &parser) {
     if (_sdp_track.empty() || parser["Session"] != _sessionid) {
         send_SessionNotFound();
         throw SockException(Err_shutdown, _sdp_track.empty() ? "can not find any available track when record" : "session not found when record");
@@ -314,31 +314,31 @@ void RtspSession::handleReq_RECORD(const Parser &parser){
     _StrPrinter rtp_info;
     for (auto &track : _sdp_track) {
         if (track->_inited == false) {
-            //还有track没有setup
+            // 还有track没有setup
             shutdown(SockException(Err_shutdown, "track not setuped"));
             return;
         }
         rtp_info << "url=" << track->getControlUrl(_content_base) << ",";
     }
     rtp_info.pop_back();
-    sendRtspResponse("200 OK", {"RTP-Info", rtp_info});
+    sendRtspResponse("200 OK", { "RTP-Info", rtp_info });
     if (_rtp_type == Rtsp::RTP_TCP) {
-        //如果是rtsp推流服务器，并且是TCP推流，设置socket flags,，这样能提升接收性能
+        // 如果是rtsp推流服务器，并且是TCP推流，设置socket flags,，这样能提升接收性能
         setSocketFlags();
     }
 }
 
-void RtspSession::emitOnPlay(){
+void RtspSession::emitOnPlay() {
     weak_ptr<RtspSession> weak_self = static_pointer_cast<RtspSession>(shared_from_this());
-    //url鉴权回调
+    // url鉴权回调
     auto onRes = [weak_self](const string &err) {
         auto strong_self = weak_self.lock();
         if (!strong_self) {
             return;
         }
         if (!err.empty()) {
-            //播放url鉴权失败
-            strong_self->sendRtspResponse("401 Unauthorized", {"Content-Type", "text/plain"}, err);
+            // 播放url鉴权失败
+            strong_self->sendRtspResponse("401 Unauthorized", { "Content-Type", "text/plain" }, err);
             strong_self->shutdown(SockException(Err_shutdown, StrPrinter << "401 Unauthorized:" << err));
             return;
         }
@@ -350,83 +350,81 @@ void RtspSession::emitOnPlay(){
         if (!strong_self) {
             return;
         }
-        strong_self->async([onRes, err, weak_self]() {
-            onRes(err);
-        });
+        strong_self->async([onRes, err, weak_self]() { onRes(err); });
     };
 
-    //广播通用播放url鉴权事件
+    // 广播通用播放url鉴权事件
     auto flag = _emit_on_play ? false : NOTICE_EMIT(BroadcastMediaPlayedArgs, Broadcast::kBroadcastMediaPlayed, _media_info, invoker, *this);
     if (!flag) {
-        //该事件无人监听,默认不鉴权
+        // 该事件无人监听,默认不鉴权
         onRes("");
     }
-    //已经鉴权过了
+    // 已经鉴权过了
     _emit_on_play = true;
 }
 
 void RtspSession::handleReq_Describe(const Parser &parser) {
-    //该请求中的认证信息
+    // 该请求中的认证信息
     auto authorization = parser["Authorization"];
     weak_ptr<RtspSession> weak_self = static_pointer_cast<RtspSession>(shared_from_this());
-    //rtsp专属鉴权是否开启事件回调
+    // rtsp专属鉴权是否开启事件回调
     onGetRealm invoker = [weak_self, authorization](const string &realm) {
         auto strong_self = weak_self.lock();
         if (!strong_self) {
-            //本对象已经销毁
+            // 本对象已经销毁
             return;
         }
-        //切换到自己的线程然后执行
+        // 切换到自己的线程然后执行
         strong_self->async([weak_self, realm, authorization]() {
             auto strong_self = weak_self.lock();
             if (!strong_self) {
-                //本对象已经销毁
+                // 本对象已经销毁
                 return;
             }
             if (realm.empty()) {
-                //无需rtsp专属认证, 那么继续url通用鉴权认证(on_play)
+                // 无需rtsp专属认证, 那么继续url通用鉴权认证(on_play)
                 strong_self->emitOnPlay();
                 return;
             }
-            //该流需要rtsp专属认证，开启rtsp专属认证后，将不再触发url通用鉴权认证(on_play)
+            // 该流需要rtsp专属认证，开启rtsp专属认证后，将不再触发url通用鉴权认证(on_play)
             strong_self->_rtsp_realm = realm;
             strong_self->onAuthUser(realm, authorization);
         });
     };
 
-    if(_rtsp_realm.empty()){
-        //广播是否需要rtsp专属认证事件
+    if (_rtsp_realm.empty()) {
+        // 广播是否需要rtsp专属认证事件
         if (!NOTICE_EMIT(BroadcastOnGetRtspRealmArgs, Broadcast::kBroadcastOnGetRtspRealm, _media_info, invoker, *this)) {
-            //无人监听此事件，说明无需认证
+            // 无人监听此事件，说明无需认证
             invoker("");
         }
-    }else{
+    } else {
         invoker(_rtsp_realm);
     }
 }
 
 void RtspSession::onAuthSuccess() {
     weak_ptr<RtspSession> weak_self = static_pointer_cast<RtspSession>(shared_from_this());
-    MediaSource::findAsync(_media_info, weak_self.lock(), [weak_self](const MediaSource::Ptr &src){
+    MediaSource::findAsync(_media_info, weak_self.lock(), [weak_self](const MediaSource::Ptr &src) {
         auto strong_self = weak_self.lock();
-        if(!strong_self){
+        if (!strong_self) {
             return;
         }
         auto rtsp_src = dynamic_pointer_cast<RtspMediaSource>(src);
         if (!rtsp_src) {
-            //未找到相应的MediaSource
+            // 未找到相应的MediaSource
             string err = StrPrinter << "no such stream:" << strong_self->_media_info.shortUrl();
             strong_self->send_StreamNotFound();
-            strong_self->shutdown(SockException(Err_shutdown,err));
+            strong_self->shutdown(SockException(Err_shutdown, err));
             return;
         }
-        //找到了相应的rtsp流
+        // 找到了相应的rtsp流
         strong_self->_sdp_track = SdpParser(rtsp_src->getSdp()).getAvailableTrack();
         if (strong_self->_sdp_track.empty()) {
-            //该流无效
+            // 该流无效
             WarnL << "sdp中无有效track，该流无效:" << rtsp_src->getSdp();
             strong_self->send_StreamNotFound();
-            strong_self->shutdown(SockException(Err_shutdown,"can not find any available track in sdp"));
+            strong_self->shutdown(SockException(Err_shutdown, "can not find any available track in sdp"));
             return;
         }
         strong_self->_rtcp_context.clear();
@@ -435,21 +433,19 @@ void RtspSession::onAuthSuccess() {
         }
         strong_self->_sessionid = makeRandStr(12);
         strong_self->_play_src = rtsp_src;
-        for(auto &track : strong_self->_sdp_track){
+        for (auto &track : strong_self->_sdp_track) {
             track->_ssrc = rtsp_src->getSsrc(track->_type);
             track->_seq = rtsp_src->getSeqence(track->_type);
             track->_time_stamp = rtsp_src->getTimeStamp(track->_type);
         }
 
-        strong_self->sendRtspResponse("200 OK",
-                                     {"Content-Base", strong_self->_content_base + "/",
-                                      "x-Accept-Retransmit","our-retransmit",
-                                      "x-Accept-Dynamic-Rate","1"
-                                     },rtsp_src->getSdp());
+        strong_self->sendRtspResponse(
+            "200 OK", { "Content-Base", strong_self->_content_base + "/", "x-Accept-Retransmit", "our-retransmit", "x-Accept-Dynamic-Rate", "1" },
+            rtsp_src->getSdp());
     });
 }
 
-void RtspSession::onAuthFailed(const string &realm,const string &why,bool close) {
+void RtspSession::onAuthFailed(const string &realm, const string &why, bool close) {
     GET_CONFIG(bool, authBasic, Rtsp::kAuthBasic);
     if (!authBasic) {
         // 我们需要客户端优先以md5方式认证
@@ -465,7 +461,7 @@ void RtspSession::onAuthFailed(const string &realm,const string &why,bool close)
 }
 
 void RtspSession::onAuthBasic(const string &realm, const string &auth_base64) {
-    //base64认证
+    // base64认证
     auto user_passwd = decodeBase64(auth_base64);
     auto user_pwd_vec = split(user_passwd, ":");
     if (user_pwd_vec.size() < 2) {
@@ -479,67 +475,67 @@ void RtspSession::onAuthBasic(const string &realm, const string &auth_base64) {
     onAuth invoker = [pwd, realm, weak_self](bool encrypted, const string &good_pwd) {
         auto strong_self = weak_self.lock();
         if (!strong_self) {
-            //本对象已经销毁
+            // 本对象已经销毁
             return;
         }
-        //切换到自己的线程执行
+        // 切换到自己的线程执行
         strong_self->async([weak_self, good_pwd, pwd, realm]() {
             auto strong_self = weak_self.lock();
             if (!strong_self) {
-                //本对象已经销毁
+                // 本对象已经销毁
                 return;
             }
-            //base64忽略encrypted参数，上层必须传入明文密码
+            // base64忽略encrypted参数，上层必须传入明文密码
             if (pwd == good_pwd) {
-                //提供的密码且匹配正确
+                // 提供的密码且匹配正确
                 strong_self->onAuthSuccess();
                 return;
             }
-            //密码错误
+            // 密码错误
             strong_self->onAuthFailed(realm, StrPrinter << "password mismatch when base64 auth:" << pwd << " != " << good_pwd);
         });
     };
 
-    //此时必须提供明文密码
+    // 此时必须提供明文密码
     if (!NOTICE_EMIT(BroadcastOnRtspAuthArgs, Broadcast::kBroadcastOnRtspAuth, _media_info, realm, user, true, invoker, *this)) {
-        //表明该流需要认证却没监听请求密码事件，这一般是大意的程序所为，警告之
+        // 表明该流需要认证却没监听请求密码事件，这一般是大意的程序所为，警告之
         WarnP(this) << "请监听kBroadcastOnRtspAuth事件！";
-        //但是我们还是忽略认证以便完成播放
-        //我们输入的密码是明文
+        // 但是我们还是忽略认证以便完成播放
+        // 我们输入的密码是明文
         invoker(false, pwd);
     }
 }
 
-void RtspSession::onAuthDigest(const string &realm,const string &auth_md5){
+void RtspSession::onAuthDigest(const string &realm, const string &auth_md5) {
     DebugP(this) << auth_md5;
     auto mapTmp = Parser::parseArgs(auth_md5, ",", "=");
     decltype(mapTmp) map;
-    for(auto &pr : mapTmp){
-        map[trim(string(pr.first)," \"")] = trim(pr.second," \"");
+    for (auto &pr : mapTmp) {
+        map[trim(string(pr.first), " \"")] = trim(pr.second, " \"");
     }
-    //check realm
-    if(realm != map["realm"]){
-        onAuthFailed(realm,StrPrinter << "realm not mached:" << realm << " != " << map["realm"]);
-        return ;
+    // check realm
+    if (realm != map["realm"]) {
+        onAuthFailed(realm, StrPrinter << "realm not mached:" << realm << " != " << map["realm"]);
+        return;
     }
-    //check nonce
+    // check nonce
     auto nonce = map["nonce"];
-    if(_auth_nonce != nonce){
-        onAuthFailed(realm,StrPrinter << "nonce not mached:" << nonce << " != " << _auth_nonce);
-        return ;
+    if (_auth_nonce != nonce) {
+        onAuthFailed(realm, StrPrinter << "nonce not mached:" << nonce << " != " << _auth_nonce);
+        return;
     }
-    //check username and uri
+    // check username and uri
     auto username = map["username"];
     auto uri = map["uri"];
     auto response = map["response"];
-    if(username.empty() || uri.empty() || response.empty()){
-        onAuthFailed(realm,StrPrinter << "username/uri/response empty:" << username << "," << uri << "," << response);
-        return ;
+    if (username.empty() || uri.empty() || response.empty()) {
+        onAuthFailed(realm, StrPrinter << "username/uri/response empty:" << username << "," << uri << "," << response);
+        return;
     }
 
-    auto realInvoker = [this,realm,nonce,uri,username,response](bool ignoreAuth,bool encrypted,const string &good_pwd){
-        if(ignoreAuth){
-            //忽略认证
+    auto realInvoker = [this, realm, nonce, uri, username, response](bool ignoreAuth, bool encrypted, const string &good_pwd) {
+        if (ignoreAuth) {
+            // 忽略认证
             TraceP(this) << "auth ignored";
             onAuthSuccess();
             return;
@@ -553,103 +549,98 @@ void RtspSession::onAuthDigest(const string &realm,const string &auth_md5){
             response= md5( md5(username:realm:password):nonce:md5(public_method:url) );
          */
         auto encrypted_pwd = good_pwd;
-        if(!encrypted){
-            //提供的是明文密码
-            encrypted_pwd = MD5(username+ ":" + realm + ":" + good_pwd).hexdigest();
+        if (!encrypted) {
+            // 提供的是明文密码
+            encrypted_pwd = MD5(username + ":" + realm + ":" + good_pwd).hexdigest();
         }
 
-        auto good_response = MD5( encrypted_pwd + ":" + nonce + ":" + MD5(string("DESCRIBE") + ":" + uri).hexdigest()).hexdigest();
-        if(strcasecmp(good_response.data(),response.data()) == 0){
-            //认证成功！md5不区分大小写
+        auto good_response = MD5(encrypted_pwd + ":" + nonce + ":" + MD5(string("DESCRIBE") + ":" + uri).hexdigest()).hexdigest();
+        if (strcasecmp(good_response.data(), response.data()) == 0) {
+            // 认证成功！md5不区分大小写
             onAuthSuccess();
-        }else{
-            //认证失败！
-            onAuthFailed(realm, StrPrinter << "password mismatch when md5 auth:" << good_response << " != " << response );
+        } else {
+            // 认证失败！
+            onAuthFailed(realm, StrPrinter << "password mismatch when md5 auth:" << good_response << " != " << response);
         }
     };
 
     weak_ptr<RtspSession> weak_self = static_pointer_cast<RtspSession>(shared_from_this());
-    onAuth invoker = [realInvoker,weak_self](bool encrypted,const string &good_pwd){
+    onAuth invoker = [realInvoker, weak_self](bool encrypted, const string &good_pwd) {
         auto strong_self = weak_self.lock();
-        if(!strong_self){
+        if (!strong_self) {
             return;
         }
-        //切换到自己的线程确保realInvoker执行时，this指针有效
-        strong_self->async([realInvoker,weak_self,encrypted,good_pwd](){
+        // 切换到自己的线程确保realInvoker执行时，this指针有效
+        strong_self->async([realInvoker, weak_self, encrypted, good_pwd]() {
             auto strong_self = weak_self.lock();
-            if(!strong_self){
+            if (!strong_self) {
                 return;
             }
-            realInvoker(false,encrypted,good_pwd);
+            realInvoker(false, encrypted, good_pwd);
         });
     };
 
-    //此时可以提供明文或md5加密的密码
-    if(!NOTICE_EMIT(BroadcastOnRtspAuthArgs, Broadcast::kBroadcastOnRtspAuth, _media_info, realm, username, false, invoker, *this)){
-        //表明该流需要认证却没监听请求密码事件，这一般是大意的程序所为，警告之
+    // 此时可以提供明文或md5加密的密码
+    if (!NOTICE_EMIT(BroadcastOnRtspAuthArgs, Broadcast::kBroadcastOnRtspAuth, _media_info, realm, username, false, invoker, *this)) {
+        // 表明该流需要认证却没监听请求密码事件，这一般是大意的程序所为，警告之
         WarnP(this) << "请监听kBroadcastOnRtspAuth事件！";
-        //但是我们还是忽略认证以便完成播放
-        realInvoker(true,true,"");
+        // 但是我们还是忽略认证以便完成播放
+        realInvoker(true, true, "");
     }
 }
 
-void RtspSession::onAuthUser(const string &realm,const string &authorization){
-    if(authorization.empty()){
-        onAuthFailed(realm,"", false);
+void RtspSession::onAuthUser(const string &realm, const string &authorization) {
+    if (authorization.empty()) {
+        onAuthFailed(realm, "", false);
         return;
     }
-    //请求中包含认证信息
+    // 请求中包含认证信息
     auto authType = findSubString(authorization.data(), NULL, " ");
     auto authStr = findSubString(authorization.data(), " ", NULL);
-    if(authType.empty() || authStr.empty()){
-        //认证信息格式不合法，回复401 Unauthorized
-        onAuthFailed(realm,"can not find auth type or auth string");
+    if (authType.empty() || authStr.empty()) {
+        // 认证信息格式不合法，回复401 Unauthorized
+        onAuthFailed(realm, "can not find auth type or auth string");
         return;
     }
-    if(authType == "Basic"){
-        //base64认证，需要明文密码
-        onAuthBasic(realm,authStr);
-    }else if(authType == "Digest"){
-        //md5认证
-        onAuthDigest(realm,authStr);
-    }else{
-        //其他认证方式？不支持！
-        onAuthFailed(realm,StrPrinter << "unsupported auth type:" << authType);
+    if (authType == "Basic") {
+        // base64认证，需要明文密码
+        onAuthBasic(realm, authStr);
+    } else if (authType == "Digest") {
+        // md5认证
+        onAuthDigest(realm, authStr);
+    } else {
+        // 其他认证方式？不支持！
+        onAuthFailed(realm, StrPrinter << "unsupported auth type:" << authType);
     }
 }
 
 void RtspSession::send_StreamNotFound() {
-    sendRtspResponse("404 Stream Not Found",{"Connection","Close"});
+    sendRtspResponse("404 Stream Not Found", { "Connection", "Close" });
 }
 
 void RtspSession::send_UnsupportedTransport() {
-    sendRtspResponse("461 Unsupported Transport",{"Connection","Close"});
+    sendRtspResponse("461 Unsupported Transport", { "Connection", "Close" });
 }
 
 void RtspSession::send_SessionNotFound() {
-    sendRtspResponse("454 Session Not Found",{"Connection","Close"});
+    sendRtspResponse("454 Session Not Found", { "Connection", "Close" });
 }
 
 void RtspSession::handleReq_Setup(const Parser &parser) {
-    //处理setup命令，该函数可能进入多次
+    // 处理setup命令，该函数可能进入多次
     int trackIdx = getTrackIndexByControlUrl(parser.fullUrl());
     SdpTrack::Ptr &trackRef = _sdp_track[trackIdx];
     if (trackRef->_inited) {
-        //已经初始化过该Track
+        // 已经初始化过该Track
         throw SockException(Err_shutdown, "can not setup one track twice");
     }
 
     static auto getRtpTypeStr = [](const int type) {
-        switch (type)
-        {
-        case Rtsp::RTP_TCP:
-            return "TCP";
-        case Rtsp::RTP_UDP:
-            return "UDP";
-        case Rtsp::RTP_MULTICAST:
-            return "MULTICAST";
-        default:
-            return "Invalid";
+        switch (type) {
+            case Rtsp::RTP_TCP: return "TCP";
+            case Rtsp::RTP_UDP: return "UDP";
+            case Rtsp::RTP_MULTICAST: return "MULTICAST";
+            default: return "Invalid";
         }
     };
 
@@ -663,127 +654,123 @@ void RtspSession::handleReq_Setup(const Parser &parser) {
         } else {
             rtpType = Rtsp::RTP_UDP;
         }
-        //检查RTP传输类型限制
+        // 检查RTP传输类型限制
         GET_CONFIG(int, transport, Rtsp::kRtpTransportType);
         if (transport != Rtsp::RTP_Invalid && transport != rtpType) {
             WarnL << "rtsp client setup transport " << getRtpTypeStr(rtpType) << " but config force transport " << getRtpTypeStr(transport);
-            //配置限定RTSP传输方式，但是客户端握手方式不一致，返回461
+            // 配置限定RTSP传输方式，但是客户端握手方式不一致，返回461
             sendRtspResponse("461 Unsupported transport");
             return;
         }
         _rtp_type = rtpType;
     }
 
-    trackRef->_inited = true; //现在初始化
+    trackRef->_inited = true; // 现在初始化
 
-    //允许接收rtp、rtcp包
+    // 允许接收rtp、rtcp包
     RtspSplitter::enableRecvRtp(_rtp_type == Rtsp::RTP_TCP);
 
     switch (_rtp_type) {
-    case Rtsp::RTP_TCP: {
-        if (_push_src) {
-            // rtsp推流时，interleaved由推流者决定
-            auto key_values = Parser::parseArgs(parser["Transport"], ";", "=");
-            int interleaved_rtp = -1, interleaved_rtcp = -1;
-            if (2 == sscanf(key_values["interleaved"].data(), "%d-%d", &interleaved_rtp, &interleaved_rtcp)) {
-                trackRef->_interleaved = interleaved_rtp;
-            } else {
-                throw SockException(Err_shutdown, "can not find interleaved when setup of rtp over tcp");
-            }
-        } else {
-            // rtsp播放时，由于数据共享分发，所以interleaved必须由服务器决定
-            trackRef->_interleaved = 2 * trackRef->_type;
-        }
-        sendRtspResponse("200 OK",
-                         {"Transport", StrPrinter << "RTP/AVP/TCP;unicast;"
-                                                  << "interleaved=" << (int) trackRef->_interleaved << "-"
-                                                  << (int) trackRef->_interleaved + 1 << ";"
-                                                  << "ssrc=" << printSSRC(trackRef->_ssrc),
-                          "x-Transport-Options", "late-tolerance=1.400000",
-                          "x-Dynamic-Rate", "1"
-                         });
-    }
-        break;
-
-    case Rtsp::RTP_UDP: {
-        std::pair<Socket::Ptr, Socket::Ptr> pr = std::make_pair(createSocket(),createSocket());
-        try {
-            makeSockPair(pr, get_local_ip());
-        } catch (std::exception &ex) {
-            //分配端口失败
-            send_NotAcceptable();
-            throw SockException(Err_shutdown, ex.what());
-        }
-
-        _rtp_socks[trackIdx] = pr.first;
-        _rtcp_socks[trackIdx] = pr.second;
-
-        //设置客户端内网端口信息
-        string strClientPort = findSubString(parser["Transport"].data(), "client_port=", NULL);
-        uint16_t ui16RtpPort = atoi(findSubString(strClientPort.data(), NULL, "-").data());
-        uint16_t ui16RtcpPort = atoi(findSubString(strClientPort.data(), "-", NULL).data());
-
-        auto peerAddr = SockUtil::make_sockaddr(get_peer_ip().data(), ui16RtpPort);
-        //设置rtp发送目标地址
-        pr.first->bindPeerAddr((struct sockaddr *) (&peerAddr), 0, true);
-
-        //设置rtcp发送目标地址
-        peerAddr = SockUtil::make_sockaddr(get_peer_ip().data(), ui16RtcpPort);
-        pr.second->bindPeerAddr((struct sockaddr *) (&peerAddr), 0, true);
-
-        //尝试获取客户端nat映射地址
-        startListenPeerUdpData(trackIdx);
-        //InfoP(this) << "分配端口:" << srv_port;
-
-        sendRtspResponse("200 OK",
-                         {"Transport", StrPrinter << "RTP/AVP/UDP;unicast;"
-                                                  << "client_port=" << strClientPort << ";"
-                                                  << "server_port=" << pr.first->get_local_port() << "-"
-                                                  << pr.second->get_local_port() << ";"
-                                                  << "ssrc=" << printSSRC(trackRef->_ssrc)
-                         });
-    }
-        break;
-    case Rtsp::RTP_MULTICAST: {
-        if(!_multicaster){
-            _multicaster = RtpMultiCaster::get(*this, get_local_ip(), _media_info, _multicast_ip, _multicast_video_port, _multicast_audio_port);
-            if (!_multicaster) {
-                send_NotAcceptable();
-                throw SockException(Err_shutdown, "can not get a available udp multicast socket");
-            }
-            weak_ptr<RtspSession> weak_self = static_pointer_cast<RtspSession>(shared_from_this());
-            _multicaster->setDetachCB(this, [weak_self]() {
-                auto strong_self = weak_self.lock();
-                if(!strong_self) {
-                    return;
+        case Rtsp::RTP_TCP: {
+            if (_push_src) {
+                // rtsp推流时，interleaved由推流者决定
+                auto key_values = Parser::parseArgs(parser["Transport"], ";", "=");
+                int interleaved_rtp = -1, interleaved_rtcp = -1;
+                if (2 == sscanf(key_values["interleaved"].data(), "%d-%d", &interleaved_rtp, &interleaved_rtcp)) {
+                    trackRef->_interleaved = interleaved_rtp;
+                } else {
+                    throw SockException(Err_shutdown, "can not find interleaved when setup of rtp over tcp");
                 }
-                strong_self->safeShutdown(SockException(Err_shutdown,"ring buffer detached"));
-            });
-        }
-        int iSrvPort = _multicaster->getMultiCasterPort(trackRef->_type);
-        //我们用trackIdx区分rtp和rtcp包
-        //由于组播udp端口是共享的，而rtcp端口为组播udp端口+1，所以rtcp端口需要改成共享端口
-        auto pSockRtcp = UDPServer::Instance().getSock(*this, get_local_ip().data(), 2 * trackIdx + 1, iSrvPort + 1);
-        if (!pSockRtcp) {
-            //分配端口失败
-            send_NotAcceptable();
-            throw SockException(Err_shutdown, "open shared rtcp socket failed");
-        }
-        startListenPeerUdpData(trackIdx);
-        GET_CONFIG(uint32_t,udpTTL,MultiCast::kUdpTTL);
+            } else {
+                // rtsp播放时，由于数据共享分发，所以interleaved必须由服务器决定
+                trackRef->_interleaved = 2 * trackRef->_type;
+            }
+            sendRtspResponse(
+                "200 OK",
+                { "Transport",
+                  StrPrinter << "RTP/AVP/TCP;unicast;"
+                             << "interleaved=" << (int)trackRef->_interleaved << "-" << (int)trackRef->_interleaved + 1 << ";"
+                             << "ssrc=" << printSSRC(trackRef->_ssrc),
+                  "x-Transport-Options", "late-tolerance=1.400000", "x-Dynamic-Rate", "1" });
+        } break;
 
-        sendRtspResponse("200 OK",
-                         {"Transport", StrPrinter << "RTP/AVP;multicast;"
-                                                  << "destination=" << _multicaster->getMultiCasterIP() << ";"
-                                                  << "source=" << get_local_ip() << ";"
-                                                  << "port=" << iSrvPort << "-" << pSockRtcp->get_local_port() << ";"
-                                                  << "ttl=" << udpTTL << ";"
-                                                  << "ssrc=" << printSSRC(trackRef->_ssrc)
-                         });
-    }
-        break;
-    default:
-        break;
+        case Rtsp::RTP_UDP: {
+            std::pair<Socket::Ptr, Socket::Ptr> pr = std::make_pair(createSocket(), createSocket());
+            try {
+                makeSockPair(pr, get_local_ip());
+            } catch (std::exception &ex) {
+                // 分配端口失败
+                send_NotAcceptable();
+                throw SockException(Err_shutdown, ex.what());
+            }
+
+            _rtp_socks[trackIdx] = pr.first;
+            _rtcp_socks[trackIdx] = pr.second;
+
+            // 设置客户端内网端口信息
+            string strClientPort = findSubString(parser["Transport"].data(), "client_port=", NULL);
+            uint16_t ui16RtpPort = atoi(findSubString(strClientPort.data(), NULL, "-").data());
+            uint16_t ui16RtcpPort = atoi(findSubString(strClientPort.data(), "-", NULL).data());
+
+            auto peerAddr = SockUtil::make_sockaddr(get_peer_ip().data(), ui16RtpPort);
+            // 设置rtp发送目标地址
+            pr.first->bindPeerAddr((struct sockaddr *)(&peerAddr), 0, true);
+
+            // 设置rtcp发送目标地址
+            peerAddr = SockUtil::make_sockaddr(get_peer_ip().data(), ui16RtcpPort);
+            pr.second->bindPeerAddr((struct sockaddr *)(&peerAddr), 0, true);
+
+            // 尝试获取客户端nat映射地址
+            startListenPeerUdpData(trackIdx);
+            // InfoP(this) << "分配端口:" << srv_port;
+
+            sendRtspResponse(
+                "200 OK",
+                { "Transport",
+                  StrPrinter << "RTP/AVP/UDP;unicast;"
+                             << "client_port=" << strClientPort << ";"
+                             << "server_port=" << pr.first->get_local_port() << "-" << pr.second->get_local_port() << ";"
+                             << "ssrc=" << printSSRC(trackRef->_ssrc) });
+        } break;
+        case Rtsp::RTP_MULTICAST: {
+            if (!_multicaster) {
+                _multicaster = RtpMultiCaster::get(*this, get_local_ip(), _media_info, _multicast_ip, _multicast_video_port, _multicast_audio_port);
+                if (!_multicaster) {
+                    send_NotAcceptable();
+                    throw SockException(Err_shutdown, "can not get a available udp multicast socket");
+                }
+                weak_ptr<RtspSession> weak_self = static_pointer_cast<RtspSession>(shared_from_this());
+                _multicaster->setDetachCB(this, [weak_self]() {
+                    auto strong_self = weak_self.lock();
+                    if (!strong_self) {
+                        return;
+                    }
+                    strong_self->safeShutdown(SockException(Err_shutdown, "ring buffer detached"));
+                });
+            }
+            int iSrvPort = _multicaster->getMultiCasterPort(trackRef->_type);
+            // 我们用trackIdx区分rtp和rtcp包
+            // 由于组播udp端口是共享的，而rtcp端口为组播udp端口+1，所以rtcp端口需要改成共享端口
+            auto pSockRtcp = UDPServer::Instance().getSock(*this, get_local_ip().data(), 2 * trackIdx + 1, iSrvPort + 1);
+            if (!pSockRtcp) {
+                // 分配端口失败
+                send_NotAcceptable();
+                throw SockException(Err_shutdown, "open shared rtcp socket failed");
+            }
+            startListenPeerUdpData(trackIdx);
+            GET_CONFIG(uint32_t, udpTTL, MultiCast::kUdpTTL);
+
+            sendRtspResponse(
+                "200 OK",
+                { "Transport",
+                  StrPrinter << "RTP/AVP;multicast;"
+                             << "destination=" << _multicaster->getMultiCasterIP() << ";"
+                             << "source=" << get_local_ip() << ";"
+                             << "port=" << iSrvPort << "-" << pSockRtcp->get_local_port() << ";"
+                             << "ttl=" << udpTTL << ";"
+                             << "ssrc=" << printSSRC(trackRef->_ssrc) });
+        } break;
+        default: break;
     }
 }
 
@@ -793,9 +780,9 @@ void RtspSession::handleReq_Play(const Parser &parser) {
         throw SockException(Err_shutdown, _sdp_track.empty() ? "can not find any available track when play" : "session not found when play");
     }
     auto play_src = _play_src.lock();
-    if(!play_src){
+    if (!play_src) {
         send_StreamNotFound();
-        shutdown(SockException(Err_shutdown,"rtsp stream released"));
+        shutdown(SockException(Err_shutdown, "rtsp stream released"));
         return;
     }
 
@@ -804,7 +791,7 @@ void RtspSession::handleReq_Play(const Parser &parser) {
     auto &strRange = parser["Range"];
     StrCaseMap res_header;
     if (!strScale.empty()) {
-        //这是设置播放速度
+        // 这是设置播放速度
         res_header.emplace("Scale", strScale);
         auto speed = atof(strScale.data());
         play_src->speed(speed);
@@ -812,14 +799,14 @@ void RtspSession::handleReq_Play(const Parser &parser) {
     }
 
     if (!strRange.empty()) {
-        //这是seek操作
+        // 这是seek操作
         res_header.emplace("Range", strRange);
         auto strStart = findSubString(strRange.data(), "npt=", "-");
         if (strStart == "now") {
             strStart = "0";
         }
-        auto iStartTime = 1000 * (float) atof(strStart.data());
-        use_gop = !play_src->seekTo((uint32_t) iStartTime);
+        auto iStartTime = 1000 * (float)atof(strStart.data());
+        use_gop = !play_src->seekTo((uint32_t)iStartTime);
         InfoP(this) << "rtsp seekTo(ms):" << iStartTime;
     }
 
@@ -827,7 +814,7 @@ void RtspSession::handleReq_Play(const Parser &parser) {
     _StrPrinter rtp_info;
     for (auto &track : _sdp_track) {
         if (track->_inited == false) {
-            //为支持播放器播放单一track, 不校验没有发setup的track
+            // 为支持播放器播放单一track, 不校验没有发setup的track
             continue;
         }
         inited_tracks.emplace_back(track->_type);
@@ -837,23 +824,23 @@ void RtspSession::handleReq_Play(const Parser &parser) {
 
         rtp_info << "url=" << track->getControlUrl(_content_base) << ";"
                  << "seq=" << track->_seq << ";"
-                 << "rtptime=" << (int64_t)(track->_time_stamp) * (int64_t)(track->_samplerate/ 1000) << ",";
+                 << "rtptime=" << (int64_t)(track->_time_stamp) * (int64_t)(track->_samplerate / 1000) << ",";
     }
 
     rtp_info.pop_back();
 
     res_header.emplace("RTP-Info", rtp_info);
-    //已存在Range时不覆盖
+    // 已存在Range时不覆盖
     res_header.emplace("Range", StrPrinter << "npt=" << setiosflags(ios::fixed) << setprecision(2) << play_src->getTimeStamp(TrackInvalid) / 1000.0);
     sendRtspResponse("200 OK", res_header);
 
-    //设置播放track
+    // 设置播放track
     if (inited_tracks.size() == 1) {
         _target_play_track = inited_tracks[0];
         InfoP(this) << "指定播放track:" << _target_play_track;
     }
 
-    //在回复rtsp信令后再恢复播放
+    // 在回复rtsp信令后再恢复播放
     play_src->pause(false);
 
     setSocketFlags();
@@ -898,20 +885,26 @@ void RtspSession::handleReq_Pause(const Parser &parser) {
 
 void RtspSession::handleReq_Teardown(const Parser &parser) {
     _push_src = nullptr;
-    //此时回复可能触发broken pipe事件，从而直接触发onError回调；所以需要先把_push_src置空，防止触发断流续推功能
+    // 此时回复可能触发broken pipe事件，从而直接触发onError回调；所以需要先把_push_src置空，防止触发断流续推功能
     sendRtspResponse("200 OK");
-    throw SockException(Err_shutdown,"recv teardown request");
+    throw SockException(Err_shutdown, "recv teardown request");
 }
 
 void RtspSession::handleReq_Get(const Parser &parser) {
     _http_x_sessioncookie = parser["x-sessioncookie"];
-    sendRtspResponse("200 OK",
-                     {"Cache-Control","no-store",
-                      "Pragma","no-store",
-                      "Content-Type","application/x-rtsp-tunnelled",
-                     },"","HTTP/1.0");
+    sendRtspResponse(
+        "200 OK",
+        {
+            "Cache-Control",
+            "no-store",
+            "Pragma",
+            "no-store",
+            "Content-Type",
+            "application/x-rtsp-tunnelled",
+        },
+        "", "HTTP/1.0");
 
-    //注册http getter，以便http poster绑定
+    // 注册http getter，以便http poster绑定
     lock_guard<recursive_mutex> lock(g_mtxGetter);
     g_mapGetter[_http_x_sessioncookie] = static_pointer_cast<RtspSession>(shared_from_this());
 }
@@ -919,54 +912,60 @@ void RtspSession::handleReq_Get(const Parser &parser) {
 void RtspSession::handleReq_Post(const Parser &parser) {
     lock_guard<recursive_mutex> lock(g_mtxGetter);
     string sessioncookie = parser["x-sessioncookie"];
-    //Poster 找到 Getter
+    // Poster 找到 Getter
     auto it = g_mapGetter.find(sessioncookie);
     if (it == g_mapGetter.end()) {
-        throw SockException(Err_shutdown,"can not find http getter by x-sessioncookie");
+        throw SockException(Err_shutdown, "can not find http getter by x-sessioncookie");
     }
 
-    //Poster 找到Getter的SOCK
+    // Poster 找到Getter的SOCK
     auto httpGetterWeak = it->second;
-    //移除http getter的弱引用记录
+    // 移除http getter的弱引用记录
     g_mapGetter.erase(sessioncookie);
 
-    //http poster收到请求后转发给http getter处理
-    _on_recv = [this,httpGetterWeak](const Buffer::Ptr &buf){
+    // http poster收到请求后转发给http getter处理
+    _on_recv = [this, httpGetterWeak](const Buffer::Ptr &buf) {
         auto httpGetterStrong = httpGetterWeak.lock();
-        if(!httpGetterStrong){
-            shutdown(SockException(Err_shutdown,"http getter released"));
+        if (!httpGetterStrong) {
+            shutdown(SockException(Err_shutdown, "http getter released"));
             return;
         }
 
-        //切换到http getter的线程
-        httpGetterStrong->async([buf,httpGetterWeak](){
+        // 切换到http getter的线程
+        httpGetterStrong->async([buf, httpGetterWeak]() {
             auto httpGetterStrong = httpGetterWeak.lock();
-            if(!httpGetterStrong){
+            if (!httpGetterStrong) {
                 return;
             }
             httpGetterStrong->onRecv(std::make_shared<BufferString>(decodeBase64(string(buf->data(), buf->size()))));
         });
     };
 
-    if(!parser.content().empty()){
-        //http poster后面的粘包
+    if (!parser.content().empty()) {
+        // http poster后面的粘包
         _on_recv(std::make_shared<BufferString>(parser.content()));
     }
 
-    sendRtspResponse("200 OK",
-                     {"Cache-Control","no-store",
-                      "Pragma","no-store",
-                      "Content-Type","application/x-rtsp-tunnelled",
-                     },"","HTTP/1.0");
+    sendRtspResponse(
+        "200 OK",
+        {
+            "Cache-Control",
+            "no-store",
+            "Pragma",
+            "no-store",
+            "Content-Type",
+            "application/x-rtsp-tunnelled",
+        },
+        "", "HTTP/1.0");
 }
 
 void RtspSession::handleReq_SET_PARAMETER(const Parser &parser) {
-    //TraceP(this) <<endl;
+    // TraceP(this) <<endl;
     sendRtspResponse("200 OK");
 }
 
 void RtspSession::send_NotAcceptable() {
-    sendRtspResponse("406 Not Acceptable",{"Connection","Close"});
+    sendRtspResponse("406 Not Acceptable", { "Connection", "Close" });
 }
 
 void RtspSession::onRtpSorted(RtpPacket::Ptr rtp, int track_idx) {
@@ -978,23 +977,23 @@ void RtspSession::onRtpSorted(RtpPacket::Ptr rtp, int track_idx) {
 }
 
 void RtspSession::onRcvPeerUdpData(int interleaved, const Buffer::Ptr &buf, const struct sockaddr_storage &addr) {
-    //这是rtcp心跳包，说明播放器还存活
+    // 这是rtcp心跳包，说明播放器还存活
     _alive_ticker.resetTime();
 
     if (interleaved % 2 == 0) {
         if (_push_src) {
-            //这是rtsp推流上来的rtp包
+            // 这是rtsp推流上来的rtp包
             auto &ref = _sdp_track[interleaved / 2];
-            handleOneRtp(interleaved / 2, ref->_type, ref->_samplerate, (uint8_t *) buf->data(), buf->size());
+            handleOneRtp(interleaved / 2, ref->_type, ref->_samplerate, (uint8_t *)buf->data(), buf->size());
         } else if (!_udp_connected_flags.count(interleaved)) {
-            //这是rtsp播放器的rtp打洞包
+            // 这是rtsp播放器的rtp打洞包
             _udp_connected_flags.emplace(interleaved);
             if (_rtp_socks[interleaved / 2]) {
                 _rtp_socks[interleaved / 2]->bindPeerAddr((struct sockaddr *)&addr);
             }
         }
     } else {
-        //rtcp包
+        // rtcp包
         if (!_udp_connected_flags.count(interleaved)) {
             _udp_connected_flags.emplace(interleaved);
             if (_rtcp_socks[(interleaved - 1) / 2]) {
@@ -1008,15 +1007,14 @@ void RtspSession::onRcvPeerUdpData(int interleaved, const Buffer::Ptr &buf, cons
 void RtspSession::startListenPeerUdpData(int track_idx) {
     weak_ptr<RtspSession> weak_self = static_pointer_cast<RtspSession>(shared_from_this());
     auto peer_ip = get_peer_ip();
-    auto onUdpData = [weak_self,peer_ip](const Buffer::Ptr &buf, struct sockaddr *peer_addr, int interleaved){
+    auto onUdpData = [weak_self, peer_ip](const Buffer::Ptr &buf, struct sockaddr *peer_addr, int interleaved) {
         auto strong_self = weak_self.lock();
         if (!strong_self) {
             return false;
         }
 
         if (SockUtil::inet_ntoa(peer_addr) != peer_ip) {
-            WarnP(strong_self.get()) << ((interleaved % 2 == 0) ? "收到其他地址的rtp数据:" : "收到其他地址的rtcp数据:")
-                                    << SockUtil::inet_ntoa(peer_addr);
+            WarnP(strong_self.get()) << ((interleaved % 2 == 0) ? "收到其他地址的rtp数据:" : "收到其他地址的rtcp数据:") << SockUtil::inet_ntoa(peer_addr);
             return true;
         }
 
@@ -1037,77 +1035,71 @@ void RtspSession::startListenPeerUdpData(int track_idx) {
         return true;
     };
 
-    switch (_rtp_type){
-        case Rtsp::RTP_MULTICAST:{
-            //组播使用的共享rtcp端口
-            UDPServer::Instance().listenPeer(get_peer_ip().data(), this,
-                    [onUdpData]( int interleaved, const Buffer::Ptr &buf, struct sockaddr *peer_addr) {
+    switch (_rtp_type) {
+        case Rtsp::RTP_MULTICAST: {
+            // 组播使用的共享rtcp端口
+            UDPServer::Instance().listenPeer(get_peer_ip().data(), this, [onUdpData](int interleaved, const Buffer::Ptr &buf, struct sockaddr *peer_addr) {
                 return onUdpData(buf, peer_addr, interleaved);
             });
-        }
-            break;
-        case Rtsp::RTP_UDP:{
-            auto setEvent = [&](Socket::Ptr &sock,int interleaved){
-                if(!sock){
+        } break;
+        case Rtsp::RTP_UDP: {
+            auto setEvent = [&](Socket::Ptr &sock, int interleaved) {
+                if (!sock) {
                     WarnP(this) << "udp端口为空:" << interleaved;
                     return;
                 }
-                sock->setOnRead([onUdpData,interleaved](const Buffer::Ptr &pBuf, struct sockaddr *pPeerAddr , int addr_len){
-                    onUdpData(pBuf, pPeerAddr, interleaved);
-                });
+                sock->setOnRead(
+                    [onUdpData, interleaved](const Buffer::Ptr &pBuf, struct sockaddr *pPeerAddr, int addr_len) { onUdpData(pBuf, pPeerAddr, interleaved); });
             };
-            setEvent(_rtp_socks[track_idx], 2 * track_idx );
-            setEvent(_rtcp_socks[track_idx], 2 * track_idx + 1 );
-        }
-            break;
+            setEvent(_rtp_socks[track_idx], 2 * track_idx);
+            setEvent(_rtcp_socks[track_idx], 2 * track_idx + 1);
+        } break;
 
-        default:
-            break;
+        default: break;
     }
-
 }
 
-static string dateStr(){
+static string dateStr() {
     char buf[64];
     time_t tt = time(NULL);
     strftime(buf, sizeof buf, "%a, %b %d %Y %H:%M:%S GMT", gmtime(&tt));
     return buf;
 }
 
-bool RtspSession::sendRtspResponse(const string &res_code, const StrCaseMap &header_const, const string &sdp, const char *protocol){
+bool RtspSession::sendRtspResponse(const string &res_code, const StrCaseMap &header_const, const string &sdp, const char *protocol) {
     auto header = header_const;
-    header.emplace("CSeq",StrPrinter << _cseq);
-    if(!_sessionid.empty()){
+    header.emplace("CSeq", StrPrinter << _cseq);
+    if (!_sessionid.empty()) {
         header.emplace("Session", _sessionid);
     }
 
-    header.emplace("Server",kServerName);
-    header.emplace("Date",dateStr());
+    header.emplace("Server", kServerName);
+    header.emplace("Date", dateStr());
 
-    if(!sdp.empty()){
-        header.emplace("Content-Length",StrPrinter << sdp.size());
-        header.emplace("Content-Type","application/sdp");
+    if (!sdp.empty()) {
+        header.emplace("Content-Length", StrPrinter << sdp.size());
+        header.emplace("Content-Type", "application/sdp");
     }
 
     _StrPrinter printer;
     printer << protocol << " " << res_code << "\r\n";
-    for (auto &pr : header){
+    for (auto &pr : header) {
         printer << pr.first << ": " << pr.second << "\r\n";
     }
 
     printer << "\r\n";
 
-    if(!sdp.empty()){
+    if (!sdp.empty()) {
         printer << sdp;
     }
-//	DebugP(this) << printer;
-    return send(std::make_shared<BufferString>(std::move(printer))) > 0 ;
+    //	DebugP(this) << printer;
+    return send(std::make_shared<BufferString>(std::move(printer))) > 0;
 }
 
-ssize_t RtspSession::send(Buffer::Ptr pkt){
-//	if(!_enableSendRtp){
-//		DebugP(this) << pkt->data();
-//	}
+ssize_t RtspSession::send(Buffer::Ptr pkt) {
+    //	if(!_enableSendRtp){
+    //		DebugP(this) << pkt->data();
+    //	}
     _bytes_usage += pkt->size();
     return Session::send(std::move(pkt));
 }
@@ -1116,14 +1108,14 @@ bool RtspSession::sendRtspResponse(const string &res_code, const std::initialize
     string key;
     StrCaseMap header_map;
     int i = 0;
-    for(auto &val : header){
-        if(++i % 2 == 0){
-            header_map.emplace(key,val);
-        }else{
+    for (auto &val : header) {
+        if (++i % 2 == 0) {
+            header_map.emplace(key, val);
+        } else {
             key = val;
         }
     }
-    return sendRtspResponse(res_code,header_map,sdp,protocol);
+    return sendRtspResponse(res_code, header_map, sdp, protocol);
 }
 
 int RtspSession::getTrackIndexByPT(int pt) const {
@@ -1175,9 +1167,9 @@ int RtspSession::getTrackIndexByInterleaved(int interleaved) {
 }
 
 bool RtspSession::close(MediaSource &sender) {
-    //此回调在其他线程触发
+    // 此回调在其他线程触发
     string err = StrPrinter << "close media: " << sender.getUrl();
-    safeShutdown(SockException(Err_shutdown,err));
+    safeShutdown(SockException(Err_shutdown, err));
     return true;
 }
 
@@ -1185,7 +1177,7 @@ int RtspSession::totalReaderCount(MediaSource &sender) {
     return _push_src ? _push_src->totalReaderCount() : sender.readerCount();
 }
 
-MediaOriginType RtspSession::getOriginType(MediaSource &sender) const{
+MediaOriginType RtspSession::getOriginType(MediaSource &sender) const {
     return MediaOriginType::rtsp_push;
 }
 
@@ -1201,11 +1193,11 @@ toolkit::EventPoller::Ptr RtspSession::getOwnerPoller(MediaSource &sender) {
     return getPoller();
 }
 
-void RtspSession::onBeforeRtpSorted(const RtpPacket::Ptr &rtp, int track_index){
+void RtspSession::onBeforeRtpSorted(const RtpPacket::Ptr &rtp, int track_index) {
     updateRtcpContext(rtp);
 }
 
-void RtspSession::updateRtcpContext(const RtpPacket::Ptr &rtp){
+void RtspSession::updateRtcpContext(const RtpPacket::Ptr &rtp) {
     int track_index = getTrackIndexByTrackType(rtp->type);
     auto &rtcp_ctx = _rtcp_context[track_index];
     rtcp_ctx->onRtp(rtp->getSeq(), rtp->getStamp(), rtp->ntp_stamp, rtp->sample_rate, rtp->size() - RtpPacket::kRtpTcpHeaderSize);
@@ -1215,9 +1207,9 @@ void RtspSession::updateRtcpContext(const RtpPacket::Ptr &rtp){
     }
 
     auto &ticker = _rtcp_send_tickers[track_index];
-    //send rtcp every 5 second
+    // send rtcp every 5 second
     if (ticker.elapsedTime() > 5 * 1000 || (_send_sr_rtcp[track_index] && !_push_src)) {
-        //确保在发送rtp前，先发送一次sender report rtcp(用于播放器同步音视频)
+        // 确保在发送rtp前，先发送一次sender report rtcp(用于播放器同步音视频)
         ticker.resetTime();
         _send_sr_rtcp[track_index] = false;
 
@@ -1232,8 +1224,8 @@ void RtspSession::updateRtcpContext(const RtpPacket::Ptr &rtp){
         };
 
         auto ssrc = rtp->getSSRC();
-        auto rtcp = _push_src ?  rtcp_ctx->createRtcpRR(ssrc + 1, ssrc) : rtcp_ctx->createRtcpSR(ssrc);
-        auto rtcp_sdes = RtcpSdes::create({kServerName});
+        auto rtcp = _push_src ? rtcp_ctx->createRtcpRR(ssrc + 1, ssrc) : rtcp_ctx->createRtcpSR(ssrc);
+        auto rtcp_sdes = RtcpSdes::create({ kServerName });
         rtcp_sdes->chunks.type = (uint8_t)SdesType::RTCP_SDES_CNAME;
         rtcp_sdes->chunks.ssrc = htonl(ssrc);
         send_rtcp(this, track_index, std::move(rtcp));
@@ -1253,10 +1245,9 @@ void RtspSession::sendRtpPacket(const RtspMediaSource::RingDataType &pkt) {
             });
             flushAll();
             setSendFlushFlag(true);
-        }
-            break;
+        } break;
         case Rtsp::RTP_UDP: {
-            //下标0表示视频，1表示音频
+            // 下标0表示视频，1表示音频
             Socket::Ptr rtp_socks[2];
             rtp_socks[TrackVideo] = _rtp_socks[getTrackIndexByTrackType(TrackVideo)];
             rtp_socks[TrackAudio] = _rtp_socks[getTrackIndexByTrackType(TrackAudio)];
@@ -1277,22 +1268,20 @@ void RtspSession::sendRtpPacket(const RtspMediaSource::RingDataType &pkt) {
                     sock->flushAll();
                 }
             }
-        }
-            break;
-        default:
-            break;
+        } break;
+        default: break;
     }
 }
 
-void RtspSession::setSocketFlags(){
+void RtspSession::setSocketFlags() {
     GET_CONFIG(int, mergeWriteMS, General::kMergeWriteMS);
-    if(mergeWriteMS > 0) {
-        //推流模式下，关闭TCP_NODELAY会增加推流端的延时，但是服务器性能将提高
+    if (mergeWriteMS > 0) {
+        // 推流模式下，关闭TCP_NODELAY会增加推流端的延时，但是服务器性能将提高
         SockUtil::setNoDelay(getSock()->rawFD(), false);
-        //播放模式下，开启MSG_MORE会增加延时，但是能提高发送性能
+        // 播放模式下，开启MSG_MORE会增加延时，但是能提高发送性能
         setSendFlags(SOCKET_DEFAULE_FLAGS | FLAG_MORE);
     }
 }
 
-}
+} // namespace mediakit
 /* namespace mediakit */


### PR DESCRIPTION
MediaTuple结构体加入userdata字段，在addxxx接口和onpublish 用于保存用户上下文数据，然后在回调中回传给用户，某些场景下非常用处。
比如，在addStreamProxy中查询数据库，json后放入userdata，交由zlmediakit。在on_publish，on_streamchanged等回调函数的json数据中取出userdata，省去再次查询数据库的操作，提高性能，减少错误发生。对于zlmediakit来说，只是多一点点的内存来保存这个userdata，对其他逻辑没有影响。
我是golang开发，第一次修改c++代码，如果有不对或者遗漏的地方，请作者帮忙纠正，谢啦！