### PR TITLE
fix:  `MultiMediaSourceMuxer` 析构函数内联在某些版本编译器上可能导致的崩溃问题。

### DIFF
--- a/src/Common/MultiMediaSourceMuxer.cpp
+++ b/src/Common/MultiMediaSourceMuxer.cpp
@@ -245,6 +245,8 @@ MultiMediaSourceMuxer::MultiMediaSourceMuxer(const MediaTuple& tuple, float dur_
     enableMuteAudio(option.add_mute_audio);
 }
 
+MultiMediaSourceMuxer::~MultiMediaSourceMuxer() = default;
+
 void MultiMediaSourceMuxer::setMediaListener(const std::weak_ptr<MediaSourceEvent> &listener) {
     setDelegate(listener);
 

--- a/src/Common/MultiMediaSourceMuxer.h
+++ b/src/Common/MultiMediaSourceMuxer.h
@@ -37,7 +37,7 @@ public:
     };
 
     MultiMediaSourceMuxer(const MediaTuple& tuple, float dur_sec = 0.0,const ProtocolOption &option = ProtocolOption());
-
+    ~MultiMediaSourceMuxer() override;
     /**
      * 设置事件监听器
      * @param listener 监听器


### PR DESCRIPTION
显式定义~MultiMediaSourceMuxer() 析构函数，并将实现放到cpp文件中；以防止其被内联到模板析构函数中，从而避免崩溃。


AI分析:
```
之前析构函数在头文件中内联定义，导致每个包含该头文件的翻译单元
都有自己的析构函数定义副本。这可能会被内联到模板析构逻辑中，
从而导致崩溃。  
通过将析构函数定义移到 .cpp 文件中，现在只有一个定义，并且不会
被内联到其他翻译单元中。map 析构函数将通过 vtable 调用此实现，
从而避免崩溃。
```