### PR TITLE
ci: add Linux ARM64 build workflow

### DIFF
--- a/.github/workflows/linux_arm64.yml
+++ b/.github/workflows/linux_arm64.yml
@@ -1,0 +1,87 @@
+name: Linux_ARM64
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: 下载submodule源码
+      run: mv -f .gitmodules_github .gitmodules && git submodule sync && git submodule update --init
+
+    - name: 下载 SRTP
+      uses: actions/checkout@v4
+      with:
+        repository: cisco/libsrtp
+        fetch-depth: 1
+        ref: v2.3.0
+        path: 3rdpart/libsrtp
+
+    - name: 下载 openssl
+      uses: actions/checkout@v4
+      with:
+        repository: openssl/openssl
+        fetch-depth: 1
+        ref: OpenSSL_1_1_1
+        path: 3rdpart/openssl
+
+    - name: 下载 usrsctp
+      uses: actions/checkout@v4
+      with:
+        repository: sctplab/usrsctp
+        fetch-depth: 1
+        ref: 0.9.5.0
+        path: 3rdpart/usrsctp
+
+    # Use Debian 11 (glibc 2.31) for broader binary compatibility.
+    # ubuntu:20.04 is EOL and apt mirrors often fail in 2026.
+    - name: 在 Docker(debian:11/arm64) 中编译
+      run: |
+        set -eux
+        chmod +x package/build_linux_arm64.sh
+        docker version
+        docker pull --platform linux/arm64 debian:11
+        docker run --platform linux/arm64 --rm \
+          -v "${GITHUB_WORKSPACE}:/work" \
+          -w /work \
+          debian:11 \
+          bash /work/package/build_linux_arm64.sh
+
+    - name: 设置环境变量
+      run: |
+        echo "BRANCH=$(echo ${GITHUB_REF#refs/heads/} | tr -s "/\?%*:|\"<>" "_")" >> $GITHUB_ENV
+        echo "BRANCH2=$(echo ${GITHUB_REF#refs/heads/} )" >> $GITHUB_ENV
+        echo "DATE=$(date +%Y-%m-%d)" >> $GITHUB_ENV
+
+    - name: 打包二进制
+      id: upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.workflow }}_${{ env.BRANCH }}_${{ env.DATE }}
+        path: release/*
+        if-no-files-found: error
+        retention-days: 90
+
+    - name: issue评论
+      if: github.event_name != 'pull_request' && github.ref != 'refs/heads/feature/test'
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          github.rest.issues.createComment({
+            issue_number: ${{vars.VERSION_ISSUE_NO}},
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: '- 下载地址: [${{ github.workflow }}_${{ env.BRANCH }}_${{ env.DATE }}](${{ steps.upload.outputs.artifact-url }})\n'
+              + '- 分支: ${{ env.BRANCH2 }}\n'
+              + '- git hash: ${{ github.sha }} \n'
+              + '- 编译日期: ${{ env.DATE }}\n'
+              + '- 编译记录: [${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})\n'
+              + '- 打包ci名: ${{ github.workflow }}\n'
+              + '- 开启特性: openssl/webrtc/datachannel\n'
+              + '- 说明: 本二进制为 linux/arm64(aarch64)，在 debian:11(arm64, glibc 2.31) 上编译，目标机需 arm64 且 glibc >= 2.31\n'
+          })

--- a/package/build_linux_arm64.sh
+++ b/package/build_linux_arm64.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Build ZLMediaKit for linux/arm64 inside a container or on a native arm64 host.
+set -euxo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+if command -v apt-get >/dev/null 2>&1; then
+  apt-get update
+  apt-get install -y --no-install-recommends \
+    git wget ca-certificates gcc g++ make perl python3 \
+    tar gzip xz-utils pkg-config zlib1g-dev
+elif command -v yum >/dev/null 2>&1; then
+  yum install -y git wget gcc gcc-c++ make perl python3 tar gzip which zlib-devel
+else
+  echo "Unsupported package manager" >&2
+  exit 1
+fi
+
+ARCH="$(uname -m)"
+case "${ARCH}" in
+  aarch64|arm64) CMAKE_ARCH="aarch64" ;;
+  x86_64|amd64)  CMAKE_ARCH="x86_64" ;;
+  *) echo "Unsupported arch: ${ARCH}" >&2; exit 1 ;;
+esac
+
+CMAKE_VER="3.29.5"
+CMAKE_DIR="/opt/cmake-${CMAKE_VER}-linux-${CMAKE_ARCH}"
+if [ ! -x "${CMAKE_DIR}/bin/cmake" ]; then
+  wget -q "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-linux-${CMAKE_ARCH}.tar.gz" \
+    -O "/tmp/cmake.tar.gz"
+  tar -xzf /tmp/cmake.tar.gz -C /opt
+fi
+export PATH="${CMAKE_DIR}/bin:${PATH}"
+cmake --version
+gcc --version
+uname -a
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+INSTALL_DIR="${ROOT_DIR}/thirdparty_install"
+mkdir -p "${INSTALL_DIR}"
+
+# OpenSSL (static, no-asm: its armv8 assembly is non-PIC and breaks .so linking;
+# no-dso: avoids requiring -ldl for the dlfcn engine)
+cd "${ROOT_DIR}/3rdpart/openssl"
+make distclean >/dev/null 2>&1 || true
+./config no-shared no-asm no-dso -fPIC --prefix="${INSTALL_DIR}"
+make -j"$(nproc)"
+make install_sw
+ls -la "${INSTALL_DIR}/lib" "${INSTALL_DIR}/include/openssl" || ls -la "${INSTALL_DIR}/lib64" || true
+
+export PKG_CONFIG_PATH="${INSTALL_DIR}/lib/pkgconfig:${INSTALL_DIR}/lib64/pkgconfig:${PKG_CONFIG_PATH:-}"
+export CPPFLAGS="-I${INSTALL_DIR}/include ${CPPFLAGS:-}"
+export LDFLAGS="-L${INSTALL_DIR}/lib -L${INSTALL_DIR}/lib64 ${LDFLAGS:-}"
+export LIBS="-ldl -lpthread ${LIBS:-}"
+
+# usrsctp
+cd "${ROOT_DIR}/3rdpart/usrsctp"
+rm -rf build
+mkdir -p build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON ..
+make -j"$(nproc)"
+make install
+
+# libsrtp
+# GCC 10+ defaults to -fno-common and breaks libsrtp 2.3.0 tests
+# (multiple definition of `bit_string`). Same fix as project dockerfile:
+# always pass CFLAGS=-fcommon for configure/make/install.
+cd "${ROOT_DIR}/3rdpart/libsrtp"
+make distclean >/dev/null 2>&1 || true
+export CFLAGS="-fcommon ${CPPFLAGS:-}"
+export LDFLAGS="${LDFLAGS:-}"
+export LIBS="${LIBS:-}"
+./configure --enable-openssl --with-openssl-dir="${INSTALL_DIR}"
+make -j"$(nproc)"
+make install
+# Ensure headers/libs are visible to CMake
+ls -la /usr/local/lib/libsrtp* /usr/local/include/srtp* 2>/dev/null || true
+ls -la ./*.a ./include 2>/dev/null || true
+
+# ZLMediaKit
+cd "${ROOT_DIR}"
+rm -rf linux_build
+mkdir -p linux_build
+cd linux_build
+cmake .. \
+  -DOPENSSL_ROOT_DIR="${INSTALL_DIR}" \
+  -DCMAKE_BUILD_TYPE=Release
+make -j"$(nproc)"
+
+echo "Build finished. Artifacts under: ${ROOT_DIR}/release"
+ls -la "${ROOT_DIR}/release" || true
+find "${ROOT_DIR}/release" -type f | head -50


### PR DESCRIPTION
Add GitHub Actions workflow to build ZLMediaKit for linux/arm64 (aarch64) using the native ubuntu-24.04-arm runner.

- Build container: debian:11 (glibc 2.31) for broad compatibility
- Compile steps extracted into package/build_linux_arm64.sh for debugging
- OpenSSL: no-asm/no-dso/-fPIC to fix aarch64 PIC relocation issues
- Artifacts: Linux_ARM64_<branch>_<date>

Successfully tested on my fork; artifact includes MediaServer and related binaries.