### PR TITLE
解决在window mingw 5.3环境下编译出现报错信息

### DIFF
--- a/server/System.cpp
+++ b/server/System.cpp
@@ -185,6 +185,7 @@ void System::startDaemon(bool &kill_parent_if_failed) {
 #endif // _WIN32
 }
 
+#ifdef _WIN32
 static LONG __stdcall customUnhandledExceptionFilter(EXCEPTION_POINTERS *pException) {
     // 生成 dump 文件名，带时间戳
     char dumpPath[MAX_PATH];
@@ -208,6 +209,7 @@ static LONG __stdcall customUnhandledExceptionFilter(EXCEPTION_POINTERS *pExcept
     }
     return EXCEPTION_EXECUTE_HANDLER;
 }
+#endif//!defined(_WIN32)
 
 void System::systemSetup(){
 

--- a/server/System.cpp
+++ b/server/System.cpp
@@ -83,6 +83,30 @@ static std::string get_func_symbol(const std::string &symbol) {
     return ret;
 }
 
+static LONG __stdcall UnhandledExceptionFilter(EXCEPTION_POINTERS *pException) {
+    // 生成 dump 文件名，带时间戳
+    char dumpPath[MAX_PATH];
+    std::time_t t = std::time(nullptr);
+    std::tm tm;
+#ifdef _MSC_VER
+    localtime_s(&tm, &t);
+#else
+    tm = *std::localtime(&t);
+#endif
+    std::strftime(dumpPath, sizeof(dumpPath), "crash_%Y%m%d_%H%M%S.dmp", &tm);
+
+    HANDLE hFile = CreateFileA(dumpPath, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (hFile != INVALID_HANDLE_VALUE) {
+        MINIDUMP_EXCEPTION_INFORMATION mdei;
+        mdei.ThreadId = GetCurrentThreadId();
+        mdei.ExceptionPointers = pException;
+        mdei.ClientPointers = FALSE;
+        MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), hFile, MiniDumpNormal, &mdei, nullptr, nullptr);
+        CloseHandle(hFile);
+    }
+    return EXCEPTION_EXECUTE_HANDLER;
+}
+
 static void sig_crash(int sig) {
     signal(sig, SIG_DFL);
     void *array[MAX_STACK_FRAMES];
@@ -238,29 +262,7 @@ void System::systemSetup(){
     std::ios_base::sync_with_stdio(false);
 
       // 注册crash自动生成dump（等价core dump）
-    SetUnhandledExceptionFilter([](EXCEPTION_POINTERS *pException) -> LONG {
-        // 生成 dump 文件名，带时间戳
-        char dumpPath[MAX_PATH];
-        std::time_t t = std::time(nullptr);
-        std::tm tm;
-#ifdef _MSC_VER
-        localtime_s(&tm, &t);
-#else
-        tm = *std::localtime(&t);
-#endif
-        std::strftime(dumpPath, sizeof(dumpPath), "crash_%Y%m%d_%H%M%S.dmp", &tm);
-
-        HANDLE hFile = CreateFileA(dumpPath, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
-        if (hFile != INVALID_HANDLE_VALUE) {
-            MINIDUMP_EXCEPTION_INFORMATION mdei;
-            mdei.ThreadId = GetCurrentThreadId();
-            mdei.ExceptionPointers = pException;
-            mdei.ClientPointers = FALSE;
-            MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), hFile, MiniDumpNormal, &mdei, nullptr, nullptr);
-            CloseHandle(hFile);
-        }
-        return EXCEPTION_EXECUTE_HANDLER;
-    });
+    SetUnhandledExceptionFilter(UnhandledExceptionFilter);
 #endif//!defined(_WIN32)
 }
 

--- a/server/System.cpp
+++ b/server/System.cpp
@@ -83,7 +83,7 @@ static std::string get_func_symbol(const std::string &symbol) {
     return ret;
 }
 
-static LONG __stdcall UnhandledExceptionFilter(EXCEPTION_POINTERS *pException) {
+static LONG __stdcall customUnhandledExceptionFilter(EXCEPTION_POINTERS *pException) {
     // 生成 dump 文件名，带时间戳
     char dumpPath[MAX_PATH];
     std::time_t t = std::time(nullptr);
@@ -262,7 +262,7 @@ void System::systemSetup(){
     std::ios_base::sync_with_stdio(false);
 
       // 注册crash自动生成dump（等价core dump）
-    SetUnhandledExceptionFilter(UnhandledExceptionFilter);
+    SetUnhandledExceptionFilter(customUnhandledExceptionFilter);
 #endif//!defined(_WIN32)
 }
 

--- a/server/System.cpp
+++ b/server/System.cpp
@@ -83,30 +83,6 @@ static std::string get_func_symbol(const std::string &symbol) {
     return ret;
 }
 
-static LONG __stdcall customUnhandledExceptionFilter(EXCEPTION_POINTERS *pException) {
-    // 生成 dump 文件名，带时间戳
-    char dumpPath[MAX_PATH];
-    std::time_t t = std::time(nullptr);
-    std::tm tm;
-#ifdef _MSC_VER
-    localtime_s(&tm, &t);
-#else
-    tm = *std::localtime(&t);
-#endif
-    std::strftime(dumpPath, sizeof(dumpPath), "crash_%Y%m%d_%H%M%S.dmp", &tm);
-
-    HANDLE hFile = CreateFileA(dumpPath, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
-    if (hFile != INVALID_HANDLE_VALUE) {
-        MINIDUMP_EXCEPTION_INFORMATION mdei;
-        mdei.ThreadId = GetCurrentThreadId();
-        mdei.ExceptionPointers = pException;
-        mdei.ClientPointers = FALSE;
-        MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), hFile, MiniDumpNormal, &mdei, nullptr, nullptr);
-        CloseHandle(hFile);
-    }
-    return EXCEPTION_EXECUTE_HANDLER;
-}
-
 static void sig_crash(int sig) {
     signal(sig, SIG_DFL);
     void *array[MAX_STACK_FRAMES];
@@ -207,6 +183,30 @@ void System::startDaemon(bool &kill_parent_if_failed) {
         } while (true);
     } while (true);
 #endif // _WIN32
+}
+
+static LONG __stdcall customUnhandledExceptionFilter(EXCEPTION_POINTERS *pException) {
+    // 生成 dump 文件名，带时间戳
+    char dumpPath[MAX_PATH];
+    std::time_t t = std::time(nullptr);
+    std::tm tm;
+#ifdef _MSC_VER
+    localtime_s(&tm, &t);
+#else
+    tm = *std::localtime(&t);
+#endif
+    std::strftime(dumpPath, sizeof(dumpPath), "crash_%Y%m%d_%H%M%S.dmp", &tm);
+
+    HANDLE hFile = CreateFileA(dumpPath, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (hFile != INVALID_HANDLE_VALUE) {
+        MINIDUMP_EXCEPTION_INFORMATION mdei;
+        mdei.ThreadId = GetCurrentThreadId();
+        mdei.ExceptionPointers = pException;
+        mdei.ClientPointers = FALSE;
+        MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), hFile, MiniDumpNormal, &mdei, nullptr, nullptr);
+        CloseHandle(hFile);
+    }
+    return EXCEPTION_EXECUTE_HANDLER;
 }
 
 void System::systemSetup(){


### PR DESCRIPTION
解决在window mingw 5.3环境下编译出现如下报错信息
 no known conversion from 'LONG (*)(EXCEPTION_POINTERS*) {aka long int (*)(_EXCEPTION_POINTERS*)}' to 'LPTOP_LEVEL_EXCEPTION_FILTER {aka long int (__attribute__((__stdcall__)) *)(_EXCEPTION_POINTERS*)}' 