### PR TITLE
fix(webrtc): 修复异常 ICE 会话导致的端口资源泄漏

### DIFF
--- a/conf/config.ini
+++ b/conf/config.ini
@@ -587,6 +587,9 @@ enableTurn=1
 # ICE传输策略：0=不限制(默认)，1=仅支持Relay转发，2=仅支持P2P直连
 # ICE transport policy: 0 (No restrictions, default), 1 (Relay forwarding only), 2 (P2P direct connection only).
 iceTransportPolicy=0
+# UDP ICE会话空闲超时时间，单位秒，0为关闭
+# UDP ICE session idle timeout in seconds; set to 0 to disable.
+iceSessionTimeoutSec=60
 # STUN/TURN 服务Ice密码
 # ICE credentials for STUN/TURN services.
 iceUfrag=ZLMediaKit

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,7 +37,7 @@ foreach(TEST_SRC ${TEST_SRC_LIST})
 
   if(NOT TARGET ZLMediaKit::WebRTC)
     # 暂时过滤掉依赖 WebRTC 的测试模块
-    if("${TEST_EXE_NAME}" MATCHES "test_rtcp_nack|test_webrtc_regression")
+    if("${TEST_EXE_NAME}" MATCHES "test_rtcp_nack|test_webrtc_regression|test_turn_allocation")
       continue()
     endif()
   endif()

--- a/tests/test_turn_allocation.cpp
+++ b/tests/test_turn_allocation.cpp
@@ -1,0 +1,215 @@
+﻿/*
+ * Copyright (c) 2016-present The ZLMediaKit project authors. All Rights Reserved.
+ *
+ * This file is part of ZLMediaKit(https://github.com/ZLMediaKit/ZLMediaKit).
+ *
+ * Use of this source code is governed by MIT-like license that can be found in the
+ * LICENSE file in the root of the source tree. All contributing project authors
+ * may be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "Common/config.h"
+#include "Network/Socket.h"
+#include "Poller/EventPoller.h"
+#include "Util/NoticeCenter.h"
+#include "../webrtc/IceTransport.hpp"
+
+using namespace std;
+using namespace toolkit;
+using namespace RTC;
+using namespace mediakit;
+
+namespace {
+void expect(bool cond, const string &message) {
+    if (!cond) {
+        throw runtime_error(message);
+    }
+}
+
+class TestSocketHelper : public SocketHelper {
+public:
+    explicit TestSocketHelper(const Socket::Ptr &socket) : SocketHelper(socket) {}
+
+    void onRecv(const Buffer::Ptr &) override {}
+    void onError(const SockException &) override {}
+    void onManager() override {}
+};
+
+class TestIceServer : public IceServer {
+public:
+    explicit TestIceServer(const EventPoller::Ptr &poller)
+        : IceServer(nullptr, "testUfrag", "testPassword", poller) {}
+
+    using IceServer::handleAllocateRequest;
+    using IceServer::handleRefreshRequest;
+
+    void sendSocketData(const Buffer::Ptr &buf, const Pair::Ptr &, bool = true) override {
+        auto packet = StunPacket::parse(reinterpret_cast<const uint8_t *>(buf->data()), buf->size());
+        expect(packet != nullptr, "handler must send a serialized STUN response");
+        _responses.emplace_back(std::move(packet));
+    }
+
+    void seedAllocation(const Pair::Ptr &pair, const string &transaction_id, uint64_t update_time) {
+        sockaddr_storage peer_addr;
+        pair->get_peer_addr(peer_addr);
+        auto socket = Socket::createSocket(getPoller());
+        expect(socket->bindUdpSock(0, "127.0.0.1"), "test relay socket should bind locally");
+        auto relay_socket = make_shared<TestSocketHelper>(std::move(socket));
+        auto relay_pair = make_shared<Pair>(relay_socket);
+        _relayed_pairs.emplace(peer_addr, make_pair(shared_ptr<uint16_t>(), relay_pair));
+        _allocation_transaction_id = transaction_id;
+        _allocation_update_time = update_time;
+    }
+
+    const StunPacket::Ptr &response() const {
+        expect(_responses.size() == 1, "handler must send exactly one response");
+        return _responses.front();
+    }
+    const string &allocationTransactionId() const { return _allocation_transaction_id; }
+    uint64_t allocationUpdateTime() const { return _allocation_update_time; }
+    size_t allocationCount() const { return _relayed_pairs.size(); }
+    SocketHelper::Ptr relaySocket(const Pair::Ptr &pair) const {
+        auto peer_addr = SockUtil::make_sockaddr(pair->get_peer_ip().data(), pair->get_peer_port());
+        auto it = _relayed_pairs.find(peer_addr);
+        return it == _relayed_pairs.end() ? nullptr : it->second.second->_socket;
+    }
+
+private:
+    vector<StunPacket::Ptr> _responses;
+};
+
+IceTransport::Pair::Ptr makePair(const EventPoller::Ptr &poller, const string &ip, uint16_t port) {
+    auto socket = make_shared<TestSocketHelper>(Socket::createSocket(poller));
+    return make_shared<IceTransport::Pair>(socket, ip, port);
+}
+
+StunPacket::Ptr makeRequest(StunPacket::Method method, const char *transaction_id, int lifetime = -1) {
+    auto packet = make_shared<StunPacket>(StunPacket::Class::REQUEST, method, transaction_id);
+    if (lifetime >= 0) {
+        auto attr = make_shared<StunAttrLifeTime>();
+        attr->setLifetime(static_cast<uint32_t>(lifetime));
+        packet->addAttribute(std::move(attr));
+    }
+    return packet;
+}
+
+void expectResponse(const StunPacket::Ptr &response, StunPacket::Class klass,
+                    StunPacket::Method method, StunAttrErrorCode::Code error = StunAttrErrorCode::Code::Invalid) {
+    expect(response->getClass() == klass, "unexpected STUN response class");
+    expect(response->getMethod() == method, "unexpected STUN response method");
+    expect(response->getErrorCode() == error, "unexpected STUN error code");
+}
+
+void testAllocateHandlers() {
+    auto poller = EventPollerPool::Instance().getPoller();
+    auto server = make_shared<TestIceServer>(poller);
+    auto owner = makePair(poller, "127.0.0.1", 40000);
+    const string original_id = "allocate0001";
+
+    server->handleAllocateRequest(makeRequest(StunPacket::Method::ALLOCATE, original_id.c_str()), owner);
+    expectResponse(server->response(), StunPacket::Class::SUCCESS_RESPONSE, StunPacket::Method::ALLOCATE);
+    expect(server->allocationCount() == 1, "first Allocate should create one relay allocation");
+    expect(server->allocationTransactionId() == original_id,
+           "successful first Allocate should record its transaction ID");
+    auto original_socket = server->relaySocket(owner);
+    auto original_time = server->allocationUpdateTime();
+
+    auto retransmission = make_shared<TestIceServer>(poller);
+    retransmission->seedAllocation(owner, original_id, original_time);
+    auto seeded_socket = retransmission->relaySocket(owner);
+    retransmission->handleAllocateRequest(makeRequest(StunPacket::Method::ALLOCATE, original_id.c_str()), owner);
+    expectResponse(retransmission->response(), StunPacket::Class::SUCCESS_RESPONSE, StunPacket::Method::ALLOCATE);
+    expect(retransmission->relaySocket(owner) == seeded_socket,
+           "Allocate retransmission should reuse the existing relay socket");
+    expect(retransmission->allocationUpdateTime() == original_time,
+           "Allocate retransmission must not refresh allocation lifetime");
+
+    auto mismatch = make_shared<TestIceServer>(poller);
+    mismatch->seedAllocation(owner, original_id, original_time);
+    mismatch->handleAllocateRequest(makeRequest(StunPacket::Method::ALLOCATE, "allocate0002"), owner);
+    expectResponse(mismatch->response(), StunPacket::Class::ERROR_RESPONSE, StunPacket::Method::ALLOCATE,
+                   StunAttrErrorCode::Code::AllocationMismatch);
+    expect(mismatch->allocationCount() == 1 && mismatch->relaySocket(owner) != nullptr,
+           "mismatched Allocate must preserve the allocation");
+    expect(mismatch->allocationUpdateTime() == original_time && mismatch->allocationTransactionId() == original_id,
+           "mismatched Allocate must preserve lifetime and transaction ID");
+    expect(original_socket != nullptr, "first Allocate should expose a live relay socket");
+}
+
+void testRefreshHandlers() {
+    auto poller = EventPollerPool::Instance().getPoller();
+    auto owner = makePair(poller, "127.0.0.1", 40001);
+    auto other = makePair(poller, "127.0.0.1", 40002);
+    const string allocation_id = "allocate0003";
+    const uint64_t original_time = UINT64_MAX;
+
+    for (int lifetime : {600, 0}) {
+        auto server = make_shared<TestIceServer>(poller);
+        server->seedAllocation(owner, allocation_id, original_time);
+        server->handleRefreshRequest(makeRequest(StunPacket::Method::REFRESH,
+                                                 lifetime ? "refresh00001" : "refresh00002", lifetime), other);
+        expectResponse(server->response(), StunPacket::Class::ERROR_RESPONSE, StunPacket::Method::REFRESH,
+                       StunAttrErrorCode::Code::AllocationMismatch);
+        expect(server->allocationCount() == 1, "non-owner Refresh must not release the allocation");
+        expect(server->allocationUpdateTime() == original_time,
+               "non-owner Refresh must not refresh allocation lifetime");
+    }
+
+    auto refresh = make_shared<TestIceServer>(poller);
+    refresh->seedAllocation(owner, allocation_id, original_time);
+    refresh->handleRefreshRequest(makeRequest(StunPacket::Method::REFRESH, "refresh00003", 600), owner);
+    expectResponse(refresh->response(), StunPacket::Class::SUCCESS_RESPONSE, StunPacket::Method::REFRESH);
+    expect(refresh->allocationUpdateTime() != original_time, "owner Refresh should update allocation lifetime");
+    expect(refresh->allocationCount() == 1, "owner Refresh should preserve the allocation");
+
+    auto remove = make_shared<TestIceServer>(poller);
+    remove->seedAllocation(owner, allocation_id, original_time);
+    remove->handleRefreshRequest(makeRequest(StunPacket::Method::REFRESH, "refresh00004", 0), owner);
+    expectResponse(remove->response(), StunPacket::Class::SUCCESS_RESPONSE, StunPacket::Method::REFRESH);
+    expect(remove->allocationCount() == 0, "owner zero-lifetime Refresh should release the allocation");
+    expect(remove->allocationTransactionId().empty(),
+           "owner zero-lifetime Refresh should clear the Allocate transaction ID");
+}
+
+void testAllocateCapacityFailure() {
+    auto poller = EventPollerPool::Instance().getPoller();
+    vector<TestIceServer::Ptr> allocations;
+    for (uint16_t index = 0; index < 36; ++index) {
+        auto server = make_shared<TestIceServer>(poller);
+        auto pair = makePair(poller, "127.0.0.1", static_cast<uint16_t>(41000 + index));
+        server->handleAllocateRequest(makeRequest(StunPacket::Method::ALLOCATE, "fillport0001"), pair);
+        expect(server->hasAllocation(), "test setup should consume every configured relay port");
+        allocations.emplace_back(std::move(server));
+    }
+
+    auto server = make_shared<TestIceServer>(poller);
+    auto pair = makePair(poller, "127.0.0.1", 42000);
+    server->handleAllocateRequest(makeRequest(StunPacket::Method::ALLOCATE, "allocate0004"), pair);
+    expectResponse(server->response(), StunPacket::Class::ERROR_RESPONSE, StunPacket::Method::ALLOCATE,
+                   StunAttrErrorCode::Code::InsuficientCapacity);
+    expect(!server->hasAllocation(), "capacity failure must not create an allocation");
+    expect(server->allocationTransactionId().empty(), "capacity failure must not record a transaction ID");
+}
+} // namespace
+
+int main() {
+    try {
+        mINI::Instance()["rtc.port_range"] = "61000-61036";
+        NOTICE_EMIT(BroadcastReloadConfigArgs, Broadcast::kBroadcastReloadConfig);
+
+        testAllocateHandlers();
+        testRefreshHandlers();
+        testAllocateCapacityFailure();
+        cout << "test_turn_allocation passed" << endl;
+        return 0;
+    } catch (const exception &ex) {
+        cerr << "test_turn_allocation failed: " << ex.what() << endl;
+        return EXIT_FAILURE;
+    }
+}

--- a/webrtc/IceSession.cpp
+++ b/webrtc/IceSession.cpp
@@ -33,7 +33,6 @@ static IceSession::Ptr queryIceTransport(uint8_t *data, size_t size) {
 IceSession::IceSession(const Socket::Ptr &sock) : Session(sock) {
     TraceL << getIdentifier();
     _over_tcp = sock->sockType() == SockNum::Sock_TCP;
-    _last_recv_time = toolkit::getCurrentMillisecond();
     GET_CONFIG(string, iceUfrag, Rtc::kIceUfrag);
     GET_CONFIG(string, icePwd, Rtc::kIcePwd);
     _ice_transport = std::make_shared<IceServer>(this, iceUfrag, icePwd, getPoller());
@@ -60,7 +59,7 @@ void IceSession::onRecv(const Buffer::Ptr &buffer) {
 }
 
 void IceSession::onRecv_l(const char* buffer, size_t size) {
-    _last_recv_time = toolkit::getCurrentMillisecond();
+    _alive_ticker.resetTime();
     if (!_session_pair) {
         _session_pair = std::make_shared<IceTransport::Pair>(shared_from_this());
     }
@@ -86,8 +85,7 @@ void IceSession::onManager() {
         return;
     }
 
-    uint64_t now = toolkit::getCurrentMillisecond();
-    if (now - _last_recv_time <= static_cast<uint64_t>(ice_session_timeout_sec) * 1000) {
+    if (_alive_ticker.elapsedTime() <= static_cast<uint64_t>(ice_session_timeout_sec) * 1000) {
         return;
     }
 

--- a/webrtc/IceSession.cpp
+++ b/webrtc/IceSession.cpp
@@ -33,6 +33,7 @@ static IceSession::Ptr queryIceTransport(uint8_t *data, size_t size) {
 IceSession::IceSession(const Socket::Ptr &sock) : Session(sock) {
     TraceL << getIdentifier();
     _over_tcp = sock->sockType() == SockNum::Sock_TCP;
+    _last_recv_time = toolkit::getCurrentMillisecond();
     GET_CONFIG(string, iceUfrag, Rtc::kIceUfrag);
     GET_CONFIG(string, icePwd, Rtc::kIcePwd);
     _ice_transport = std::make_shared<IceServer>(this, iceUfrag, icePwd, getPoller());
@@ -59,6 +60,7 @@ void IceSession::onRecv(const Buffer::Ptr &buffer) {
 }
 
 void IceSession::onRecv_l(const char* buffer, size_t size) {
+    _last_recv_time = toolkit::getCurrentMillisecond();
     if (!_session_pair) {
         _session_pair = std::make_shared<IceTransport::Pair>(shared_from_this());
     }
@@ -67,11 +69,40 @@ void IceSession::onRecv_l(const char* buffer, size_t size) {
 
 void IceSession::onError(const SockException &err) {
     InfoL;
+    if (_ice_transport) {
+        _ice_transport->releaseSessionResources();
+    }
     // 消除循环引用
     _session_pair = nullptr;
 }
 
 void IceSession::onManager() {
+    if (_over_tcp) {
+        return;
+    }
+
+    GET_CONFIG(uint32_t, ice_session_timeout_sec, Rtc::kIceSessionTimeoutSec);
+    if (!ice_session_timeout_sec) {
+        return;
+    }
+
+    uint64_t now = toolkit::getCurrentMillisecond();
+    if (now - _last_recv_time <= static_cast<uint64_t>(ice_session_timeout_sec) * 1000) {
+        return;
+    }
+
+    if (_ice_transport && _ice_transport->hasAllocation()) {
+        // Keep the UDP ICE session alive while TURN allocation exists. After the allocation timer releases
+        // relay resources, the next manager tick closes this idle session.
+        return;
+    }
+
+    InfoL << "ICE UDP session timeout: " << getIdentifier();
+    if (_ice_transport) {
+        _ice_transport->releaseSessionResources();
+    }
+    _session_pair = nullptr;
+    shutdown(SockException(Err_timeout, "ice udp session timeout"));
 }
 
 ssize_t IceSession::onRecvHeader(const char *data, size_t len) {

--- a/webrtc/IceSession.hpp
+++ b/webrtc/IceSession.hpp
@@ -46,6 +46,7 @@ public:
     void onRecv_l(const char *data, size_t len);
 protected:
     bool _over_tcp = false;
+    uint64_t _last_recv_time = 0;
 
     RTC::IceTransport::Pair::Ptr _session_pair = nullptr;
     RTC::IceServer::Ptr _ice_transport;

--- a/webrtc/IceSession.hpp
+++ b/webrtc/IceSession.hpp
@@ -46,7 +46,7 @@ public:
     void onRecv_l(const char *data, size_t len);
 protected:
     bool _over_tcp = false;
-    uint64_t _last_recv_time = 0;
+    toolkit::Ticker _alive_ticker;
 
     RTC::IceTransport::Pair::Ptr _session_pair = nullptr;
     RTC::IceServer::Ptr _ice_transport;

--- a/webrtc/IceTransport.cpp
+++ b/webrtc/IceTransport.cpp
@@ -11,6 +11,7 @@
 #include <utility>
 #include <random>
 #include <algorithm>
+#include <mutex>
 #include "json/json.h"
 #include "Util/onceToken.h"
 #include "Network/UdpClient.h"
@@ -28,6 +29,9 @@ namespace RTC {
 #define RTC_FIELD "rtc."
 const string kPortRange = RTC_FIELD "port_range";
 const string kMaxStunRetry = RTC_FIELD "max_stun_retry";
+static constexpr uint32_t kTurnAllocationLifetimeSec = 600;
+static constexpr uint64_t kTurnAllocationLifetimeMs = kTurnAllocationLifetimeSec * 1000ULL;
+static constexpr float kTurnAllocationCheckIntervalSec = 10.0f;
 static onceToken token([]() {
     mINI::Instance()[kPortRange] = "49152-65535";
     mINI::Instance()[kMaxStunRetry] = 7;
@@ -664,6 +668,7 @@ onceToken PortManager_token([](){
     PortManager<1>::Instance().addListenConfigReload();
 });
 
+static std::mutex s_relayed_session_mutex;
 std::unordered_map<sockaddr_storage /*peer ip:port*/, IceServer::WeakPtr, toolkit::SockUtil::SockAddrHash, toolkit::SockUtil::SockAddrEqual> _relayed_session;
 
 IceServer::IceServer(Listener* listener, std::string ufrag, std::string password, toolkit::EventPoller::Ptr poller)
@@ -686,11 +691,81 @@ IceServer::IceServer(Listener* listener, std::string ufrag, std::string password
 
 }
 
+void IceServer::initialize() {
+    IceTransport::initialize();
+
+    GET_CONFIG(bool, enable_turn, Rtc::kEnableTurn);
+    if (!enable_turn) {
+        return;
+    }
+
+    weak_ptr<IceServer> weak_self = static_pointer_cast<IceServer>(shared_from_this());
+    _allocation_timer = std::make_shared<Timer>(kTurnAllocationCheckIntervalSec, [weak_self]() {
+        auto strong_self = weak_self.lock();
+        if (!strong_self) {
+            return false;
+        }
+        strong_self->checkAllocationTimeout();
+        return true;
+    }, getPoller());
+}
+
 bool IceServer::processSocketData(const uint8_t* data, size_t len, const Pair::Ptr& pair) {
-    if (!_session_pair) {
+    if (_session_pair.expired()) {
         _session_pair = pair;
     }
     return IceTransport::processSocketData(data, len, pair);
+}
+
+void IceServer::releaseSessionResources() {
+    _session_pair.reset();
+    releaseAllocation();
+}
+
+bool IceServer::hasAllocation() const {
+    return !_relayed_pairs.empty();
+}
+
+void IceServer::removeRelayedSessions() {
+    for (const auto& relayed_pair : _relayed_pairs) {
+        IceServer::Ptr strong_session;
+        {
+            std::lock_guard<std::mutex> lck(s_relayed_session_mutex);
+            auto it = _relayed_session.find(relayed_pair.first);
+            if (it == _relayed_session.end()) {
+                continue;
+            }
+
+            strong_session = it->second.lock();
+            if (!strong_session || strong_session.get() == this) {
+                _relayed_session.erase(it);
+            }
+        }
+    }
+}
+
+void IceServer::releaseAllocation() {
+    removeRelayedSessions();
+    _relayed_pairs.clear();
+    _permissions.clear();
+    _channel_bindings.clear();
+    _channel_binding_times.clear();
+    _allocation_update_time = 0;
+}
+
+void IceServer::checkAllocationTimeout() {
+    if (_relayed_pairs.empty() || !_allocation_update_time) {
+        return;
+    }
+
+    uint64_t now = toolkit::getCurrentMillisecond();
+    if (now - _allocation_update_time <= kTurnAllocationLifetimeMs) {
+        return;
+    }
+
+    InfoL << "TURN allocation timeout: " << getIdentifier();
+    // Only relay resources are released here. The idle ICE session fd is closed by IceSession::onManager().
+    releaseAllocation();
 }
 
 void IceServer::processRelayPacket(const Buffer::Ptr &buffer, const Pair::Ptr& pair) {
@@ -704,7 +779,13 @@ void IceServer::processRelayPacket(const Buffer::Ptr &buffer, const Pair::Ptr& p
         return;
     }
 
-    auto forward_pair = std::make_shared<Pair>(_session_pair->_socket, pair->_socket->get_peer_ip(), pair->_socket->get_peer_port());
+    auto session_pair = _session_pair.lock();
+    if (!session_pair || !session_pair->_socket) {
+        WarnL << "No active ICE session pair for relayed packet";
+        return;
+    }
+
+    auto forward_pair = std::make_shared<Pair>(session_pair->_socket, pair->_socket->get_peer_ip(), pair->_socket->get_peer_port());
     uint16_t channel_number;
     if (hasChannelBind(peer_addr, channel_number)) {
         sendChannelData(channel_number, buffer, forward_pair);
@@ -729,20 +810,48 @@ void IceServer::handleAllocateRequest(const StunPacket::Ptr& packet, const Pair:
 
     // Add XOR-RELAYED-ADDRESS.
     auto socket = allocateRelayed(pair);
+    if (!socket) {
+        sendErrorResponse(packet, pair, StunAttrErrorCode::Code::InsuficientCapacity);
+        return;
+    }
+
     sockaddr_storage relayed_addr = SockUtil::make_sockaddr(socket->get_local_ip().data(), socket->get_local_port());
     auto attr_xor_relayed_address = std::make_shared<StunAttrXorRelayedAddress>(response->getTransactionId());
     attr_xor_relayed_address->setAddr(relayed_addr);
     response->addAttribute(std::move(attr_xor_relayed_address));
 
     auto attr_lifetime = std::make_shared<StunAttrLifeTime>();
-    attr_lifetime->setLifetime(600);
+    attr_lifetime->setLifetime(kTurnAllocationLifetimeSec);
     response->addAttribute(std::move(attr_lifetime));
  
     sendPacket(response, pair);
 }
 
 void IceServer::handleRefreshRequest(const StunPacket::Ptr& packet, const Pair::Ptr& pair) {
-    // TraceL
+    // TraceL;
+    auto attr_lifetime_request = packet->getAttribute<StunAttrLifeTime>();
+    if (_relayed_pairs.empty()) {
+        sendErrorResponse(packet, pair, StunAttrErrorCode::Code::AllocationMismatch);
+        return;
+    }
+
+    uint32_t lifetime = kTurnAllocationLifetimeSec;
+    if (attr_lifetime_request && attr_lifetime_request->getLifetime() == 0) {
+        lifetime = 0;
+        releaseAllocation();
+    } else {
+        _allocation_update_time = toolkit::getCurrentMillisecond();
+    }
+
+    auto response = packet->createSuccessResponse();
+    response->setUfrag(_ufrag);
+    response->setPassword(_password);
+
+    auto attr_lifetime_response = std::make_shared<StunAttrLifeTime>();
+    attr_lifetime_response->setLifetime(lifetime);
+    response->addAttribute(std::move(attr_lifetime_response));
+
+    sendPacket(response, pair);
 }
 
 void IceServer::handleCreatePermissionRequest(const StunPacket::Ptr& packet, const Pair::Ptr& pair) {
@@ -902,7 +1011,19 @@ SocketHelper::Ptr IceServer::allocateRelayed(const Pair::Ptr& pair) {
     // DebugL;
 
     // only support udp
+    auto peer_addr = SockUtil::make_sockaddr(pair->get_peer_ip().data(), pair->get_peer_port());
+    auto relayed_it = _relayed_pairs.find(peer_addr);
+    if (relayed_it != _relayed_pairs.end()) {
+        _allocation_update_time = toolkit::getCurrentMillisecond();
+        return relayed_it->second.second->_socket;
+    }
+
     auto port = PortManager<0>::Instance().getSinglePort();
+    if (!port) {
+        WarnL << "No available TURN relay port";
+        return nullptr;
+    }
+
     std::string local_ip;
 
     GET_CONFIG_FUNC(std::vector<std::string>, interfaces, Rtc::kInterfaces, [](string str) {
@@ -950,10 +1071,14 @@ SocketHelper::Ptr IceServer::allocateRelayed(const Pair::Ptr& pair) {
 
     auto socket = createRelayedUdpSocket(pair->get_peer_ip(), pair->get_peer_port(), local_ip, *port);
     auto relayed_pair = std::make_shared<Pair>(socket);
-    auto peer_addr = SockUtil::make_sockaddr(pair->get_peer_ip().data(), pair->get_peer_port());
     weak_ptr<IceServer> weak_self = static_pointer_cast<IceServer>(shared_from_this());
-    _relayed_pairs.emplace(peer_addr, std::make_pair(port, relayed_pair));
-    _relayed_session.emplace(peer_addr, weak_self);
+    _relayed_pairs.emplace(peer_addr, std::make_pair(std::move(port), relayed_pair));
+    {
+        std::lock_guard<std::mutex> lck(s_relayed_session_mutex);
+        _relayed_session.erase(peer_addr);
+        _relayed_session.emplace(peer_addr, weak_self);
+    }
+    _allocation_update_time = toolkit::getCurrentMillisecond();
 
     InfoL << "Alloc relayed pair: " << relayed_pair->get_local_ip() << ":" <<  relayed_pair->get_local_port()
           << " for peer pair: " << pair->get_peer_ip() << ":" << pair->get_peer_port();
@@ -962,9 +1087,15 @@ SocketHelper::Ptr IceServer::allocateRelayed(const Pair::Ptr& pair) {
 
 void IceServer::relayForwordingData(const toolkit::Buffer::Ptr& buffer, const sockaddr_storage& peer_addr) {
     TraceL;
-    getPoller()->async([=]() {
-        auto it = _relayed_pairs.find(peer_addr);
-        if (it == _relayed_pairs.end()) {
+    weak_ptr<IceServer> weak_self = static_pointer_cast<IceServer>(shared_from_this());
+    getPoller()->async([weak_self, buffer, peer_addr]() {
+        auto strong_self = weak_self.lock();
+        if (!strong_self) {
+            return;
+        }
+
+        auto it = strong_self->_relayed_pairs.find(peer_addr);
+        if (it == strong_self->_relayed_pairs.end()) {
 #if 0
             //不是当前对象的转发,交给其他对象转发
             auto forword_it = _relayed_session.find(peer_addr);
@@ -986,10 +1117,11 @@ void IceServer::relayForwordingData(const toolkit::Buffer::Ptr& buffer, const so
             return;
 #else 
             WarnL << "not relayed addr for peer addr: " << addrToStr(peer_addr);
+            return;
 #endif
         }
 
-        sendSocketData(buffer, it->second.second);
+        strong_self->sendSocketData(buffer, it->second.second);
 #if 0
         TraceL << "Forwarded ChannelData to peer: " << addrToStr(peer_addr);
 #endif

--- a/webrtc/IceTransport.cpp
+++ b/webrtc/IceTransport.cpp
@@ -751,6 +751,7 @@ void IceServer::releaseAllocation() {
     _channel_bindings.clear();
     _channel_binding_times.clear();
     _allocation_update_time = 0;
+    _allocation_transaction_id.clear();
 }
 
 void IceServer::checkAllocationTimeout() {
@@ -794,8 +795,29 @@ void IceServer::processRelayPacket(const Buffer::Ptr &buffer, const Pair::Ptr& p
     }
 }
 
+bool IceServer::hasRelayedAllocation(const Pair::Ptr &pair) const {
+    auto peer_addr = SockUtil::make_sockaddr(pair->get_peer_ip().data(), pair->get_peer_port());
+    return _relayed_pairs.find(peer_addr) != _relayed_pairs.end();
+}
+
+IceServer::AllocateRequestState IceServer::classifyAllocateRequest(const StunPacket::Ptr &packet,
+                                                                   const Pair::Ptr &pair) const {
+    if (!hasRelayedAllocation(pair)) {
+        return AllocateRequestState::NewAllocation;
+    }
+    return packet->getTransactionId() == _allocation_transaction_id
+               ? AllocateRequestState::Retransmission
+               : AllocateRequestState::AllocationMismatch;
+}
+
 void IceServer::handleAllocateRequest(const StunPacket::Ptr& packet, const Pair::Ptr& pair) {
     // TraceL;
+    auto request_state = classifyAllocateRequest(packet, pair);
+    if (request_state == AllocateRequestState::AllocationMismatch) {
+        sendErrorResponse(packet, pair, StunAttrErrorCode::Code::AllocationMismatch);
+        return;
+    }
+
     auto response = packet->createSuccessResponse();
     response->setUfrag(_ufrag);
     response->setPassword(_password);
@@ -814,6 +836,9 @@ void IceServer::handleAllocateRequest(const StunPacket::Ptr& packet, const Pair:
         sendErrorResponse(packet, pair, StunAttrErrorCode::Code::InsuficientCapacity);
         return;
     }
+    if (request_state == AllocateRequestState::NewAllocation) {
+        _allocation_transaction_id = packet->getTransactionId();
+    }
 
     sockaddr_storage relayed_addr = SockUtil::make_sockaddr(socket->get_local_ip().data(), socket->get_local_port());
     auto attr_xor_relayed_address = std::make_shared<StunAttrXorRelayedAddress>(response->getTransactionId());
@@ -830,7 +855,7 @@ void IceServer::handleAllocateRequest(const StunPacket::Ptr& packet, const Pair:
 void IceServer::handleRefreshRequest(const StunPacket::Ptr& packet, const Pair::Ptr& pair) {
     // TraceL;
     auto attr_lifetime_request = packet->getAttribute<StunAttrLifeTime>();
-    if (_relayed_pairs.empty()) {
+    if (!hasRelayedAllocation(pair)) {
         sendErrorResponse(packet, pair, StunAttrErrorCode::Code::AllocationMismatch);
         return;
     }
@@ -1014,7 +1039,6 @@ SocketHelper::Ptr IceServer::allocateRelayed(const Pair::Ptr& pair) {
     auto peer_addr = SockUtil::make_sockaddr(pair->get_peer_ip().data(), pair->get_peer_port());
     auto relayed_it = _relayed_pairs.find(peer_addr);
     if (relayed_it != _relayed_pairs.end()) {
-        _allocation_update_time = toolkit::getCurrentMillisecond();
         return relayed_it->second.second->_socket;
     }
 

--- a/webrtc/IceTransport.hpp
+++ b/webrtc/IceTransport.hpp
@@ -413,9 +413,12 @@ public:
     using Ptr = std::shared_ptr<IceServer>;
     using WeakPtr = std::weak_ptr<IceServer>;
     IceServer(Listener* listener, std::string ufrag, std::string password, toolkit::EventPoller::Ptr poller);
-    virtual ~IceServer() {}
-    
+    ~IceServer() override { releaseSessionResources(); }
+
+    void initialize() override;
     bool processSocketData(const uint8_t* data, size_t len, const Pair::Ptr& pair) override;
+    void releaseSessionResources();
+    bool hasAllocation() const;
     void relayForwordingData(const toolkit::Buffer::Ptr& buffer, const sockaddr_storage& peer_addr);
     void relayBackingData(const toolkit::Buffer::Ptr& buffer, const Pair::Ptr& pair, const sockaddr_storage& peer_addr);
 
@@ -435,13 +438,18 @@ protected:
 
     toolkit::SocketHelper::Ptr allocateRelayed(const Pair::Ptr& pair);
     toolkit::SocketHelper::Ptr createRelayedUdpSocket(const std::string &peer_host, uint16_t peer_port, const std::string &local_ip, uint16_t local_port);
+    void releaseAllocation();
+    void removeRelayedSessions();
+    void checkAllocationTimeout();
 
 protected:
     std::vector<toolkit::BufferLikeString> _nonce_list;
 
     std::unordered_map<sockaddr_storage /*peer ip:port*/, std::pair<std::shared_ptr<uint16_t> /* port */, Pair::Ptr /*relayed_pairs*/>,
         toolkit::SockUtil::SockAddrHash, toolkit::SockUtil::SockAddrEqual> _relayed_pairs;
-    Pair::Ptr _session_pair;
+    std::weak_ptr<Pair> _session_pair;
+    uint64_t _allocation_update_time = 0;
+    std::shared_ptr<toolkit::Timer> _allocation_timer;
 };
 
 class IceAgent : public IceTransport {

--- a/webrtc/IceTransport.hpp
+++ b/webrtc/IceTransport.hpp
@@ -423,7 +423,15 @@ public:
     void relayBackingData(const toolkit::Buffer::Ptr& buffer, const Pair::Ptr& pair, const sockaddr_storage& peer_addr);
 
 protected:
+    enum class AllocateRequestState {
+        NewAllocation,
+        Retransmission,
+        AllocationMismatch,
+    };
+
     void processRelayPacket(const toolkit::Buffer::Ptr &buffer, const Pair::Ptr& pair);
+    bool hasRelayedAllocation(const Pair::Ptr &pair) const;
+    AllocateRequestState classifyAllocateRequest(const StunPacket::Ptr &packet, const Pair::Ptr &pair) const;
     void handleAllocateRequest(const StunPacket::Ptr& packet, const Pair::Ptr& pair);
     void handleRefreshRequest(const StunPacket::Ptr& packet, const Pair::Ptr& pair);
     void handleCreatePermissionRequest(const StunPacket::Ptr& packet, const Pair::Ptr& pair);
@@ -449,6 +457,7 @@ protected:
         toolkit::SockUtil::SockAddrHash, toolkit::SockUtil::SockAddrEqual> _relayed_pairs;
     std::weak_ptr<Pair> _session_pair;
     uint64_t _allocation_update_time = 0;
+    std::string _allocation_transaction_id;
     std::shared_ptr<toolkit::Timer> _allocation_timer;
 };
 

--- a/webrtc/StunPacket.hpp
+++ b/webrtc/StunPacket.hpp
@@ -182,7 +182,7 @@ public:
         Forbidden                   = 403, //禁止
         RequestTimedOut             = 408, //请求超时(客户端认为此事务已经失败)
         UnknownAttribute            = 420,
-        AllocationMismatch          = 438,
+        AllocationMismatch          = 437,
         StaleNonce                  = 438, //NONCE 不再有效,客户端应使用响应中的NONCE重试
         AddressFamilyNotSupported   = 440, //不支持的协议簇
         WrongCredentials            = 441, //凭据错误

--- a/webrtc/USAGE.md
+++ b/webrtc/USAGE.md
@@ -234,6 +234,9 @@ portRange=50000-65000
 #ICE传输策略：0=不限制(默认)，1=仅支持Relay转发，2=仅支持P2P直连
 iceTransportPolicy=0
 
+#UDP ICE会话空闲超时时间，单位秒，0为关闭
+iceSessionTimeoutSec=60
+
 #STUN/TURN 服务Ice密码
 iceUfrag=ZLMediaKit
 icePwd=ZLMediaKit

--- a/webrtc/WebRtcTransport.cpp
+++ b/webrtc/WebRtcTransport.cpp
@@ -72,6 +72,7 @@ const string kEnableTurn = RTC_FIELD "enableTurn";
 const string kIceUfrag = RTC_FIELD "iceUfrag";
 const string kIcePwd = RTC_FIELD "icePwd";
 const string kIceTransportPolicy = RTC_FIELD "iceTransportPolicy";
+const string kIceSessionTimeoutSec = RTC_FIELD "iceSessionTimeoutSec";
 
 // 比特率设置  [AUTO-TRANSLATED:2c75f5bc]
 // Bitrate setting
@@ -104,6 +105,7 @@ static onceToken token([]() {
     mINI::Instance()[kIceTcpPort] = 3478;
     mINI::Instance()[kEnableTurn] = 1;
     mINI::Instance()[kIceTransportPolicy] = 0;  // 默认值：不限制(kAll)
+    mINI::Instance()[kIceSessionTimeoutSec] = 60;
     mINI::Instance()[kIceUfrag] = "ZLMediaKit";
     mINI::Instance()[kIcePwd] = "ZLMediaKit";
     mINI::Instance()[kPreferredTcp] = 0;

--- a/webrtc/WebRtcTransport.h
+++ b/webrtc/WebRtcTransport.h
@@ -51,6 +51,7 @@ extern const std::string kIcePort;
 extern const std::string kIceTcpPort;
 extern const std::string kEnableTurn;
 extern const std::string kIceTransportPolicy;
+extern const std::string kIceSessionTimeoutSec;
 extern const std::string kIceUfrag;
 extern const std::string kIcePwd;
 extern const std::string kExternIP;


### PR DESCRIPTION
公网部署时，ICE 端口可能遭受恶意请求或扫描。异常会话长期不退出，
导致 UDP 会话、TURN relay 端口及关联资源无法及时释放，最终可能耗尽
可用端口。

- 增加 UDP ICE 会话空闲超时配置，自动关闭长期无数据的会话
- 完善 TURN Allocation 的创建、刷新、超时和主动释放流程
- 会话异常退出或销毁时清理 relay 端口、Permission 和 ChannelBind
- 为 relay 会话注册表增加并发保护，避免残留或竞态访问
- 使用弱引用解除会话对象之间的循环引用
- 修正 Allocation Mismatch 错误码为 437
- 补充 iceSessionTimeoutSec 配置及使用说明

Plan-Item: ICEBUGFIX