### PR TITLE
Fix/ts splitter resync

### DIFF
--- a/src/Http/HttpRequestSplitter.cpp
+++ b/src/Http/HttpRequestSplitter.cpp
@@ -149,6 +149,7 @@ void HttpRequestSplitter::reset() {
     _content_len = 0;
     _remain_data_size = 0;
     _remain_data.clear();
+    onReset();
 }
 
 const char *HttpRequestSplitter::onSearchPacketTail(const char *data,size_t len) {
@@ -179,4 +180,3 @@ HttpRequestSplitter::HttpRequestSplitter() {
 }
 
 } /* namespace mediakit */
-

--- a/src/Http/HttpRequestSplitter.h
+++ b/src/Http/HttpRequestSplitter.h
@@ -68,6 +68,8 @@ public:
     void setMaxCacheSize(size_t max_cache_size);
 
 protected:
+    virtual void onReset() {};
+
     /**
      * 收到请求头
      * @param data 请求头数据

--- a/src/Rtp/TSDecoder.cpp
+++ b/src/Rtp/TSDecoder.cpp
@@ -77,7 +77,9 @@ const char *TSSegment::searchPacketTailUnSynced(const char *data, size_t len) {
         }
     }
 
-    if (len > 4 * _size) {
+    // 等价于 len > 4 * _size，但不会发生无符号整数溢出
+    // Equivalent to len > 4 * _size without unsigned integer overflow
+    if (len && _size <= (len - 1) / 4) {
         // 尾部同步字节可能在下一次输入后组成同步对，因此只丢弃它之前的数据
         // A trailing sync byte may form a sync pair after the next input, so discard only the data before it
         const char *tail = data + len - _size;

--- a/src/Rtp/TSDecoder.cpp
+++ b/src/Rtp/TSDecoder.cpp
@@ -19,8 +19,7 @@ void TSSegment::setOnSegment(TSSegment::onSegment cb) {
     _onSegment = std::move(cb);
 }
 
-void TSSegment::reset() {
-    HttpRequestSplitter::reset();
+void TSSegment::onReset() {
     _is_synced = false;
 }
 

--- a/src/Rtp/TSDecoder.cpp
+++ b/src/Rtp/TSDecoder.cpp
@@ -53,6 +53,15 @@ const char *TSSegment::onSearchPacketTail(const char *data, size_t len) {
         return data + _size;
     }
 
+    return searchPacketTailUnSynced(data, len);
+}
+
+#if defined(_MSC_VER)
+__declspec(noinline)
+#elif defined(__GNUC__)
+__attribute__((noinline))
+#endif
+const char *TSSegment::searchPacketTailUnSynced(const char *data, size_t len) {
     if (len > _size) {
         const char *candidate = data;
         const char *search_end = data + len - _size;

--- a/src/Rtp/TSDecoder.cpp
+++ b/src/Rtp/TSDecoder.cpp
@@ -19,6 +19,11 @@ void TSSegment::setOnSegment(TSSegment::onSegment cb) {
     _onSegment = std::move(cb);
 }
 
+void TSSegment::reset() {
+    HttpRequestSplitter::reset();
+    _is_synced = false;
+}
+
 ssize_t TSSegment::onRecvHeader(const char *data, size_t len) {
     if (!isTSPacket(data, len)) {
         WarnL << "不是ts包:" << (int) (data[0]) << " " << len;
@@ -29,22 +34,49 @@ ssize_t TSSegment::onRecvHeader(const char *data, size_t len) {
 }
 
 const char *TSSegment::onSearchPacketTail(const char *data, size_t len) {
-    if (len < _size + 1) {
-        if (len == _size && ((uint8_t *) data)[0] == TS_SYNC_BYTE) {
+    auto bytes = (const uint8_t *) data;
+    if (_is_synced) {
+        if (len < _size) {
+            return nullptr;
+        }
+        // 锁定后只按当前同步字节分包，TS 语义和错误处理交给 libmpegts
+        // Once locked, split only by the current sync byte; leave TS semantics and error handling to libmpegts
+        if (bytes[0] == TS_SYNC_BYTE) {
             return data + _size;
         }
-        return nullptr;
+        _is_synced = false;
     }
-    // 下一个包头  [AUTO-TRANSLATED:c653c49d]
-    // Next packet header
-    if (((uint8_t *) data)[_size] == TS_SYNC_BYTE) {
+
+    // 单个完整包可以直接转交，但不足以确认后续数据的包边界
+    // A single complete packet can be forwarded, but is insufficient to confirm subsequent packet boundaries
+    if (len == _size && bytes[0] == TS_SYNC_BYTE) {
         return data + _size;
     }
-    auto pos = memchr(data + _size, TS_SYNC_BYTE, len - _size);
-    if (pos) {
-        return (char *) pos;
+
+    if (len > _size) {
+        const char *candidate = data;
+        const char *search_end = data + len - _size;
+        while (candidate < search_end) {
+            candidate = (const char *) memchr(candidate, TS_SYNC_BYTE, search_end - candidate);
+            if (!candidate) {
+                break;
+            }
+            if ((uint8_t) candidate[_size] == TS_SYNC_BYTE) {
+                _is_synced = true;
+                return candidate == data ? data + _size : candidate;
+            }
+            ++candidate;
+        }
     }
-    if (remainDataSize() > 4 * _size) {
+
+    if (len > 4 * _size) {
+        // 尾部同步字节可能在下一次输入后组成同步对，因此只丢弃它之前的数据
+        // A trailing sync byte may form a sync pair after the next input, so discard only the data before it
+        const char *tail = data + len - _size;
+        auto candidate = memchr(tail, TS_SYNC_BYTE, data + len - tail);
+        if (candidate) {
+            return (const char *) candidate;
+        }
         // 数据这么多都没ts包，全部清空  [AUTO-TRANSLATED:95bece98]
         // So much data but no ts packets, clear all
         return data + len;
@@ -90,7 +122,7 @@ TSDecoder::~TSDecoder() {
 }
 
 ssize_t TSDecoder::input(const uint8_t *data, size_t bytes) {
-    if (TSSegment::isTSPacket((char *)data, bytes)) {
+    if (_ts_segment.remainDataSize() == 0 && TSSegment::isTSPacket((char *)data, bytes)) {
         return ts_demuxer_input(_demuxer_ctx, (uint8_t *) data, bytes);
     }
     try {

--- a/src/Rtp/TSDecoder.h
+++ b/src/Rtp/TSDecoder.h
@@ -27,6 +27,7 @@ public:
     typedef std::function<void(const char *data,size_t len)> onSegment;
     TSSegment(size_t size = TS_PACKET_SIZE) : _size(size){}
     void setOnSegment(onSegment cb);
+    void reset();
     static bool isTSPacket(const char *data, size_t len);
 
 protected:
@@ -35,6 +36,7 @@ protected:
 
 private:
     size_t _size;
+    bool _is_synced = false;
     onSegment _onSegment;
 };
 

--- a/src/Rtp/TSDecoder.h
+++ b/src/Rtp/TSDecoder.h
@@ -35,6 +35,7 @@ protected:
     const char *onSearchPacketTail(const char *data, size_t len) override ;
 
 private:
+    const char *searchPacketTailUnSynced(const char *data, size_t len);
     size_t _size;
     bool _is_synced = false;
     onSegment _onSegment;

--- a/src/Rtp/TSDecoder.h
+++ b/src/Rtp/TSDecoder.h
@@ -27,10 +27,10 @@ public:
     typedef std::function<void(const char *data,size_t len)> onSegment;
     TSSegment(size_t size = TS_PACKET_SIZE) : _size(size){}
     void setOnSegment(onSegment cb);
-    void reset();
     static bool isTSPacket(const char *data, size_t len);
 
 protected:
+    void onReset() override;
     ssize_t onRecvHeader(const char *data, size_t len) override ;
     const char *onSearchPacketTail(const char *data, size_t len) override ;
 


### PR DESCRIPTION
用于替代 pr #2423 
一直都忘记把这个pr进行测试了, 而且当时距离现在时间比较久了, 就重新写了, 顺便测试结果也测试了

### 测试结果

在 AMD Ryzen 7 3800X、GCC 9.4.0、`-O3 -DNDEBUG` 环境下固定 CPU 2，对 master、PR #2423 和本 PR 分别交错运行 3 轮，每轮每场景采集 15 个样本，结果取中位数。

| 连续输入 | master | PR #2423 | 本 PR | 相对 master | 相对 #2423 |
|---|---:|---:|---:|---:|---:|
| 1 个 TS 包 | 10.562 ns | 10.548 ns | 10.332 ns | 快 2.18% | 快 2.05% |
| 7 个 TS 包 | 51.416 ns | 49.317 ns | 47.881 ns | 快 6.88% | 快 2.91% |
| 32 个 TS 包 | 226.452 ns | 218.088 ns | 211.141 ns | 快 6.76% | 快 3.19% |
| 256 个 TS 包 | 1755.617 ns | 1674.288 ns | 1617.681 ns | 快 7.86% | 快 3.38% |

单包场景差异较小， 甚至还略快一些；但是多包热路径中，本 PR 均优于 master 和 PR #2423。64 KiB 前缀后的重新同步场景约比 PR #2423 快 42.9 倍。

另外发现_size可能溢出导致非法内存访问,  TSSegment 的公开构造函数允许任意 _size。当 _size 足够大时，4 * _size 会无符号回绕，使条件错误成立，随后 len - _size 下溢并产生非法指针. 但是当前是188, 所以不会出现, 这个没修, 因为不清楚是否你本身有别的用途. 
