### PR TITLE
处理seek offset为负数情况

### DIFF
--- a/src/Record/MP4.cpp
+++ b/src/Record/MP4.cpp
@@ -156,8 +156,9 @@ int64_t MP4FileMemory::onTell(){
 int MP4FileMemory::onSeek(int64_t offset){
     if (offset < 0) {
         offset += _memory.size();
-        if (offset < 0)
+        if (offset < 0) {
             return -1;
+        }
         _offset = offset;
     } else {
         if (offset > _memory.size()) {

--- a/src/Record/MP4.cpp
+++ b/src/Record/MP4.cpp
@@ -35,7 +35,7 @@ static struct mov_buffer_t s_io = {
         },
         [](void *ctx) {
             MP4FileIO *thiz = (MP4FileIO *) ctx;
-            return (int64_t)thiz->onTell();
+            return thiz->onTell();
         }
 };
 
@@ -128,11 +128,11 @@ int MP4FileDisk::onWrite(const void *data, size_t bytes) {
     return bytes == fwrite(data, 1, bytes, _file.get()) ? 0 : ferror(_file.get());
 }
 
-int MP4FileDisk::onSeek(uint64_t offset) {
-    return fseek64(_file.get(), offset, SEEK_SET);
+int MP4FileDisk::onSeek(int64_t offset) {
+    return fseek64(_file.get(), offset, offset >= 0 ? SEEK_SET : SEEK_END);
 }
 
-uint64_t MP4FileDisk::onTell() {
+int64_t MP4FileDisk::onTell() {
     return ftell64(_file.get());
 }
 
@@ -149,15 +149,22 @@ size_t MP4FileMemory::fileSize() const{
     return _memory.size();
 }
 
-uint64_t MP4FileMemory::onTell(){
+int64_t MP4FileMemory::onTell(){
     return _offset;
 }
 
-int MP4FileMemory::onSeek(uint64_t offset){
-    if (offset > _memory.size()) {
-        return -1;
+int MP4FileMemory::onSeek(int64_t offset){
+    if (offset < 0) {
+        offset += _memory.size();
+        if (offset < 0)
+            return -1;
+        _offset = offset;
+    } else {
+        if (offset > _memory.size()) {
+            return -1;
+        }
+        _offset = offset;
     }
-    _offset = offset;
     return 0;
 }
 
@@ -167,7 +174,7 @@ int MP4FileMemory::onRead(void *data, size_t bytes){
         return -1;
     }
     bytes = MIN(bytes, _memory.size() - _offset);
-    memcpy(data, _memory.data(), bytes);
+    memcpy(data, _memory.data() + _offset, bytes);
     _offset += bytes;
     return 0;
 }

--- a/src/Record/MP4.h
+++ b/src/Record/MP4.h
@@ -66,7 +66,7 @@ public:
      
      * [AUTO-TRANSLATED:f8a5b290]
      */
-    virtual uint64_t onTell() = 0;
+    virtual int64_t onTell() = 0;
 
     /**
      * seek至文件某处
@@ -78,7 +78,7 @@ public:
      
      * [AUTO-TRANSLATED:936089eb]
      */
-    virtual int onSeek(uint64_t offset) = 0;
+    virtual int onSeek(int64_t offset) = 0;
 
     /**
      * 从文件读取一定数据
@@ -136,8 +136,8 @@ public:
     void closeFile();
 
 protected:
-    uint64_t onTell() override;
-    int onSeek(uint64_t offset) override;
+    int64_t onTell() override;
+    int onSeek(int64_t offset) override;
     int onRead(void *data, size_t bytes) override;
     int onWrite(const void *data, size_t bytes) override;
 
@@ -167,13 +167,13 @@ public:
     std::string getAndClearMemory();
 
 protected:
-    uint64_t onTell() override;
-    int onSeek(uint64_t offset) override;
+    int64_t onTell() override;
+    int onSeek(int64_t offset) override;
     int onRead(void *data, size_t bytes) override;
     int onWrite(const void *data, size_t bytes) override;
 
 private:
-    uint64_t _offset = 0;
+    int64_t _offset = 0;
     std::string _memory;
 };
 


### PR DESCRIPTION
详见media-server的buffer实现， seek的语义和回调不一致，这边进行统一
static int mov_file_read(void* fp, void* data, uint64_t bytes)
{
    if (bytes == fread(data, 1, bytes, (FILE*)fp))
        return 0;
	return 0 != ferror((FILE*)fp) ? ferror((FILE*)fp) : -1 /*EOF*/;
}

static int mov_file_write(void* fp, const void* data, uint64_t bytes)
{
	return bytes == fwrite(data, 1, bytes, (FILE*)fp) ? 0 : ferror((FILE*)fp);
}

static int mov_file_seek(void* fp, int64_t offset)
{
	return fseek64((FILE*)fp, offset, offset >= 0 ? SEEK_SET : SEEK_END);
}

static int64_t mov_file_tell(void* fp)
{
	return ftell64((FILE*)fp);
}