### PR TITLE
[what][feature][rtp] 支持 L16 RTP 按照 Mark 标志进行拆包

### DIFF
--- a/ext-codec/AAC.cpp
+++ b/ext-codec/AAC.cpp
@@ -410,7 +410,7 @@ RtpCodec::Ptr getRtpEncoderByCodecId(uint8_t pt) {
     return std::make_shared<AACRtpEncoder>();
 }
 
-RtpCodec::Ptr getRtpDecoderByCodecId() {
+RtpCodec::Ptr getRtpDecoderByCodecId(const Track::Ptr &track) {
     return std::make_shared<AACRtpDecoder>();
 }
 

--- a/ext-codec/AV1.cpp
+++ b/ext-codec/AV1.cpp
@@ -65,7 +65,7 @@ RtpCodec::Ptr getRtpEncoderByCodecId(uint8_t pt) {
     return std::make_shared<AV1RtpEncoder>();
 }
 
-RtpCodec::Ptr getRtpDecoderByCodecId() {
+RtpCodec::Ptr getRtpDecoderByCodecId(const Track::Ptr &track) {
     return std::make_shared<AV1RtpDecoder>();
 }
 

--- a/ext-codec/G711.cpp
+++ b/ext-codec/G711.cpp
@@ -97,11 +97,11 @@ RtpCodec::Ptr getRtpDecoderByCodecId_l(CodecId codec) {
     return std::make_shared<CommonRtpDecoder>(codec);
 }
 
-RtpCodec::Ptr getRtpDecoderByCodecIdA() {
+RtpCodec::Ptr getRtpDecoderByCodecIdA(const Track::Ptr &track) {
     return getRtpDecoderByCodecId_l(CodecG711A);
 }
 
-RtpCodec::Ptr getRtpDecoderByCodecIdU() {
+RtpCodec::Ptr getRtpDecoderByCodecIdU(const Track::Ptr &track) {
     return getRtpDecoderByCodecId_l(CodecG711U);
 }
 

--- a/ext-codec/H264.cpp
+++ b/ext-codec/H264.cpp
@@ -398,7 +398,7 @@ RtpCodec::Ptr getRtpEncoderByCodecId(uint8_t pt) {
     return std::make_shared<H264RtpEncoder>();
 }
 
-RtpCodec::Ptr getRtpDecoderByCodecId() {
+RtpCodec::Ptr getRtpDecoderByCodecId(const Track::Ptr &track) {
     return std::make_shared<H264RtpDecoder>();
 }
 

--- a/ext-codec/H265.cpp
+++ b/ext-codec/H265.cpp
@@ -402,7 +402,7 @@ RtpCodec::Ptr getRtpEncoderByCodecId(uint8_t pt) {
     return std::make_shared<H265RtpEncoder>();
 }
 
-RtpCodec::Ptr getRtpDecoderByCodecId() {
+RtpCodec::Ptr getRtpDecoderByCodecId(const Track::Ptr &track) {
     return std::make_shared<H265RtpDecoder>();
 }
 

--- a/ext-codec/JPEG.cpp
+++ b/ext-codec/JPEG.cpp
@@ -53,7 +53,7 @@ RtpCodec::Ptr getRtpEncoderByCodecId(uint8_t pt) {
     return std::make_shared<JPEGRtpEncoder>();
 }
 
-RtpCodec::Ptr getRtpDecoderByCodecId() {
+RtpCodec::Ptr getRtpDecoderByCodecId(const Track::Ptr &track) {
     return std::make_shared<JPEGRtpDecoder>();
 }
 

--- a/ext-codec/L16.cpp
+++ b/ext-codec/L16.cpp
@@ -44,8 +44,8 @@ RtpCodec::Ptr getRtpEncoderByCodecId(uint8_t pt) {
     return std::make_shared<CommonRtpEncoder>();
 }
 
-RtpCodec::Ptr getRtpDecoderByCodecId() {
-    return std::make_shared<CommonRtpDecoder>(CodecL16);
+RtpCodec::Ptr getRtpDecoderByCodecId(const Track::Ptr &track) {
+    return std::make_shared<CommonRtpDecoder>(CodecL16, track->getUseRtpMark() ? 32 * 1024 : 2 * 1024, track->getUseRtpMark());
 }
 
 RtmpCodec::Ptr getRtmpEncoderByTrack(const Track::Ptr &track) {

--- a/ext-codec/MP3.cpp
+++ b/ext-codec/MP3.cpp
@@ -45,7 +45,7 @@ RtpCodec::Ptr getRtpEncoderByCodecId(uint8_t pt) {
     return std::make_shared<MP3RtpEncoder>();
 }
 
-RtpCodec::Ptr getRtpDecoderByCodecId() {
+RtpCodec::Ptr getRtpDecoderByCodecId(const Track::Ptr &track) {
     return std::make_shared<MP3RtpDecoder>();
 }
 

--- a/ext-codec/Opus.cpp
+++ b/ext-codec/Opus.cpp
@@ -57,7 +57,7 @@ RtpCodec::Ptr getRtpEncoderByCodecId(uint8_t pt) {
     return std::make_shared<CommonRtpEncoder>();
 }
 
-RtpCodec::Ptr getRtpDecoderByCodecId() {
+RtpCodec::Ptr getRtpDecoderByCodecId(const Track::Ptr &track) {
     return std::make_shared<CommonRtpDecoder>(CodecOpus);
 }
 

--- a/ext-codec/VP8.cpp
+++ b/ext-codec/VP8.cpp
@@ -49,7 +49,7 @@ RtpCodec::Ptr getRtpEncoderByCodecId(uint8_t pt) {
     return std::make_shared<VP8RtpEncoder>();
 }
 
-RtpCodec::Ptr getRtpDecoderByCodecId() {
+RtpCodec::Ptr getRtpDecoderByCodecId(const Track::Ptr &track) {
     return std::make_shared<VP8RtpDecoder>();
 }
 

--- a/ext-codec/VP9.cpp
+++ b/ext-codec/VP9.cpp
@@ -46,7 +46,7 @@ RtpCodec::Ptr getRtpEncoderByCodecId(uint8_t pt) {
     return std::make_shared<VP9RtpEncoder>();
 }
 
-RtpCodec::Ptr getRtpDecoderByCodecId() {
+RtpCodec::Ptr getRtpDecoderByCodecId(const Track::Ptr &track) {
     return std::make_shared<VP9RtpDecoder>();
 }
 

--- a/src/Common/config.cpp
+++ b/src/Common/config.cpp
@@ -416,6 +416,7 @@ const string kRtspSpeed = "rtsp_speed";
 const string kLatency = "latency";
 const string kPassPhrase = "passPhrase";
 const string kCustomHeader = "custom_header";
+const string kUseRtpMark = "use_rtp_mark";
 } // namespace Client
 
 } // namespace mediakit

--- a/src/Common/config.h
+++ b/src/Common/config.h
@@ -632,6 +632,9 @@ extern const std::string kLatency;
 extern const std::string kPassPhrase;
 // 自定义rtsp/http头
 extern const std::string kCustomHeader;
+// 设置rtp解码器是否使用rtp标记作为帧的结束标志
+// Set whether the rtp decoder uses rtp mark as the end of frame flag
+extern const std::string kUseRtpMark;
 } // namespace Client
 } // namespace mediakit
 

--- a/src/Extension/CommonRtp.h
+++ b/src/Extension/CommonRtp.h
@@ -36,7 +36,7 @@ public:
      
      * [AUTO-TRANSLATED:c6b0414f]
      */
-    CommonRtpDecoder(CodecId codec, size_t max_frame_size = 2 * 1024);
+    CommonRtpDecoder(CodecId codec, size_t max_frame_size = 2 * 1024, bool use_rtp_mark = false);
 
     /**
      * 输入rtp并解码
@@ -55,6 +55,7 @@ private:
 
 private:
     bool _drop_flag = false;
+    bool _use_rtp_mark = false;
     uint16_t _last_seq = 0;
     uint64_t _last_stamp = 0;
     size_t _max_frame_size;

--- a/src/Extension/Factory.cpp
+++ b/src/Extension/Factory.cpp
@@ -71,13 +71,14 @@ RtpCodec::Ptr Factory::getRtpEncoderByCodecId(CodecId codec, uint8_t pt) {
     return it->second->getRtpEncoderByCodecId(pt);
 }
 
-RtpCodec::Ptr Factory::getRtpDecoderByCodecId(CodecId codec) {
+RtpCodec::Ptr Factory::getRtpDecoderByCodecId(const Track::Ptr& track) {
+    CodecId codec = track->getCodecId();
     auto it = s_plugins.find(codec);
     if (it == s_plugins.end()) {
         WarnL << "Unsupported codec: " << getCodecName(codec) << ", use CommonRtpDecoder";
-        return std::make_shared<CommonRtpDecoder>(codec, 10 * 1024);
+        return std::make_shared<CommonRtpDecoder>(codec, track->getUseRtpMark() ? 32 * 1024 : 10 * 1024, track->getUseRtpMark());
     }
-    return it->second->getRtpDecoderByCodecId();
+    return it->second->getRtpDecoderByCodecId(track);
 }
 
 // ///////////////////////////rtmp相关///////////////////////////////////////////  [AUTO-TRANSLATED:da9645df]

--- a/src/Extension/Factory.h
+++ b/src/Extension/Factory.h
@@ -35,7 +35,7 @@ struct CodecPlugin {
     Track::Ptr (*getTrackByCodecId)(int sample_rate, int channels, int sample_bit);
     Track::Ptr (*getTrackBySdp)(const SdpTrack::Ptr &track);
     RtpCodec::Ptr (*getRtpEncoderByCodecId)(uint8_t pt);
-    RtpCodec::Ptr (*getRtpDecoderByCodecId)();
+    RtpCodec::Ptr (*getRtpDecoderByCodecId)(const Track::Ptr &track);
     RtmpCodec::Ptr (*getRtmpEncoderByTrack)(const Track::Ptr &track);
     RtmpCodec::Ptr (*getRtmpDecoderByTrack)(const Track::Ptr &track);
     Frame::Ptr (*getFrameFromPtr)(const char *data, size_t bytes, uint64_t dts, uint64_t pts);
@@ -103,7 +103,7 @@ public:
      
      * [AUTO-TRANSLATED:50dbf826]
      */
-    static RtpCodec::Ptr getRtpDecoderByCodecId(CodecId codec);
+    static RtpCodec::Ptr getRtpDecoderByCodecId(const Track::Ptr& track);
 
 
     // //////////////////////////////rtmp相关//////////////////////////////////  [AUTO-TRANSLATED:df02d6fb]

--- a/src/Extension/Track.h
+++ b/src/Extension/Track.h
@@ -123,8 +123,25 @@ public:
      */
     virtual void setBitRate(int bit_rate) { _bit_rate = bit_rate; }
 
+    /**
+     * 设置rtp解码器是否使用rtp标记作为帧的结束标志
+     * Set whether the rtp decoder uses rtp mark as the end of frame flag
+     * @param use_rtp_mark 是否使用rtp标记作为帧的结束标志
+     * @param use_rtp_mark Whether to use rtp mark as the end of frame flag
+     */
+    virtual void setUseRtpMark(bool use_rtp_mark) { _use_rtp_mark = use_rtp_mark; }
+
+    /**
+     * @brief 获取rtp解码器是否使用rtp标记作为帧的结束标志
+     * 
+     * @return 是否使用rtp标记作为帧的结束标志
+     * @return Whether to use rtp mark as the end of frame flag
+     */
+    virtual bool getUseRtpMark() const { return _use_rtp_mark; }   
+
 private:
     int _bit_rate = 0;
+    bool _use_rtp_mark = false;
 };
 
 /**

--- a/src/Rtp/GB28181Process.cpp
+++ b/src/Rtp/GB28181Process.cpp
@@ -95,7 +95,7 @@ bool GB28181Process::inputRtp(bool, const char *data, size_t data_len) {
                     CHECK(track);
                     track->setIndex(pt);
                     _interface->addTrack(track);
-                    _rtp_decoder[pt] = Factory::getRtpDecoderByCodecId(track->getCodecId());
+                    _rtp_decoder[pt] = Factory::getRtpDecoderByCodecId(track);
                     break;
                 }
             }
@@ -107,7 +107,7 @@ bool GB28181Process::inputRtp(bool, const char *data, size_t data_len) {
                 CHECK(track);
                 track->setIndex(pt);
                 _interface->addTrack(track);
-                _rtp_decoder[pt] = Factory::getRtpDecoderByCodecId(track->getCodecId());
+                _rtp_decoder[pt] = Factory::getRtpDecoderByCodecId(track);
                 break;
             }
             if (pt == h265_pt) {
@@ -118,7 +118,7 @@ bool GB28181Process::inputRtp(bool, const char *data, size_t data_len) {
                 CHECK(track);
                 track->setIndex(pt);
                 _interface->addTrack(track);
-                _rtp_decoder[pt] = Factory::getRtpDecoderByCodecId(track->getCodecId());
+                _rtp_decoder[pt] = Factory::getRtpDecoderByCodecId(track);
                 break;
             }
             if (pt == h264_pt) {
@@ -129,7 +129,7 @@ bool GB28181Process::inputRtp(bool, const char *data, size_t data_len) {
                 CHECK(track);
                 track->setIndex(pt);
                 _interface->addTrack(track);
-                _rtp_decoder[pt] = Factory::getRtpDecoderByCodecId(track->getCodecId());
+                _rtp_decoder[pt] = Factory::getRtpDecoderByCodecId(track);
                 break;
             }
 

--- a/src/Rtsp/RtspDemuxer.cpp
+++ b/src/Rtsp/RtspDemuxer.cpp
@@ -19,7 +19,8 @@ using namespace std;
 
 namespace mediakit {
 
-void RtspDemuxer::loadSdp(const string &sdp) {
+void RtspDemuxer::loadSdp(const string &sdp, bool use_rtp_mark) {
+    _use_rtp_mark = use_rtp_mark;
     loadSdp(SdpParser(sdp));
 }
 
@@ -89,13 +90,14 @@ void RtspDemuxer::makeAudioTrack(const SdpTrack::Ptr &audio) {
     // 生成Track对象  [AUTO-TRANSLATED:c2f2ac3b]
     // Generate Track object
     _audio_track = dynamic_pointer_cast<AudioTrack>(Factory::getTrackBySdp(audio));
+    _audio_track->setUseRtpMark(_use_rtp_mark);
     if (!_audio_track) {
         return;
     }
     setBitRate(audio, _audio_track);
     // 生成RtpCodec对象以便解码rtp  [AUTO-TRANSLATED:889376fd]
     // Generate RtpCodec object to decode rtp
-    _audio_rtp_decoder = Factory::getRtpDecoderByCodecId(_audio_track->getCodecId());
+    _audio_rtp_decoder = Factory::getRtpDecoderByCodecId(_audio_track);
     if (!_audio_rtp_decoder) {
         // 找不到相应的rtp解码器，该track无效  [AUTO-TRANSLATED:1c8c5eab]
         // Cannot find the corresponding rtp decoder, the track is invalid
@@ -118,10 +120,11 @@ void RtspDemuxer::makeVideoTrack(const SdpTrack::Ptr &video) {
     if (!_video_track) {
         return;
     }
+    _video_track->setUseRtpMark(_use_rtp_mark);
     setBitRate(video, _video_track);
     // 生成RtpCodec对象以便解码rtp  [AUTO-TRANSLATED:889376fd]
     // Generate RtpCodec object to decode rtp
-    _video_rtp_decoder = Factory::getRtpDecoderByCodecId(_video_track->getCodecId());
+    _video_rtp_decoder = Factory::getRtpDecoderByCodecId(_video_track);
     if (!_video_rtp_decoder) {
         // 找不到相应的rtp解码器，该track无效  [AUTO-TRANSLATED:1c8c5eab]
         // Cannot find the corresponding rtp decoder, the track is invalid

--- a/src/Rtsp/RtspDemuxer.h
+++ b/src/Rtsp/RtspDemuxer.h
@@ -27,7 +27,7 @@ public:
      
      * [AUTO-TRANSLATED:235be34f]
      */
-    void loadSdp(const std::string &sdp);
+    void loadSdp(const std::string &sdp, bool use_rtp_mark = false);
 
     /**
      * 开始解复用
@@ -63,6 +63,7 @@ private:
     VideoTrack::Ptr _video_track;
     RtpCodec::Ptr _audio_rtp_decoder;
     RtpCodec::Ptr _video_rtp_decoder;
+    bool _use_rtp_mark = false;
 };
 
 } /* namespace mediakit */

--- a/src/Rtsp/RtspPlayer.cpp
+++ b/src/Rtsp/RtspPlayer.cpp
@@ -85,6 +85,7 @@ void RtspPlayer::play(const string &strUrl) {
     }
 
     _play_url = url._url;
+    _use_rtp_mark = (*this)[Client::kUseRtpMark].as<bool>();
     _rtp_type = (Rtsp::eRtpType)(int)(*this)[Client::kRtpType];
     _beat_type = (*this)[Client::kRtspBeatType].as<int>();
     _beat_interval_ms = (*this)[Client::kBeatIntervalMS].as<int>();
@@ -918,7 +919,7 @@ bool RtspPlayerImp::onCheckSDP(const std::string &sdp) {
     }
     _demuxer = std::make_shared<RtspDemuxer>();
     _demuxer->setTrackListener(this, (*this)[Client::kWaitTrackReady].as<bool>());
-    _demuxer->loadSdp(sdp);
+    _demuxer->loadSdp(sdp, _use_rtp_mark);
     return true;
 }
 

--- a/src/Rtsp/RtspPlayer.h
+++ b/src/Rtsp/RtspPlayer.h
@@ -183,6 +183,7 @@ private:
     std::string _control_url;
 protected:   
     Rtsp::eRtpType _rtp_type = Rtsp::RTP_TCP;
+    bool _use_rtp_mark = false;
 
 private:
     // 起始时间戳


### PR DESCRIPTION
[why]
1.锁定帧长, 便于后级处理(需要对端保证 mark 可靠性)
2.减少缓冲延迟
3. 支持通用 RTP 拆包根据 mark 的标志位 (可用 mark 标志位处理非流式数据存在的粘包问题)

[how]

1. L16 支持按照 RTP MARK 标志位拆包
2. RTP MARK 拆包模式下优化延迟, 实现单帧无缓冲

[todo]
1. 支持 RTP MARK 拆包时可指定最大缓冲区大小
2. 支持 RTP 发包时可手动指定 MARK 标志