### PR TITLE
修复: MediaSource 经 listener->getMuxer() 的空指针竞态崩溃

### DIFF
--- a/src/Common/MediaSource.cpp
+++ b/src/Common/MediaSource.cpp
@@ -238,7 +238,10 @@ toolkit::EventPoller::Ptr MediaSource::getOwnerPoller() {
 
 std::shared_ptr<MultiMediaSourceMuxer> MediaSource::getMuxer() const {
     auto listener = _listener.lock();
-    return listener ? listener->getMuxer(const_cast<MediaSource&>(*this)) : nullptr;
+    if (listener) {
+        return listener->getMuxer(const_cast<MediaSource &>(*this));
+    }
+    throw std::runtime_error("MediaSourceEvent is empty");
 }
 
 std::shared_ptr<RtpProcess> MediaSource::getRtpProcess() const {

--- a/src/Common/MediaSource.h
+++ b/src/Common/MediaSource.h
@@ -96,7 +96,7 @@ public:
 
     // 获取MultiMediaSourceMuxer对象  [AUTO-TRANSLATED:2de96d44]
     // Get MultiMediaSourceMuxer object
-    virtual std::shared_ptr<MultiMediaSourceMuxer> getMuxer(MediaSource &sender) const { return nullptr; }
+    virtual std::shared_ptr<MultiMediaSourceMuxer> getMuxer(MediaSource &sender) const { throw NotImplemented(toolkit::demangle(typeid(*this).name()) + "::getMuxer not implemented"); }
     // 获取RtpProcess对象  [AUTO-TRANSLATED:c6b7da43]
     // Get RtpProcess object
     virtual std::shared_ptr<RtpProcess> getRtpProcess(MediaSource &sender) const { return nullptr; }


### PR DESCRIPTION
MultiMediaSourceMuxer 的持有者在其它线程释放它时（例如业务侧批量
关闭/重建流）, 存在一个窗口: MediaSource 的 _listener（指向
RtspMediaSourceMuxer 等中间 MediaSourceEventInterceptor）仍可 lock 成功, 但 interceptor 内层指向 MultiMediaSourceMuxer 的弱引用已 expired, 此时 MediaSourceEventInterceptor::getMuxer() 退回 MediaSourceEvent 基类默认实现返回 nullptr。以下调用点未判空直接
解引用, 与释放并发即 SIGSEGV:

- src/Common/MediaSource.cpp: getTracks / setupRecord / isRecording / startSendRtp / stopSendRtp 共 5 处
- server/WebApi.cpp: startRecord / addProbe API 共 2 处

压测实录两条崩溃栈（40 路 RTSP 推流, 高频批量注销/重建派生流,
并叠加 getMediaInfo/getMediaList 轮询, x86 Debug + gdb）: 1) MediaSource::getTracks (MediaSource.cpp:138), 经附着在源 ring
   上的读包回调 / EventPoller::onPipeEvent 异步任务触发;
2) MultiMediaSourceMuxer::isRecording(this=0x0), 经 getMediaInfo
   -> makeMediaSourceJson (WebApi.cpp) 触发。

修复: 上述 7 处对 getMuxer() 返回值判空, 失败走各自的正常错误
返回（空 track 列表 / false / 错误回调 / API 错误响应）。回归:
同压测 300 轮零崩溃, 推拉流功能不受影响。