### PR TITLE
fix: restore SRT transport cleanup on session error

### DIFF
--- a/srt/SrtSession.cpp
+++ b/srt/SrtSession.cpp
@@ -67,10 +67,10 @@ void SrtSession::onError(const SockException &err) {
     // Prevent mutual reference from causing non-release
     auto transport = std::move(_transport);
     getPoller()->async(
-        [transport] {
+        [transport, err] {
             // 延时减引用，防止使用transport对象时，销毁对象  [AUTO-TRANSLATED:09dd6609]
             // Delayed dereference to prevent object destruction when using the transport object
-            //transport->onShutdown(err);
+            transport->onShutdown(err);
         },
         false);
 }

--- a/srt/SrtSession.cpp
+++ b/srt/SrtSession.cpp
@@ -66,6 +66,13 @@ void SrtSession::onError(const SockException &err) {
     // 防止互相引用导致不释放  [AUTO-TRANSLATED:82547e46]
     // Prevent mutual reference from causing non-release
     auto transport = std::move(_transport);
+
+    // Only shut down the transport if this session is still the selected one;
+    // otherwise a migrated session has already taken over and should not be affected.
+    if (transport->getSession().get() != static_cast<Session *>(this)) {
+        return;
+    }
+
     getPoller()->async(
         [transport, err] {
             // 延时减引用，防止使用transport对象时，销毁对象  [AUTO-TRANSLATED:09dd6609]


### PR DESCRIPTION
### Motivation
- Restore the transport cleanup path on SRT session errors so `SrtTransport::onShutdown` runs its unregister logic and prevents unbounded growth of weak_ptr entries in the transport manager that could lead to a memory-exhaustion DoS.

### Description
- Re-enabled shutdown cleanup in `srt/SrtSession.cpp` by capturing `err` in the delayed callback and calling `transport->onShutdown(err)` from the `getPoller()->async` lambda.

### Testing
- Ran `cmake -S . -B build` to sanity-check configuration; configuration failed in this environment due to a missing `3rdpart/ZLToolKit` submodule and unrelated CMake errors, not due to the patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69b32b68f8ac8320b6a9b0fad53594c6)