### PR TITLE
Fix whep/whip 注销失败问题

### DIFF
--- a/webrtc/WebRtcClient.cpp
+++ b/webrtc/WebRtcClient.cpp
@@ -155,6 +155,7 @@ void WebRtcClient::doNegotiateWhepOrWhip() {
     _negotiate = make_shared<HttpRequester>();
     _negotiate->setMethod("POST");
     _negotiate->addHeader("Content-Type", "application/sdp");
+    _negotiate->setRequestKeepAlive(false);
     _negotiate->setBody(std::move(offer_sdp));
     _negotiate->startRequester(_url._negotiate_url, [weak_self](const toolkit::SockException &ex, const Parser &response) {
         auto strong_self = weak_self.lock();
@@ -267,23 +268,21 @@ void WebRtcClient::doBye() {
     if (!_is_negotiate_finished) {
         return;
     }
+    _is_negotiate_finished = false;
 
     switch (_url._signaling_protocols) {
         case WebRtcTransport::SignalingProtocols::WHEP_WHIP: return doByeWhepOrWhip();
         case WebRtcTransport::SignalingProtocols::WEBSOCKET: return checkOut();
         default: throw std::invalid_argument(StrPrinter << "not support signaling_protocols: " << (int)_url._signaling_protocols);
     }
-    _is_negotiate_finished = false;
 }
 
 void WebRtcClient::doByeWhepOrWhip() {
     DebugL;
-    if (!_negotiate) {
-        return;
-    }
-    _negotiate->setMethod("DELETE");
-    _negotiate->setBody("");
-    _negotiate->startRequester(_url._delete_url, [](const toolkit::SockException &ex, const Parser &response) {
+    auto requester = make_shared<HttpRequester>();
+    requester->setMethod("DELETE");
+    requester->setRequestKeepAlive(false);
+    requester->startRequester(_url._delete_url, [requester](const toolkit::SockException &ex, const Parser &response) {
         if (ex) {
             WarnL << "network err:" << ex;
             return;

--- a/webrtc/WebRtcClient.cpp
+++ b/webrtc/WebRtcClient.cpp
@@ -151,17 +151,16 @@ void WebRtcClient::doNegotiateWhepOrWhip() {
     auto offer_sdp = _transport->createOfferSdp();
     DebugL << "send offer:\n" << offer_sdp;
 
-    _negotiate = make_shared<HttpRequester>();
-    _negotiate->setMethod("POST");
-    _negotiate->addHeader("Content-Type", "application/sdp");
-    _negotiate->setRequestKeepAlive(false);
-    _negotiate->setBody(std::move(offer_sdp));
-    _negotiate->startRequester(_url._negotiate_url, [weak_self](const toolkit::SockException &ex, const Parser &response) {
+    auto requester = make_shared<HttpRequester>();
+    requester->setMethod("POST");
+    requester->addHeader("Content-Type", "application/sdp");
+    requester->setRequestKeepAlive(false);
+    requester->setBody(std::move(offer_sdp));
+    requester->startRequester(_url._negotiate_url, [weak_self, requester](const toolkit::SockException &ex, const Parser &response) {
         auto strong_self = weak_self.lock();
         if (!strong_self) {
             return;
         }
-        strong_self->_negotiate = nullptr;
         if (ex) {
             WarnL << "network err:" << ex;
             strong_self->onResult(ex);
@@ -279,10 +278,10 @@ void WebRtcClient::doBye() {
 
 void WebRtcClient::doByeWhepOrWhip() {
     DebugL;
-    _negotiate = make_shared<HttpRequester>();
-    _negotiate->setMethod("DELETE");
-    _negotiate->setRequestKeepAlive(false);
-    _negotiate->startRequester(_url._delete_url, [](const toolkit::SockException &ex, const Parser &response) {
+    auto requester = make_shared<HttpRequester>();
+    requester->setMethod("DELETE");
+    requester->setRequestKeepAlive(false);
+    requester->startRequester(_url._delete_url, [requester](const toolkit::SockException &ex, const Parser &response) {
         if (ex) {
             WarnL << "network err:" << ex;
             return;

--- a/webrtc/WebRtcClient.cpp
+++ b/webrtc/WebRtcClient.cpp
@@ -8,7 +8,6 @@
  * may be found in the AUTHORS file in the root of the source tree.
  */
 
-#include "Network/TcpClient.h"
 #include "Common/config.h"
 #include "Common/Parser.h"
 #include "WebRtcClient.h"
@@ -152,12 +151,13 @@ void WebRtcClient::doNegotiateWhepOrWhip() {
     auto offer_sdp = _transport->createOfferSdp();
     DebugL << "send offer:\n" << offer_sdp;
 
-    _negotiate = make_shared<HttpRequester>();
-    _negotiate->setMethod("POST");
-    _negotiate->addHeader("Content-Type", "application/sdp");
-    _negotiate->setRequestKeepAlive(false);
-    _negotiate->setBody(std::move(offer_sdp));
-    _negotiate->startRequester(_url._negotiate_url, [weak_self](const toolkit::SockException &ex, const Parser &response) {
+    auto requester = make_shared<HttpRequester>();
+    requester->setMethod("POST");
+    requester->addHeader("Content-Type", "application/sdp");
+    requester->setRequestKeepAlive(false);
+    requester->setBody(std::move(offer_sdp));
+    requester->startRequester(_url._negotiate_url, [weak_self, requester](const toolkit::SockException &ex, const Parser &response) {
+        (void)requester;
         auto strong_self = weak_self.lock();
         if (!strong_self) {
             return;
@@ -283,6 +283,7 @@ void WebRtcClient::doByeWhepOrWhip() {
     requester->setMethod("DELETE");
     requester->setRequestKeepAlive(false);
     requester->startRequester(_url._delete_url, [requester](const toolkit::SockException &ex, const Parser &response) {
+        (void)requester;
         if (ex) {
             WarnL << "network err:" << ex;
             return;

--- a/webrtc/WebRtcClient.cpp
+++ b/webrtc/WebRtcClient.cpp
@@ -151,17 +151,17 @@ void WebRtcClient::doNegotiateWhepOrWhip() {
     auto offer_sdp = _transport->createOfferSdp();
     DebugL << "send offer:\n" << offer_sdp;
 
-    auto requester = make_shared<HttpRequester>();
-    requester->setMethod("POST");
-    requester->addHeader("Content-Type", "application/sdp");
-    requester->setRequestKeepAlive(false);
-    requester->setBody(std::move(offer_sdp));
-    requester->startRequester(_url._negotiate_url, [weak_self, requester](const toolkit::SockException &ex, const Parser &response) {
-        (void)requester;
+    _negotiate = make_shared<HttpRequester>();
+    _negotiate->setMethod("POST");
+    _negotiate->addHeader("Content-Type", "application/sdp");
+    _negotiate->setRequestKeepAlive(false);
+    _negotiate->setBody(std::move(offer_sdp));
+    _negotiate->startRequester(_url._negotiate_url, [weak_self](const toolkit::SockException &ex, const Parser &response) {
         auto strong_self = weak_self.lock();
         if (!strong_self) {
             return;
         }
+        strong_self->_negotiate = nullptr;
         if (ex) {
             WarnL << "network err:" << ex;
             strong_self->onResult(ex);
@@ -279,11 +279,10 @@ void WebRtcClient::doBye() {
 
 void WebRtcClient::doByeWhepOrWhip() {
     DebugL;
-    auto requester = make_shared<HttpRequester>();
-    requester->setMethod("DELETE");
-    requester->setRequestKeepAlive(false);
-    requester->startRequester(_url._delete_url, [requester](const toolkit::SockException &ex, const Parser &response) {
-        (void)requester;
+    _negotiate = make_shared<HttpRequester>();
+    _negotiate->setMethod("DELETE");
+    _negotiate->setRequestKeepAlive(false);
+    _negotiate->startRequester(_url._delete_url, [](const toolkit::SockException &ex, const Parser &response) {
         if (ex) {
             WarnL << "network err:" << ex;
             return;

--- a/webrtc/WebRtcClient.h
+++ b/webrtc/WebRtcClient.h
@@ -81,6 +81,7 @@ protected:
 
     // for _negotiate_sdp
     WebRTCUrl _url;
+    HttpRequester::Ptr _negotiate = nullptr;
     WebRtcSignalingPeer::Ptr _peer = nullptr;
     WebRtcTransport::Ptr _transport = nullptr;
     bool _is_negotiate_finished = false;

--- a/webrtc/WebRtcClient.h
+++ b/webrtc/WebRtcClient.h
@@ -81,7 +81,6 @@ protected:
 
     // for _negotiate_sdp
     WebRTCUrl _url;
-    HttpRequester::Ptr _negotiate = nullptr;
     WebRtcSignalingPeer::Ptr _peer = nullptr;
     WebRtcTransport::Ptr _transport = nullptr;
     bool _is_negotiate_finished = false;


### PR DESCRIPTION
- delete_webrtc时，不应该使用whep/whip开始协商时的HttpRequester，可能已经keepalive过期失效
- 修复_is_negotiate_finished=false赋值一行不生效的bug（重复发delete_webrtc）