### PR TITLE
Fix crash when RtspSession/RtspPusher handle null RtpPacket

### DIFF
--- a/src/Rtsp/RtspPusher.cpp
+++ b/src/Rtsp/RtspPusher.cpp
@@ -367,7 +367,15 @@ void RtspPusher::sendOptions() {
 }
 
 void RtspPusher::updateRtcpContext(const RtpPacket::Ptr &rtp){
+    if (!rtp) {
+        WarnL << "rtp packet is null when updating rtcp context";
+        return;
+    }
     int track_index = getTrackIndexByTrackType(rtp->type);
+    if (track_index < 0 || track_index >= (int)_rtcp_context.size()) {
+        WarnL << "invalid track index when updating rtcp context: " << track_index;
+        return;
+    }
     auto &ticker = _rtcp_send_ticker[track_index];
     auto &rtcp_ctx = _rtcp_context[track_index];
     rtcp_ctx->onRtp(rtp->getSeq(), rtp->getStamp(), rtp->ntp_stamp, rtp->sample_rate, rtp->size() - RtpPacket::kRtpTcpHeaderSize);

--- a/src/Rtsp/RtspSession.cpp
+++ b/src/Rtsp/RtspSession.cpp
@@ -1204,7 +1204,15 @@ void RtspSession::onBeforeRtpSorted(const RtpPacket::Ptr &rtp, int track_index){
 }
 
 void RtspSession::updateRtcpContext(const RtpPacket::Ptr &rtp){
+    if (!rtp) {
+        WarnL << "rtp packet is null when updating rtcp context";
+        return;
+    }
     int track_index = getTrackIndexByTrackType(rtp->type);
+    if (track_index < 0 || track_index >= (int)_rtcp_context.size()) {
+        WarnL << "invalid track index when updating rtcp context: " << track_index;
+        return;
+    }
     auto &rtcp_ctx = _rtcp_context[track_index];
     rtcp_ctx->onRtp(rtp->getSeq(), rtp->getStamp(), rtp->ntp_stamp, rtp->sample_rate, rtp->size() - RtpPacket::kRtpTcpHeaderSize);
     if (!rtp->ntp_stamp && !rtp->getStamp()) {


### PR DESCRIPTION
## 问题背景
- 设备：RK3588 嵌入式板，预装 Ubuntu 22.04。
- ZLMediaKit 版本：git hash 0b57a57/2025-10-09（release master）。
- 现象：MediaServer 多次因 `SIGSEGV` 退出，录像中断。gdb 栈为
```cpp
#0 mediakit::RtspSession::updateRtcpContext(std::shared_ptrmediakit::RtpPacket const&)
#1 mediakit::RtspSession::sendRtpPacket(...)
#2 mediakit::RtspSession::handleReq_Play(...)
```
寄存器 `x5 = 0`，说明 `updateRtcpContext` 对空 `RtpPacket::Ptr` 直接解引用。

## 原因分析
- 当 ZLM 刚恢复或某路推流尚未 ready 时，RingBuffer 可能产生默认构造的 `RtpPacket::Ptr`；RtspSession/RtspPusher 在更新 RTCP 统计时没有判空，导致空指针访问。
- 这跟上层请求数量无关，即便只有一条播放会话，在未就绪阶段也会 100% 崩溃。

## 修复方案
- 在 `RtspSession::updateRtcpContext` 和 `RtspPusher::updateRtcpContext` 开头加空指针判定，并检查 track index 是否有效；若异常则写日志并 `return`。
- 这样在流未就绪时只会打印告警，不会把整个进程带崩。
- 改动只涉及判空与边界检查，不影响正常流程。