### PR TITLE
Revert "sr发送限频"

### DIFF
--- a/src/Rtcp/RtcpContext.cpp
+++ b/src/Rtcp/RtcpContext.cpp
@@ -107,11 +107,6 @@ uint32_t RtcpContextForSend::getRtt(uint32_t ssrc) const {
 }
 
 Buffer::Ptr RtcpContextForSend::createRtcpSR(uint32_t rtcp_ssrc) {
-    uint64_t now = getCurrentMillisecond();
-    if (now - _last_sr_tsp < 5000) {
-        return nullptr;
-    }
-    _last_sr_tsp = now;
     auto rtcp = RtcpSR::create(0);
     rtcp->setNtpStamp(_last_ntp_stamp_ms);
     rtcp->rtpts = htonl(_last_rtp_stamp);
@@ -122,7 +117,7 @@ Buffer::Ptr RtcpContextForSend::createRtcpSR(uint32_t rtcp_ssrc) {
     // 记录上次发送的sender report信息，用于后续统计rtt  [AUTO-TRANSLATED:1d22d2c8]
     // Record the last sent sender report information for subsequent RTT statistics
     auto last_sr_lsr = ((ntohl(rtcp->ntpmsw) & 0xFFFF) << 16) | ((ntohl(rtcp->ntplsw) >> 16) & 0xFFFF);
-    _sender_report_ntp[last_sr_lsr] = now;
+    _sender_report_ntp[last_sr_lsr] = getCurrentMillisecond();
     if (_sender_report_ntp.size() >= 5) {
         // 删除最早的sr rtcp  [AUTO-TRANSLATED:2457e08d]
         // Delete the earliest sr rtcp

--- a/src/Rtcp/RtcpContext.h
+++ b/src/Rtcp/RtcpContext.h
@@ -154,7 +154,6 @@ public:
     uint32_t getRtt(uint32_t ssrc) const;
 
 private:
-    uint64_t _last_sr_tsp = 0;
     std::map<uint32_t /*ssrc*/, uint32_t /*rtt*/> _rtt;
     std::map<uint32_t /*last_sr_lsr*/, uint64_t /*ntp stamp*/> _sender_report_ntp;
 

--- a/webrtc/WebRtcTransport.cpp
+++ b/webrtc/WebRtcTransport.cpp
@@ -1497,10 +1497,13 @@ void WebRtcTransportImp::onSendRtp(const RtpPacket::Ptr &rtp, bool flush, bool r
     sendRtpPacket(rtp->data() + RtpPacket::kRtpTcpHeaderSize, rtp->size() - RtpPacket::kRtpTcpHeaderSize, flush, &ctx);
     _bytes_usage += rtp->size() - RtpPacket::kRtpTcpHeaderSize;
 
-    if (track->rtcp_context_send) {
-        auto sr = track->rtcp_context_send->createRtcpSR(track->answer_ssrc_rtp);
-        if (sr && sr->size() > 0) {
-            sendRtcpPacket(sr->data(), sr->size(), true);
+    if (_rtcp_sr_send_ticker.elapsedTime() > 5000) {
+        _rtcp_sr_send_ticker.resetTime();
+        if (track->rtcp_context_send) {
+            auto sr = track->rtcp_context_send->createRtcpSR(track->answer_ssrc_rtp);
+            if (sr && sr->size() > 0) {
+                sendRtcpPacket(sr->data(), sr->size(), true);
+            }
         }
     }
 }

--- a/webrtc/WebRtcTransport.h
+++ b/webrtc/WebRtcTransport.h
@@ -380,6 +380,7 @@ private:
     // pli rtcp timer
     toolkit::Ticker _pli_ticker;
 
+    toolkit::Ticker _rtcp_sr_send_ticker;
     toolkit::Ticker _rtcp_rr_send_ticker;
 
     // twcc rtcp发送上下文对象  [AUTO-TRANSLATED:aef6476a]


### PR DESCRIPTION
This reverts commit 21d1ea96760851dea16a9d80cbbe8e7c39a1ba8b.
之前代码改多了，会导致空指针错误，现进行还原
关联 #4521 