### PR TITLE
支持 MPEG-1 Video 的 TS/PS 解复用与 RTP 打包

### DIFF
--- a/ext-codec/MP1V.cpp
+++ b/ext-codec/MP1V.cpp
@@ -1,0 +1,96 @@
+﻿/*
+ * Copyright (c) 2016-present The ZLMediaKit project authors. All Rights Reserved.
+ *
+ * This file is part of ZLMediaKit(https://github.com/ZLMediaKit/ZLMediaKit).
+ *
+ * Use of this source code is governed by MIT-like license that can be found in the
+ * LICENSE file in the root of the source tree. All contributing project authors
+ * may be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include "MP1V.h"
+#include "MP2VRtp.h"
+#include "Extension/Factory.h"
+
+using namespace std;
+using namespace toolkit;
+
+namespace mediakit {
+
+bool MP1VTrack::inputFrame(const Frame::Ptr &frame) {
+    if (!frame) {
+        return false;
+    }
+    auto size = frame->size();
+    auto prefix_size = frame->prefixSize();
+    auto data = frame->data();
+    if (!data || prefix_size > size) {
+        return false;
+    }
+    if (!_sequence_parser.parsed()
+        && _sequence_parser.input((const uint8_t *)data + prefix_size, size - prefix_size)) {
+        _width = _sequence_parser.width();
+        _height = _sequence_parser.height();
+        _fps = _sequence_parser.fps();
+    }
+    return VideoTrackImp::inputFrame(frame);
+}
+
+Sdp::Ptr MP1VTrack::getSdp(uint8_t pt) const {
+    // 当前只接通 TS/PS；静态 RTP PT 32 仍由 CodecMP2V 表示，不能在此伪装成完整 RTSP 支持。
+    // Only TS/PS is wired for now; static RTP PT 32 still maps to CodecMP2V.
+    return nullptr;
+}
+
+namespace {
+
+CodecId getCodec() {
+    return CodecMP1V;
+}
+
+Track::Ptr getTrackByCodecId(int sample_rate, int channels, int sample_bit) {
+    return std::make_shared<MP1VTrack>();
+}
+
+Track::Ptr getTrackBySdp(const SdpTrack::Ptr &track) {
+    WarnL << "Unsupported MP1V sdp track";
+    return nullptr;
+}
+
+RtpCodec::Ptr getRtpEncoderByCodecId(uint8_t pt) {
+    // RFC 2250 的 MPEG Video packetizer 同时适用于 MPEG-1/2。
+    // The RFC 2250 MPEG Video packetizer is shared by MPEG-1 and MPEG-2.
+    return std::make_shared<MP2VRtpEncoder>();
+}
+
+RtpCodec::Ptr getRtpDecoderByCodecId() {
+    WarnL << "Unsupported MP1V rtp decoder";
+    return nullptr;
+}
+
+RtmpCodec::Ptr getRtmpEncoderByTrack(const Track::Ptr &track) {
+    WarnL << "Unsupported MP1V rtmp encoder";
+    return nullptr;
+}
+
+RtmpCodec::Ptr getRtmpDecoderByTrack(const Track::Ptr &track) {
+    WarnL << "Unsupported MP1V rtmp decoder";
+    return nullptr;
+}
+
+Frame::Ptr getFrameFromPtr(const char *data, size_t bytes, uint64_t dts, uint64_t pts) {
+    return std::make_shared<MP1VFrameNoCacheAble>((char *)data, bytes, dts, pts, 0);
+}
+
+} // namespace
+
+CodecPlugin mp1v_plugin = { getCodec,
+                             getTrackByCodecId,
+                             getTrackBySdp,
+                             getRtpEncoderByCodecId,
+                             getRtpDecoderByCodecId,
+                             getRtmpEncoderByTrack,
+                             getRtmpDecoderByTrack,
+                             getFrameFromPtr };
+
+} // namespace mediakit

--- a/ext-codec/MP1V.h
+++ b/ext-codec/MP1V.h
@@ -1,0 +1,93 @@
+﻿/*
+ * Copyright (c) 2016-present The ZLMediaKit project authors. All Rights Reserved.
+ *
+ * This file is part of ZLMediaKit(https://github.com/ZLMediaKit/ZLMediaKit).
+ *
+ * Use of this source code is governed by MIT-like license that can be found in the
+ * LICENSE file in the root of the source tree. All contributing project authors
+ * may be found in the AUTHORS file in the root of the source tree.
+ */
+
+#ifndef ZLMEDIAKIT_MP1V_H
+#define ZLMEDIAKIT_MP1V_H
+
+#include "Extension/Frame.h"
+#include "Extension/Track.h"
+#include "MpegVideoSequence.h"
+
+namespace mediakit {
+
+/**
+ * MPEG-1 Video 帧辅助类模板
+ * MPEG-1 Video frame helper class template
+ */
+template <typename Parent>
+class MP1VFrameHelper : public Parent {
+public:
+    using Ptr = std::shared_ptr<MP1VFrameHelper>;
+
+    template <typename... ARGS>
+    MP1VFrameHelper(ARGS &&...args)
+        : Parent(std::forward<ARGS>(args)...) {
+        this->_codec_id = CodecMP1V;
+    }
+
+    /**
+     * MPEG-1 picture start code 为 00 00 01 00，picture_coding_type 为 1 时是 I-Picture。
+     * MPEG-1 uses 00 00 01 00 as picture start code; picture_coding_type 1 denotes an I-Picture.
+     */
+    bool keyFrame() const override {
+        auto size = this->size();
+        auto prefix_size = this->prefixSize();
+        auto data = this->data();
+        if (!data || prefix_size > size) {
+            return false;
+        }
+        return isMP1VKeyFrame((const uint8_t *)data + prefix_size, size - prefix_size);
+    }
+
+    bool configFrame() const override { return false; }
+
+    static bool isMP1VKeyFrame(const uint8_t *data, size_t size) {
+        if (!data) {
+            return false;
+        }
+        // 查找 picture start code，再读取 picture_coding_type；循环条件保证可读取到 i + 5。
+        // Locate the picture start code and read picture_coding_type; the loop bounds protect i + 5.
+        for (size_t i = 0; i + 5 < size; ++i) {
+            if (data[i] == 0x00 && data[i + 1] == 0x00 && data[i + 2] == 0x01 && data[i + 3] == 0x00) {
+                auto picture_coding_type = (data[i + 5] >> 3) & 0x07;
+                return picture_coding_type == 1;
+            }
+        }
+        return false;
+    }
+};
+
+using MP1VFrame = MP1VFrameHelper<FrameImp>;
+using MP1VFrameNoCacheAble = MP1VFrameHelper<FrameFromPtr>;
+
+/**
+ * MPEG-1 Video Track
+ */
+class MP1VTrack : public VideoTrackImp {
+public:
+    using Ptr = std::shared_ptr<MP1VTrack>;
+
+    MP1VTrack()
+        : VideoTrackImp(CodecMP1V, 0, 0, 0) {}
+
+    Track::Ptr clone() const override { return std::make_shared<MP1VTrack>(*this); }
+
+    bool inputFrame(const Frame::Ptr &frame) override;
+
+private:
+    Sdp::Ptr getSdp(uint8_t payload_type) const override;
+
+private:
+    MpegVideoSequenceParser _sequence_parser;
+};
+
+} // namespace mediakit
+
+#endif // ZLMEDIAKIT_MP1V_H

--- a/ext-codec/MP2V.cpp
+++ b/ext-codec/MP2V.cpp
@@ -18,46 +18,21 @@ using namespace toolkit;
 
 namespace mediakit {
 
-// MPEG-2 sequence header 帧率表 (ISO 13818-2 Table 6-4)
-// MPEG-2 sequence header frame rate table
-static const float s_mp2v_frame_rate_table[] = {
-    0,       // 0000 forbidden
-    24000.0 / 1001, // 0001 23.976
-    24.0,    // 0010
-    25.0,    // 0011
-    30000.0 / 1001, // 0100 29.97
-    30.0,    // 0101
-    50.0,    // 0110
-    60000.0 / 1001, // 0111 59.94
-    60.0,    // 1000
-};
-
-void MP2VTrack::parseSequenceHeader(const uint8_t *data, size_t size) {
-    // 查找 sequence header start code: 00 00 01 B3
-    // Look for sequence header start code: 00 00 01 B3
-    for (size_t i = 0; i + 7 < size; ++i) {
-        if (data[i] == 0x00 && data[i + 1] == 0x00 && data[i + 2] == 0x01 && data[i + 3] == 0xB3) {
-            // sequence_header() 结构:
-            // horizontal_size_value: 12 bits
-            // vertical_size_value: 12 bits
-            // aspect_ratio_information: 4 bits
-            // frame_rate_code: 4 bits
-            _width = (data[i + 4] << 4) | ((data[i + 5] >> 4) & 0x0F);
-            _height = ((data[i + 5] & 0x0F) << 8) | data[i + 6];
-            uint8_t frame_rate_code = data[i + 7] & 0x0F;
-            if (frame_rate_code > 0 && frame_rate_code <= 8) {
-                _fps = s_mp2v_frame_rate_table[frame_rate_code];
-            }
-            _seq_header_parsed = true;
-            return;
-        }
-    }
-}
-
 bool MP2VTrack::inputFrame(const Frame::Ptr &frame) {
-    if (!_seq_header_parsed) {
-        parseSequenceHeader((const uint8_t *)frame->data() + frame->prefixSize(),
-                            frame->size() - frame->prefixSize());
+    if (!frame) {
+        return false;
+    }
+    auto size = frame->size();
+    auto prefix_size = frame->prefixSize();
+    auto data = frame->data();
+    if (!data || prefix_size > size) {
+        return false;
+    }
+    if (!_sequence_parser.parsed()
+        && _sequence_parser.input((const uint8_t *)data + prefix_size, size - prefix_size)) {
+        _width = _sequence_parser.width();
+        _height = _sequence_parser.height();
+        _fps = _sequence_parser.fps();
     }
     return VideoTrackImp::inputFrame(frame);
 }

--- a/ext-codec/MP2V.h
+++ b/ext-codec/MP2V.h
@@ -13,6 +13,7 @@
 
 #include "Extension/Frame.h"
 #include "Extension/Track.h"
+#include "MpegVideoSequence.h"
 
 namespace mediakit {
 
@@ -40,14 +41,21 @@ public:
      * I-frame detection: picture_coding_type == 1 (I-Picture)
      */
     bool keyFrame() const override {
-        auto data = (const uint8_t *)this->data() + this->prefixSize();
-        auto size = this->size() - this->prefixSize();
-        return isMP2VKeyFrame(data, size);
+        auto size = this->size();
+        auto prefix_size = this->prefixSize();
+        auto data = this->data();
+        if (!data || prefix_size > size) {
+            return false;
+        }
+        return isMP2VKeyFrame((const uint8_t *)data + prefix_size, size - prefix_size);
     }
 
     bool configFrame() const override { return false; }
 
     static bool isMP2VKeyFrame(const uint8_t *data, size_t size) {
+        if (!data) {
+            return false;
+        }
         // 查找 picture start code (00 00 01 00)，然后检查 picture_coding_type
         // Look for picture start code (00 00 01 00), then check picture_coding_type
         for (size_t i = 0; i + 5 < size; ++i) {
@@ -82,14 +90,8 @@ public:
 private:
     Sdp::Ptr getSdp(uint8_t payload_type) const override;
 
-    /**
-     * 从 sequence header 中解析宽高和帧率
-     * Parse width, height and fps from sequence header
-     */
-    void parseSequenceHeader(const uint8_t *data, size_t size);
-
 private:
-    bool _seq_header_parsed = false;
+    MpegVideoSequenceParser _sequence_parser;
 };
 
 } // namespace mediakit

--- a/ext-codec/MP2VRtp.cpp
+++ b/ext-codec/MP2VRtp.cpp
@@ -223,8 +223,23 @@ void MP2VRtpEncoder::buildMpvHeader(uint8_t *buf, const uint8_t *data, size_t si
 }
 
 bool MP2VRtpEncoder::inputFrame(const Frame::Ptr &frame) {
-    auto ptr = (const uint8_t *)frame->data() + frame->prefixSize();
-    auto size = frame->size() - frame->prefixSize();
+    if (!frame) {
+        return false;
+    }
+    auto frame_size = frame->size();
+    auto prefix_size = frame->prefixSize();
+    auto data = frame->data();
+    if (!data || prefix_size > frame_size) {
+        return false;
+    }
+    auto rtp_payload_size = getRtpInfo().getMaxSize();
+    if (rtp_payload_size <= kMP2VHeaderSize) {
+        // RTP 负载必须同时容纳 MPEG Video 头和至少一个 ES 字节。
+        // The RTP payload must hold both the MPEG Video header and at least one ES byte.
+        return false;
+    }
+    auto ptr = (const uint8_t *)data + prefix_size;
+    auto size = frame_size - prefix_size;
     if (size == 0) {
         return false;
     }
@@ -233,7 +248,7 @@ bool MP2VRtpEncoder::inputFrame(const Frame::Ptr &frame) {
     parsePictureInfo(ptr, size);
 
     bool is_key = frame->keyFrame();
-    auto max_payload = getRtpInfo().getMaxSize() - kMP2VHeaderSize;
+    auto max_payload = rtp_payload_size - kMP2VHeaderSize;
     size_t offset = 0;
 
     while (offset < size) {

--- a/ext-codec/MpegVideoSequence.h
+++ b/ext-codec/MpegVideoSequence.h
@@ -1,0 +1,141 @@
+﻿/*
+ * Copyright (c) 2016-present The ZLMediaKit project authors. All Rights Reserved.
+ *
+ * This file is part of ZLMediaKit(https://github.com/ZLMediaKit/ZLMediaKit).
+ *
+ * Use of this source code is governed by MIT-like license that can be found in the
+ * LICENSE file in the root of the source tree. All contributing project authors
+ * may be found in the AUTHORS file in the root of the source tree.
+ */
+
+#ifndef ZLMEDIAKIT_MPEGVIDEOSEQUENCE_H
+#define ZLMEDIAKIT_MPEGVIDEOSEQUENCE_H
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace mediakit {
+
+/**
+ * MPEG-1/2 Video 公共 sequence header 流式解析器。
+ * Streaming parser for the common MPEG-1/2 Video sequence header.
+ *
+ * 解析器只保存起始码状态和 4 字节 header，允许合法 header 跨 Frame/PES。
+ * It retains only start-code state and four header bytes, allowing a valid header
+ * to span Frame/PES boundaries.
+ */
+class MpegVideoSequenceParser {
+public:
+    bool input(const uint8_t *data, size_t size) {
+        if (_parsed || !data) {
+            return _parsed;
+        }
+        for (size_t i = 0; i < size && !_parsed; ++i) {
+            inputByte(data[i]);
+        }
+        return _parsed;
+    }
+
+    bool parsed() const { return _parsed; }
+    int width() const { return _width; }
+    int height() const { return _height; }
+    float fps() const { return _fps; }
+
+private:
+    enum class State : uint8_t {
+        Searching,
+        StartCodeValue,
+        SequenceHeader
+    };
+
+    static float getFrameRate(uint8_t code) {
+        switch (code) {
+            case 1: return 24000.0f / 1001.0f;
+            case 2: return 24.0f;
+            case 3: return 25.0f;
+            case 4: return 30000.0f / 1001.0f;
+            case 5: return 30.0f;
+            case 6: return 50.0f;
+            case 7: return 60000.0f / 1001.0f;
+            case 8: return 60.0f;
+            default: return 0.0f;
+        }
+    }
+
+    void inputByte(uint8_t byte) {
+        switch (_state) {
+            case State::Searching: {
+                if (byte == 0x00) {
+                    if (_zero_count < 3) {
+                        ++_zero_count;
+                    }
+                    return;
+                }
+                if (byte == 0x01 && _zero_count >= 2) {
+                    _state = State::StartCodeValue;
+                    _zero_count = 0;
+                    return;
+                }
+                _zero_count = 0;
+                return;
+            }
+            case State::StartCodeValue: {
+                _state = State::Searching;
+                _zero_count = 0;
+                if (byte == 0xB3) {
+                    _state = State::SequenceHeader;
+                    _header_size = 0;
+                } else if (byte == 0x00) {
+                    _zero_count = 1;
+                }
+                return;
+            }
+            case State::SequenceHeader: {
+                _header[_header_size++] = byte;
+                if (_header_size == _header.size()) {
+                    parseHeader();
+                }
+                return;
+            }
+        }
+    }
+
+    void parseHeader() {
+        auto width = (_header[0] << 4) | ((_header[1] >> 4) & 0x0F);
+        auto height = ((_header[1] & 0x0F) << 8) | _header[2];
+        auto fps = getFrameRate(_header[3] & 0x0F);
+        if (width && height && fps > 0) {
+            _width = width;
+            _height = height;
+            _fps = fps;
+            _parsed = true;
+            return;
+        }
+
+        // 损坏的 header 可能同时包含下一个起始码，重新扫描这 4 字节避免丢失重叠匹配。
+        // A damaged header may contain the next start code; rescan these four bytes
+        // so an overlapping match is not lost.
+        auto header = _header;
+        _state = State::Searching;
+        _zero_count = 0;
+        _header_size = 0;
+        for (auto byte : header) {
+            inputByte(byte);
+        }
+    }
+
+private:
+    bool _parsed = false;
+    State _state = State::Searching;
+    uint8_t _zero_count = 0;
+    std::array<uint8_t, 4> _header = {{ 0 }};
+    size_t _header_size = 0;
+    int _width = 0;
+    int _height = 0;
+    float _fps = 0;
+};
+
+} // namespace mediakit
+
+#endif // ZLMEDIAKIT_MPEGVIDEOSEQUENCE_H

--- a/src/Extension/Factory.cpp
+++ b/src/Extension/Factory.cpp
@@ -35,6 +35,7 @@ REGISTER_CODEC(l16_plugin);
 REGISTER_CODEC(mp3_plugin);
 REGISTER_CODEC(mp2v_plugin);
 REGISTER_CODEC(mp2a_plugin);
+REGISTER_CODEC(mp1v_plugin);
 
 void Factory::registerPlugin(const CodecPlugin &plugin) {
     InfoL << "Load codec: " << getCodecName(plugin.getCodec());

--- a/src/Extension/Frame.h
+++ b/src/Extension/Frame.h
@@ -56,7 +56,8 @@ typedef enum {
     XX(CodecG728,  TrackAudio, 20, "G728", PSI_STREAM_RESERVED, MOV_OBJECT_NONE)     \
     XX(CodecG729,  TrackAudio, 21, "G729", PSI_STREAM_AUDIO_G729, MOV_OBJECT_NONE)   \
     XX(CodecMP2V,  TrackVideo, 22, "MPV", PSI_STREAM_MPEG2, MOV_OBJECT_MP2V)         \
-    XX(CodecMP2A,  TrackAudio, 23, "MPA", PSI_STREAM_AUDIO_MPEG1, MOV_OBJECT_MP3)
+    XX(CodecMP2A,  TrackAudio, 23, "MPA", PSI_STREAM_AUDIO_MPEG1, MOV_OBJECT_MP3)    \
+    XX(CodecMP1V,  TrackVideo, 24, "MP1V", PSI_STREAM_MPEG1, MOV_OBJECT_NONE)
 
 typedef enum {
     CodecInvalid = -1,


### PR DESCRIPTION
  - 新增 MPEG-1 Video 编码类型、Track 和插件注册，支持从 TS/PS 中正确识别并处理 MPEG-1 Video。
  - 支持解析 MPEG-1 Video 的分辨率、帧率和 I 帧。
  - MPEG-1/2 共用流式 Sequence Header 解析器，支持 Header 跨 Frame/PES 的情况。
  - MPEG-1 Video 复用现有的 RFC 2250 RTP 打包实现。
  - 补充 MPEG-2 Video 帧数据、前缀长度和 RTP MTU 的输入边界检查。

这里主要是老陈的libmpeg中MPEG-1/2 缺少访问单元分帧导致的通用边界缺陷, 所以需要修复. 
但是问题并没有完全解决, 如果picture header 跨 PES, 那么Track可能永远无法就绪.

稍后会向老陈那提交pr, 如果能合并, 那么当前的逻辑可以减少一部分, 正确的边界应该是再libmpeg中处理这些, 而不是再zlm中处理