### PR TITLE
Require API secret for protected HTTP API (fix cookie-first auth bypass)

### DIFF
--- a/server/WebApi.cpp
+++ b/server/WebApi.cpp
@@ -741,31 +741,9 @@ void check_secret(toolkit::SockInfo &sender, mediakit::HttpSession::KeyValue &he
         throw AuthException("Your ip is not allowed to access the service.");
     }
 
-    try {
-        auto logined_cookie = HttpCookieManager::Instance().getCookie(kLoginedCookieName, allArgs.getParser().getHeader());
-        if (!logined_cookie) {
-            auto unlogin_cookie = HttpCookieManager::Instance().getCookie(kUnLoginCookieName, allArgs.getParser().getHeader());
-            if (!unlogin_cookie) {
-                unlogin_cookie = HttpCookieManager::Instance().addCookie(kUnLoginCookieName, "", kUnLoginCookieLifeSeconds);
-                headerOut["Set-Cookie"] = unlogin_cookie->getCookie(kLoginCookiePath);
-            }
-            val["cookie"] = unlogin_cookie->getCookie();
-            throw AuthException("Please login first", headerOut, val);
-        }
-        // 优先cookie登陆鉴权
-    } catch (...) {
-        try {
-            // cookie登陆鉴权失败了再比对secret
-            CHECK_ARGS("secret");
-            if (api_secret != allArgs["secret"]) {
-                throw AuthException("Incorrect secret");
-            }
-            return;
-        } catch (...) {
-            // 未提供secret或secret不匹配，这个异常隐藏
-        }
-        // secret鉴权模式失败，抛出要求cookie登录的异常
-        throw;
+    CHECK_ARGS("secret");
+    if (api_secret != allArgs["secret"]) {
+        throw AuthException("Incorrect secret");
     }
 }
 


### PR DESCRIPTION
### Motivation

- A recent change made `ZLM_LOGINED` session cookies sufficient to authorize API calls, which together with permissive CORS and cookies lacking `SameSite`/`HttpOnly` enables CSRF-style actions by a logged-in admin.
- The intent of this PR is to restore the legacy behavior that protected HTTP API endpoints always require the configured API `secret` (after IP allowlist checks) to prevent cookie-only authorization.

### Description

- Restored secret-only verification in `check_secret` by requiring the configured API `secret` and removing the cookie-first fallback path in `server/WebApi.cpp`.
- The change is localized to `server/WebApi.cpp` (the `check_secret` function), minimizing behavioral impact outside API authorization.
- Commit message: `Restore secret requirement for HTTP API auth`.

### Testing

- Ran `git diff --check` which completed without reported whitespace errors.
- Ran `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` which started configuration but failed to finish because `3rdpart/ZLToolKit` is missing from this checkout, so a full build could not be produced in this environment.
- Changes were committed locally with message `Restore secret requirement for HTTP API auth`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69bbe759dc0083208a61c3ddf1385909)