### PR TITLE
fix: add DELETE and PUT to OPTIONS allowed methods for WHIP/WHEP CORS preflight

### DIFF
--- a/src/Http/HttpSession.cpp
+++ b/src/Http/HttpSession.cpp
@@ -42,15 +42,15 @@ void HttpSession::onHttpRequest_HEAD() {
 
 void HttpSession::onHttpRequest_OPTIONS() {
     KeyValue header;
-    header.emplace("Allow", "GET, POST, HEAD, OPTIONS");
+    header.emplace("Allow", "GET, POST, PUT, HEAD, OPTIONS, DELETE");
     GET_CONFIG(bool, allow_cross_domains, Http::kAllowCrossDomains);
     if (allow_cross_domains) {
         header.emplace("Access-Control-Allow-Origin", "*");
         header.emplace("Access-Control-Allow-Headers", "*");
-        header.emplace("Access-Control-Allow-Methods", "GET, POST, HEAD, OPTIONS");
+        header.emplace("Access-Control-Allow-Methods", "GET, POST, PUT, HEAD, OPTIONS, DELETE");
     }
     header.emplace("Access-Control-Allow-Credentials", "true");
-    header.emplace("Access-Control-Request-Methods", "GET, POST, OPTIONS");
+    header.emplace("Access-Control-Request-Methods", "GET, POST, PUT, OPTIONS, DELETE");
     header.emplace("Access-Control-Request-Headers", "Accept,Accept-Language,Content-Language,Content-Type");
     sendResponse(200, true, nullptr, header);
 }


### PR DESCRIPTION
## 问题

`onHttpRequest_OPTIONS()` 返回的三个 HTTP 响应头均未包含 `DELETE`（及 `PUT`）方法，而 `onRecvHeader()` 中已明确注册了这两个方法（注释说明用于 WHIP/WHEP）。

这导致浏览器发起跨域 `DELETE` 请求（WHIP session teardown）前的 CORS 预检失败，无法完成 WHIP session 的正常关闭。

关联 issue: #4726

## 修改内容

在 `src/Http/HttpSession.cpp` 的 `onHttpRequest_OPTIONS()` 中：

| 响应头 | 修改前 | 修改后 |
|---|---|---|
| `Allow` | `GET, POST, HEAD, OPTIONS` | `GET, POST, PUT, HEAD, OPTIONS, DELETE` |
| `Access-Control-Allow-Methods` | `GET, POST, HEAD, OPTIONS` | `GET, POST, PUT, HEAD, OPTIONS, DELETE` |
| `Access-Control-Request-Methods` | `GET, POST, OPTIONS` | `GET, POST, PUT, OPTIONS, DELETE` |

## 测试

使用支持 WHIP 协议的浏览器客户端，在 `allow_cross_domains=1` 配置下，跨域 `DELETE` 请求可通过 CORS 预检，WHIP session 正常 teardown。