### PR TITLE
fix dockerfile warnning

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -86,5 +86,5 @@ WORKDIR /opt/media/bin/
 COPY --from=build /opt/media/ZLMediaKit/release/linux/${MODEL}/MediaServer /opt/media/ZLMediaKit/default.pem /opt/media/bin/
 COPY --from=build /opt/media/ZLMediaKit/release/linux/${MODEL}/config.ini /opt/media/conf/
 COPY --from=build /opt/media/ZLMediaKit/www/ /opt/media/bin/www/
-ENV PATH /opt/media/bin:$PATH
+ENV PATH=/opt/media/bin:$PATH
 CMD ["./MediaServer","-s", "default.pem", "-c", "../conf/config.ini", "-l","0"]


### PR DESCRIPTION
在build的时候提示
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 89)