### PR TITLE
修复HTTP-TS 媒体帧超时

### DIFF
--- a/src/Http/HlsPlayer.cpp
+++ b/src/Http/HlsPlayer.cpp
@@ -396,6 +396,7 @@ void HlsDemuxer::pushTask(std::function<void()> task) {
 }
 
 bool HlsDemuxer::inputFrame(const Frame::Ptr &frame) {
+    ++_input_frame_count;
     // 为了避免track准备时间过长, 因此在没准备好之前, 直接消费掉所有的帧  [AUTO-TRANSLATED:72b35430]
     // To avoid the track preparation time being too long, all frames are directly consumed before it is ready
     // In order to avoid the track preparation time is too long, so before it is ready, all frames are consumed directly

--- a/src/Http/HlsPlayer.h
+++ b/src/Http/HlsPlayer.h
@@ -33,6 +33,9 @@ public:
     void addTrackCompleted() override { _delegate.addTrackCompleted(); }
     void resetTracks() override { ((MediaSink &)_delegate).resetTracks(); }
     std::vector<Track::Ptr> getTracks(bool ready = true) const override { return _delegate.getTracks(ready); }
+    // 返回已进入媒体消费链的 frame 数，用于 HTTP-TS 输入健康检查。
+    // Return the number of frames entering the media pipeline for HTTP-TS health checks.
+    uint64_t getInputFrameCount() const { return _input_frame_count; }
     void pushTask(std::function<void()> task);
 
 private:
@@ -47,6 +50,7 @@ private:
     toolkit::Timer::Ptr _timer;
     MediaSinkDelegate _delegate;
     std::deque<std::pair<int64_t, std::function<void()> > > _frame_cache;
+    uint64_t _input_frame_count = 0;
 };
 
 class HlsPlayer: public  HttpClientImp, public PlayerBase, public HlsParser {

--- a/src/Http/HttpClient.h
+++ b/src/Http/HttpClient.h
@@ -263,6 +263,10 @@ protected:
     virtual bool onRedirectUrl(const std::string &url, bool temporary) { return true; };
 
 protected:
+    // complete timeout 生效时，HTTP body timeout 按约定失效。
+    // HTTP body timeout is disabled while complete timeout is in effect.
+    size_t getEffectiveBodyTimeout() const { return _wait_complete_ms > 0 ? 0 : _wait_body_ms; }
+
     //// HttpRequestSplitter override ////
     ssize_t onRecvHeader(const char *data, size_t len) override;
     void onRecvContent(const char *data, size_t len) override;

--- a/src/Http/TsPlayer.cpp
+++ b/src/Http/TsPlayer.cpp
@@ -34,18 +34,21 @@ void TsPlayer::teardown() {
 }
 
 void TsPlayer::onResponseCompleted(const SockException &ex) {
+    auto complete_ex = ex;
     if (!_play_result) {
         _play_result = true;
         if (!ex && responseBodyTotalSize() == 0 && responseBodySize() == 0) {
             //if the server does not return any data, it is considered a failure
-            onShutdown(ex);
+            complete_ex = translateShutdownException(ex);
+            onShutdown(complete_ex);
         } else {
             onPlayResult(ex);
         }
     } else {
-        onShutdown(ex);
+        complete_ex = translateShutdownException(ex);
+        onShutdown(complete_ex);
     }
-    HttpTSPlayer::onResponseCompleted(ex);
+    HttpTSPlayer::onResponseCompleted(complete_ex);
 }
 
 void TsPlayer::onResponseBody(const char *buf, size_t size) {

--- a/src/Http/TsPlayer.h
+++ b/src/Http/TsPlayer.h
@@ -43,6 +43,9 @@ public:
 protected:
     void onResponseBody(const char *buf, size_t size) override;
     void onResponseCompleted(const toolkit::SockException &ex) override;
+    // 将 HTTP 完成状态转换为播放器最终的 shutdown 状态，确保所有完成回调语义一致。
+    // Convert the HTTP completion status to the final player shutdown status so all completion callbacks agree.
+    virtual toolkit::SockException translateShutdownException(const toolkit::SockException &ex) { return ex; }
 
 private:
     bool _play_result = true;

--- a/src/Http/TsPlayerImp.h
+++ b/src/Http/TsPlayerImp.h
@@ -31,6 +31,7 @@ private:
     //// TsPlayer override////
     void onResponseBody(const char *buf, size_t size) override;
     void onManager() override;
+    toolkit::SockException translateShutdownException(const toolkit::SockException &ex) override;
 
 private:
     //// PlayerBase override////

--- a/src/Http/TsPlayerImp.h
+++ b/src/Http/TsPlayerImp.h
@@ -13,8 +13,11 @@
 
 #include <unordered_set>
 #include "TsPlayer.h"
+#include "Util/TimeTicker.h"
 
 namespace mediakit {
+
+class HlsDemuxer;
 
 class TsPlayerImp : public PlayerImp<TsPlayer, PlayerBase>, private TrackListener {
 public:
@@ -27,6 +30,7 @@ public:
 private:
     //// TsPlayer override////
     void onResponseBody(const char *buf, size_t size) override;
+    void onManager() override;
 
 private:
     //// PlayerBase override////
@@ -40,8 +44,14 @@ private:
     void addTrackCompleted() override;
 
 private:
+    void resetMediaFrameCheck();
+
+private:
     DecoderImp::Ptr _decoder;
-    MediaSinkInterface::Ptr _demuxer;
+    std::shared_ptr<HlsDemuxer> _demuxer;
+    uint64_t _last_input_frame_count = 0;
+    toolkit::Ticker _media_frame_ticker;
+    bool _media_frame_timeout = false;
 };
 
 }//namespace mediakit

--- a/src/Http/TsplayerImp.cpp
+++ b/src/Http/TsplayerImp.cpp
@@ -30,6 +30,26 @@ void TsPlayerImp::onResponseBody(const char *data, size_t len) {
     }
 }
 
+void TsPlayerImp::onManager() {
+    HttpClientImp::onManager();
+    if (!waitResponse() || !_demuxer) {
+        return;
+    }
+
+    auto frame_count = _demuxer->getInputFrameCount();
+    if (frame_count != _last_input_frame_count) {
+        _last_input_frame_count = frame_count;
+        _media_frame_ticker.resetTime();
+        return;
+    }
+
+    auto timeout_ms = getEffectiveBodyTimeout();
+    if (timeout_ms > 0 && _media_frame_ticker.elapsedTime() > timeout_ms) {
+        _media_frame_timeout = true;
+        shutdown(SockException(Err_timeout, "http-ts media frame timeout"));
+    }
+}
+
 void TsPlayerImp::addTrackCompleted() {
     PlayerImp<TsPlayer, PlayerBase>::onPlayResult(SockException(Err_success, "play http-ts success"));
 }
@@ -42,13 +62,22 @@ void TsPlayerImp::onPlayResult(const SockException &ex) {
         auto demuxer = std::make_shared<HlsDemuxer>();
         demuxer->start(getPoller(), this);
         _demuxer = std::move(demuxer);
+        resetMediaFrameCheck();
     }
 }
 
 void TsPlayerImp::onShutdown(const SockException &ex) {
-    if (!ex) {
+    auto shutdown_ex = ex;
+    if (_media_frame_timeout) {
+        // 无 Content-Length 的 HTTP body 在已收到数据后会把断开归一化为成功，
+        // 因此需要在 player 层恢复本次主动触发的媒体超时语义。
+        // An HTTP body without Content-Length normalizes a close after data to success,
+        // so restore the media timeout explicitly triggered by this player.
+        _media_frame_timeout = false;
+        shutdown_ex.reset(Err_timeout, "http-ts media frame timeout");
+    } else if (!shutdown_ex) {
         // http-ts拉流，如果为eof正常断开，那么强制为异常状态
-        const_cast<SockException &>(ex).reset(Err_other, ex.what());
+        shutdown_ex.reset(Err_other, ex.what());
     }
     while (_demuxer) {
         try {
@@ -60,10 +89,10 @@ void TsPlayerImp::onShutdown(const SockException &ex) {
             }
             // 等待所有frame flush输出后，再触发onShutdown事件  [AUTO-TRANSLATED:93982eb3]
             // Wait for all frame flush output before triggering the onShutdown event
-            static_pointer_cast<HlsDemuxer>(_demuxer)->pushTask([weak_self, ex]() {
+            _demuxer->pushTask([weak_self, shutdown_ex]() {
                 if (auto strong_self = weak_self.lock()) {
                     strong_self->_demuxer = nullptr;
-                    strong_self->onShutdown(ex);
+                    strong_self->onShutdown(shutdown_ex);
                 }
             });
             return;
@@ -71,14 +100,19 @@ void TsPlayerImp::onShutdown(const SockException &ex) {
             break;
         }
     }
-    PlayerImp<TsPlayer, PlayerBase>::onShutdown(ex);
+    PlayerImp<TsPlayer, PlayerBase>::onShutdown(shutdown_ex);
+}
+
+void TsPlayerImp::resetMediaFrameCheck() {
+    _last_input_frame_count = _demuxer ? _demuxer->getInputFrameCount() : 0;
+    _media_frame_ticker.resetTime();
 }
 
 vector<Track::Ptr> TsPlayerImp::getTracks(bool ready) const {
     if (!_demuxer) {
         return vector<Track::Ptr>();
     }
-    return static_pointer_cast<HlsDemuxer>(_demuxer)->getTracks(ready);
+    return _demuxer->getTracks(ready);
 }
 
 size_t TsPlayerImp::getRecvSpeed() {

--- a/src/Http/TsplayerImp.cpp
+++ b/src/Http/TsplayerImp.cpp
@@ -67,6 +67,31 @@ void TsPlayerImp::onPlayResult(const SockException &ex) {
 }
 
 void TsPlayerImp::onShutdown(const SockException &ex) {
+    while (_demuxer) {
+        try {
+            // shared_from_this()可能抛异常  [AUTO-TRANSLATED:6af9bd3c]
+            // shared_from_this() may throw an exception
+            std::weak_ptr<TsPlayerImp> weak_self = static_pointer_cast<TsPlayerImp>(shared_from_this());
+            if (_decoder) {
+                _decoder->flush();
+            }
+            // 等待所有frame flush输出后，再触发onShutdown事件  [AUTO-TRANSLATED:93982eb3]
+            // Wait for all frame flush output before triggering the onShutdown event
+            _demuxer->pushTask([weak_self, ex]() {
+                if (auto strong_self = weak_self.lock()) {
+                    strong_self->_demuxer = nullptr;
+                    strong_self->onShutdown(ex);
+                }
+            });
+            return;
+        } catch (...) {
+            break;
+        }
+    }
+    PlayerImp<TsPlayer, PlayerBase>::onShutdown(ex);
+}
+
+SockException TsPlayerImp::translateShutdownException(const SockException &ex) {
     auto shutdown_ex = ex;
     if (_media_frame_timeout) {
         // 无 Content-Length 的 HTTP body 在已收到数据后会把断开归一化为成功，
@@ -79,28 +104,7 @@ void TsPlayerImp::onShutdown(const SockException &ex) {
         // http-ts拉流，如果为eof正常断开，那么强制为异常状态
         shutdown_ex.reset(Err_other, ex.what());
     }
-    while (_demuxer) {
-        try {
-            // shared_from_this()可能抛异常  [AUTO-TRANSLATED:6af9bd3c]
-            // shared_from_this() may throw an exception
-            std::weak_ptr<TsPlayerImp> weak_self = static_pointer_cast<TsPlayerImp>(shared_from_this());
-            if (_decoder) {
-                _decoder->flush();
-            }
-            // 等待所有frame flush输出后，再触发onShutdown事件  [AUTO-TRANSLATED:93982eb3]
-            // Wait for all frame flush output before triggering the onShutdown event
-            _demuxer->pushTask([weak_self, shutdown_ex]() {
-                if (auto strong_self = weak_self.lock()) {
-                    strong_self->_demuxer = nullptr;
-                    strong_self->onShutdown(shutdown_ex);
-                }
-            });
-            return;
-        } catch (...) {
-            break;
-        }
-    }
-    PlayerImp<TsPlayer, PlayerBase>::onShutdown(shutdown_ex);
+    return shutdown_ex;
 }
 
 void TsPlayerImp::resetMediaFrameCheck() {


### PR DESCRIPTION
这个修复是因为有时的可能由于上游网络flow损坏,会导致http-ts拉流时连接不会断开, 只有几kb的速度. 这样实际上流媒体是无法正常播放的, 但是又因为能读取到非常少的数据, 不会触发超时. 等于链接假死在那里了.常见与跨域/跨洲传输时.
所以这个pr就是用于判断如果媒体帧长时间接收不全, 就也应该认为是超时断开.

后面还会提交一个新的pr, 主要是配合这个pr实现"PlayerProxy 无感重连与 muxer 保留策略", 这样就能在遇到坏flow时, 自动重连, 但是播放器无感知, 也不会断开.


