### PR TITLE
[what][bugfix][rtmp] 兼容某些 RTMP 服务 connect 返回的 _result 顺序可能不固定

### DIFF
--- a/src/Rtmp/RtmpPusher.cpp
+++ b/src/Rtmp/RtmpPusher.cpp
@@ -16,6 +16,8 @@
 #include "Common/Parser.h"
 #include "Common/config.h"
 
+#include <exception>
+
 using namespace std;
 using namespace toolkit;
 
@@ -157,14 +159,23 @@ void RtmpPusher::send_connect() {
     sendInvoke("connect", obj);
     addOnResultCB([this](AMFDecoder &dec) {
         //TraceL << "connect result";
-        dec.load<AMFValue>();
-        auto val = dec.load<AMFValue>();
-        auto level = val["level"].as_string();
-        auto code = val["code"].as_string();
-        if (level != "status") {
-            throw std::runtime_error(StrPrinter << "connect 失败:" << level << " " << code << endl);
-        }
-        send_createStream();
+        do {
+            try {
+                auto val = dec.load<AMFValue>();
+                if(val["level"].type()== AMF_NULL && val["code"].type()== AMF_NULL){
+                    continue;
+                }
+                auto level = val["level"].as_string();
+                auto code = val["code"].as_string();
+                if (level != "status") {
+                    throw std::runtime_error(StrPrinter << "connect 失败:" << level << " " << code << endl);
+                }
+                send_createStream();
+                break;
+            } catch (const std::exception& ex) {
+                throw std::runtime_error(StrPrinter <<"connect 失败:AMF "<< ex.what());
+            }
+        } while(1);
     });
 }
 


### PR DESCRIPTION
[why] 原解析按照固定顺序解析

[how] 现改成兼容乱序解析