### PR TITLE
修复 ffmpeg.snap 模板注入导致的命令执行

### DIFF
--- a/server/FFmpegSource.cpp
+++ b/server/FFmpegSource.cpp
@@ -449,36 +449,6 @@ static bool makeSnapAsync(const string &play_url, const string &save_path, float
 
 #endif
 
-static bool formatSnapCommand(const string &snap_template, const string &ffmpeg_bin, const string &play_url,
-                              const string &save_path, string &command) {
-    if (!start_with(snap_template, "%s")) {
-        return false;
-    }
-
-    const string *values[] = { &ffmpeg_bin, &play_url, &save_path };
-    size_t placeholder_count = 0;
-    command.clear();
-    command.reserve(snap_template.size() + ffmpeg_bin.size() + play_url.size() + save_path.size());
-    for (size_t i = 0; i < snap_template.size(); ++i) {
-        if (snap_template[i] != '%') {
-            command.push_back(snap_template[i]);
-            continue;
-        }
-        if (++i >= snap_template.size()) {
-            return false;
-        }
-        if (snap_template[i] == '%') {
-            command.push_back('%');
-            continue;
-        }
-        if (snap_template[i] != 's' || placeholder_count >= 3) {
-            return false;
-        }
-        command.append(*values[placeholder_count++]);
-    }
-    return placeholder_count == 3;
-}
-
 void FFmpegSnap::makeSnap(bool async, const string &play_url, const string &save_path, float timeout_sec, const onSnap &cb) {
 #if defined(ENABLE_FFMPEG)
     if (async) {
@@ -491,16 +461,8 @@ void FFmpegSnap::makeSnap(bool async, const string &play_url, const string &save
     GET_CONFIG(string, ffmpeg_bin, FFmpeg::kBin);
     GET_CONFIG(string, ffmpeg_snap, FFmpeg::kSnap);
     GET_CONFIG(string, ffmpeg_log, FFmpeg::kLog);
-    string cmd;
-    if (!formatSnapCommand(ffmpeg_snap, File::absolutePath("", ffmpeg_bin), play_url, save_path, cmd)) {
-        cb(false, "invalid ffmpeg snap template: expected exactly three '%s' placeholders and no other format specifiers");
-        return;
-    }
-    // Capture the formatted command and log path by value. GET_CONFIG returns
-    // references whose contents may change on a concurrent configuration reload.
-    auto log_file = ffmpeg_log.empty() ? ffmpeg_log : File::absolutePath("", ffmpeg_log);
     Ticker ticker;
-    WorkThreadPool::Instance().getPoller()->async([timeout_sec, save_path, cb, ticker, cmd, log_file]() {
+    WorkThreadPool::Instance().getPoller()->async([timeout_sec, play_url, save_path, cb, ticker]() {
         auto elapsed_ms = ticker.elapsedTime();
         if (elapsed_ms > timeout_sec * 1000) {
             // 超时，后台线程负载太高，当代太久才启动该任务  [AUTO-TRANSLATED:815606d6]
@@ -508,7 +470,11 @@ void FFmpegSnap::makeSnap(bool async, const string &play_url, const string &save
             cb(false, "wait work poller schedule snap task timeout");
             return;
         }
+        char cmd[2048] = { 0 };
+        snprintf(cmd, sizeof(cmd), ffmpeg_snap.data(), File::absolutePath("", ffmpeg_bin).data(), play_url.data(), save_path.data());
+
         std::shared_ptr<Process> process = std::make_shared<Process>();
+        auto log_file = ffmpeg_log.empty() ? ffmpeg_log : File::absolutePath("", ffmpeg_log);
         process->run(cmd, log_file);
 
         // 定时器延时应该减去后台任务启动的延时  [AUTO-TRANSLATED:7d224687]

--- a/server/FFmpegSource.cpp
+++ b/server/FFmpegSource.cpp
@@ -449,6 +449,36 @@ static bool makeSnapAsync(const string &play_url, const string &save_path, float
 
 #endif
 
+static bool formatSnapCommand(const string &snap_template, const string &ffmpeg_bin, const string &play_url,
+                              const string &save_path, string &command) {
+    if (!start_with(snap_template, "%s")) {
+        return false;
+    }
+
+    const string *values[] = { &ffmpeg_bin, &play_url, &save_path };
+    size_t placeholder_count = 0;
+    command.clear();
+    command.reserve(snap_template.size() + ffmpeg_bin.size() + play_url.size() + save_path.size());
+    for (size_t i = 0; i < snap_template.size(); ++i) {
+        if (snap_template[i] != '%') {
+            command.push_back(snap_template[i]);
+            continue;
+        }
+        if (++i >= snap_template.size()) {
+            return false;
+        }
+        if (snap_template[i] == '%') {
+            command.push_back('%');
+            continue;
+        }
+        if (snap_template[i] != 's' || placeholder_count >= 3) {
+            return false;
+        }
+        command.append(*values[placeholder_count++]);
+    }
+    return placeholder_count == 3;
+}
+
 void FFmpegSnap::makeSnap(bool async, const string &play_url, const string &save_path, float timeout_sec, const onSnap &cb) {
 #if defined(ENABLE_FFMPEG)
     if (async) {
@@ -461,35 +491,16 @@ void FFmpegSnap::makeSnap(bool async, const string &play_url, const string &save
     GET_CONFIG(string, ffmpeg_bin, FFmpeg::kBin);
     GET_CONFIG(string, ffmpeg_snap, FFmpeg::kSnap);
     GET_CONFIG(string, ffmpeg_log, FFmpeg::kLog);
-    // The template is passed to snprintf and the resulting command is executed.
-    // Only accept the documented three string placeholders, with the executable
-    // as the first argument. This also rejects dangerous format specifiers such
-    // as %n and prevents a configured template from selecting another program.
-    size_t placeholder_count = 0;
-    bool valid_template = start_with(ffmpeg_snap, "%s");
-    for (size_t i = 0; valid_template && i < ffmpeg_snap.size(); ++i) {
-        if (ffmpeg_snap[i] != '%') {
-            continue;
-        }
-        if (++i >= ffmpeg_snap.size()) {
-            valid_template = false;
-            break;
-        }
-        if (ffmpeg_snap[i] == '%') {
-            continue;
-        }
-        if (ffmpeg_snap[i] != 's') {
-            valid_template = false;
-            break;
-        }
-        ++placeholder_count;
-    }
-    if (!valid_template || placeholder_count != 3) {
+    string cmd;
+    if (!formatSnapCommand(ffmpeg_snap, File::absolutePath("", ffmpeg_bin), play_url, save_path, cmd)) {
         cb(false, "invalid ffmpeg snap template: expected exactly three '%s' placeholders and no other format specifiers");
         return;
     }
+    // Capture the formatted command and log path by value. GET_CONFIG returns
+    // references whose contents may change on a concurrent configuration reload.
+    auto log_file = ffmpeg_log.empty() ? ffmpeg_log : File::absolutePath("", ffmpeg_log);
     Ticker ticker;
-    WorkThreadPool::Instance().getPoller()->async([timeout_sec, play_url, save_path, cb, ticker]() {
+    WorkThreadPool::Instance().getPoller()->async([timeout_sec, save_path, cb, ticker, cmd, log_file]() {
         auto elapsed_ms = ticker.elapsedTime();
         if (elapsed_ms > timeout_sec * 1000) {
             // 超时，后台线程负载太高，当代太久才启动该任务  [AUTO-TRANSLATED:815606d6]
@@ -497,11 +508,7 @@ void FFmpegSnap::makeSnap(bool async, const string &play_url, const string &save
             cb(false, "wait work poller schedule snap task timeout");
             return;
         }
-        char cmd[2048] = { 0 };
-        snprintf(cmd, sizeof(cmd), ffmpeg_snap.data(), File::absolutePath("", ffmpeg_bin).data(), play_url.data(), save_path.data());
-
         std::shared_ptr<Process> process = std::make_shared<Process>();
-        auto log_file = ffmpeg_log.empty() ? ffmpeg_log : File::absolutePath("", ffmpeg_log);
         process->run(cmd, log_file);
 
         // 定时器延时应该减去后台任务启动的延时  [AUTO-TRANSLATED:7d224687]

--- a/server/FFmpegSource.cpp
+++ b/server/FFmpegSource.cpp
@@ -461,6 +461,33 @@ void FFmpegSnap::makeSnap(bool async, const string &play_url, const string &save
     GET_CONFIG(string, ffmpeg_bin, FFmpeg::kBin);
     GET_CONFIG(string, ffmpeg_snap, FFmpeg::kSnap);
     GET_CONFIG(string, ffmpeg_log, FFmpeg::kLog);
+    // The template is passed to snprintf and the resulting command is executed.
+    // Only accept the documented three string placeholders, with the executable
+    // as the first argument. This also rejects dangerous format specifiers such
+    // as %n and prevents a configured template from selecting another program.
+    size_t placeholder_count = 0;
+    bool valid_template = start_with(ffmpeg_snap, "%s");
+    for (size_t i = 0; valid_template && i < ffmpeg_snap.size(); ++i) {
+        if (ffmpeg_snap[i] != '%') {
+            continue;
+        }
+        if (++i >= ffmpeg_snap.size()) {
+            valid_template = false;
+            break;
+        }
+        if (ffmpeg_snap[i] == '%') {
+            continue;
+        }
+        if (ffmpeg_snap[i] != 's') {
+            valid_template = false;
+            break;
+        }
+        ++placeholder_count;
+    }
+    if (!valid_template || placeholder_count != 3) {
+        cb(false, "invalid ffmpeg snap template: expected exactly three '%s' placeholders and no other format specifiers");
+        return;
+    }
     Ticker ticker;
     WorkThreadPool::Instance().getPoller()->async([timeout_sec, play_url, save_path, cb, ticker]() {
         auto elapsed_ms = ticker.elapsedTime();

--- a/server/WebApi.cpp
+++ b/server/WebApi.cpp
@@ -888,8 +888,8 @@ void installWebApi() {
                 continue;
 #endif
             }
-            if (pr.first == FFmpeg::kBin) {
-                WarnL << "Configuration named " << FFmpeg::kBin << " is not allowed to be set by setServerConfig api.";
+            if (pr.first == FFmpeg::kBin || pr.first == FFmpeg::kSnap) {
+                WarnL << "Configuration named " << pr.first << " is not allowed to be set by setServerConfig api.";
                 continue;
             }
             if (ini[pr.first] == pr.second) {


### PR DESCRIPTION
注意:这个是codex自主修复, 不是我手动写的代码, 合并前请仔细验证

### Motivation
- 发现 `ffmpeg.snap` 可被 `setServerConfig` 修改并被直接作为 `snprintf` 格式串使用，攻击者可借此选择任意可执行文件从而触发远程命令执行（RCE），因此需要在代码层阻断可远程篡改入口并增加模板校验。 
- 本次变更目标是快速切断远程覆盖向量并加入纵深校验，作为短期补丁同时为后续移除格式化命令模板并改用参数数组的长期修复铺路。 

### Description
- 在 `server/FFmpegSource.cpp` 的 `FFmpegSnap::makeSnap` 中增加模板校验逻辑，要求模板以 `%s` 开头、恰好包含 3 个 `%s` 占位符且不包含其它格式说明符，否则通过回调返回错误并且不启动子进程。 
- 在 `server/WebApi.cpp` 的 `setServerConfig` 中将 `ffmpeg.snap` 加入不可通过 API 动态修改的黑名单（与已有的 `ffmpeg.bin` 限制保持一致），以切断远程通过 API 覆盖可执行程序的入口。 
- 对非法模板的处理改为：不构造/执行命令并通过 `onSnap` 回调返回明确错误信息，降低误用导致的未定义行为风险。 

### Testing
- 运行 `git diff --check` 检查代码风格和差异冲突，结果通过。 
- 进行了构建验证：`cmake -S . -B build -DENABLE_WEBRTC=OFF -DENABLE_TESTS=OFF -DCMAKE_BUILD_TYPE=Release` 且 `cmake --build build -j2` 完成并成功生成 `MediaServer` 可执行文件。 
- 提交已生成并验证工作区干净（`git status --short --branch`），构建过程无新增错误或未解决警告导致失败。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63e3fc74a08320865dbe10b93a14a2)