### PR TITLE
Fix: readerCount not decreasing on player shutdown

### DIFF
--- a/src/Player/PlayerBase.h
+++ b/src/Player/PlayerBase.h
@@ -286,7 +286,11 @@ public:
 
 protected:
     void onShutdown(const toolkit::SockException &ex) override {
-        if (_on_shutdown) {
+        if(_media_src){
+            _media_src->delSink(this);
+            _media_src.reset();
+        }
+        if( _on_shutdown) {
             _on_shutdown(ex);
             _on_shutdown = nullptr;
         }


### PR DESCRIPTION
Fixes #4628 

### Problem
When a player (for example, HTTP-FLV pulling an RTP stream) disconnects, the
MediaSink was not removed from the MediaSource. As a result, `readerCount`
remained non-zero and the `stream_none_reader` event was not triggered.

### Cause
`PlayerImp::onShutdown()` only executed shutdown callbacks but did not detach
the MediaSink from the associated MediaSource.

### Solution
Detach the MediaSink from MediaSource during player shutdown using `delSink(this)`.
This ensures `readerCount` is decremented correctly and stream cleanup works as expected.
