### PR TITLE
fix h264 rtp SEI mark=1以及sps/pps顺序问题

### DIFF
--- a/ext-codec/H264Rtp.cpp
+++ b/ext-codec/H264Rtp.cpp
@@ -230,6 +230,10 @@ void H264RtpEncoder::insertConfigFrame(uint64_t pts){
     // The gop cache starts from sps, sps, pps and then there are key frames with the same timestamp, so the mark bit is false
     packRtp(_sps->data() + _sps->prefixSize(), _sps->size() - _sps->prefixSize(), pts, false, true);
     packRtp(_pps->data() + _pps->prefixSize(), _pps->size() - _pps->prefixSize(), pts, false, false);
+    if (_sei) {
+        packRtp(_sei->data() + _sei->prefixSize(), _sei->size() - _sei->prefixSize(), pts, false, false);
+        _sei = nullptr;
+    }
 }
 
 void H264RtpEncoder::packRtp(const char *ptr, size_t len, uint64_t pts, bool is_mark, bool gop_pos){
@@ -332,6 +336,11 @@ bool H264RtpEncoder::inputFrame(const Frame::Ptr &frame) {
             _pps = Frame::getCacheAbleFrame(frame);
             return true;
         }
+        case H264Frame::NAL_SEI: {
+            _sei = Frame::getCacheAbleFrame(frame);
+            return true;
+        }
+        case H264Frame::NAL_AUD: return false;
         default: break;
     }
 

--- a/ext-codec/H264Rtp.h
+++ b/ext-codec/H264Rtp.h
@@ -105,6 +105,7 @@ private:
 private:
     Frame::Ptr _sps;
     Frame::Ptr _pps;
+    Frame::Ptr _sei;
     Frame::Ptr _last_frame;
 };
 


### PR DESCRIPTION
出现异常rtp:
SEI(mark=1) -> SPS(mark=0) -> PPS(mark=0)  -> IDR

修正为:
SPS(mark=0) -> PPS(mark=0) -> SEI(mark=0) -> IDR

异常截图:
<img width="1674" height="346" alt="Image" src="https://github.com/user-attachments/assets/847a00a8-c5a9-46da-8934-cd9ef5632240" />