### PR TITLE
fix(rtsp): 保留 Content-Base 末尾斜杠，适配严格匹配的 RTSP 服务器

### DIFF
--- a/src/Rtsp/Rtsp.cpp
+++ b/src/Rtsp/Rtsp.cpp
@@ -135,6 +135,12 @@ string SdpTrack::getControlUrl(const string &base_url) const {
         // Starts with rtsp://
         return _control;
     }
+    // base_url 已以 '/' 结尾时不再追加分隔符，避免拼接出双斜杠，同时保留多个末尾斜杠的路径语义
+    // When base_url ends with '/', avoid appending an extra separator to prevent double slash,
+    // while preserving the path semantics of multiple trailing slashes
+    if (!base_url.empty() && base_url.back() == '/') {
+        return base_url + _control;
+    }
     return base_url + "/" + _control;
 }
 

--- a/src/Rtsp/RtspPlayer.cpp
+++ b/src/Rtsp/RtspPlayer.cpp
@@ -210,9 +210,12 @@ void RtspPlayer::handleResDESCRIBE(const Parser &parser) {
     if (_content_base.empty()) {
         _content_base = _play_url;
     }
-    if (_content_base.back() == '/') {
-        _content_base.pop_back();
-    }
+    // 保留 Content-Base 末尾斜杠:部分 rtsp 服务器(如 Alltech)对 PLAY 等请求 URL 做精确匹配,
+    // 需要发送与 Content-Base 完全一致的 URL(含末尾斜杠),否则返回 404 或断开连接
+    // SETUP 拼接 track 时由 SdpTrack::getControlUrl 去掉重复斜杠
+    // Keep trailing slash in Content-Base: some RTSP servers (e.g. Alltech) match request URLs exactly,
+    // the PLAY URL must match Content-Base verbatim (including trailing slash), otherwise 404 or disconnect.
+    // Duplicate slashes in SETUP are prevented by SdpTrack::getControlUrl
 
     // 解析sdp  [AUTO-TRANSLATED:ed3f07fe]
     // Parse SDP
@@ -488,6 +491,8 @@ void RtspPlayer::sendPause(int type, uint32_t seekMS) {
     // Start or pause RTSP
     switch (type) {
         case type_pause: sendRtspRequest("PAUSE", _control_url, {}); break;
+        // _content_base 已保留 Content-Base 末尾斜杠,PLAY 直接使用即可
+        // _content_base retains the trailing slash from Content-Base, use it directly for PLAY
         case type_play: sendRtspRequest("PLAY", _content_base); break;
         case type_seek: {
             std::string range_header;


### PR DESCRIPTION
---

## 标题

```
fix(rtsp): 保留 Content-Base 末尾斜杠，适配严格匹配的 RTSP 服务器
```

## 描述

```markdown
## 问题描述

使用 `addStreamProxy` 拉流地址形如 `rtsp://<ip>/live` 时（注意 URL 末尾无斜杠），
部分 RTSP 服务器（例如 Alltech streaming server）会在 DESCRIBE 响应中返回
**带末尾斜杠**的 `Content-Base`：

```
Content-Base: rtsp://192.168.16.108:8554/live/
```

这类服务器对后续 PLAY 请求的 URL 做**精确字符串匹配**。

ZLMediaKit 原实现会去掉 `_content_base` 末尾的 `/`，随后发送无斜杠的 PLAY 请求：

```
PLAY rtsp://192.168.16.108:8554/live RTSP/1.0
```

服务器匹配失败，返回 `404 Stream Not Found`。

## 现象佐证

- 用 VLC 直接播放同一个 `rtsp://<ip>/live` 源**可以正常播放**，说明源本身正常；
- 用 VLC 播放经 ZLM 转出的流同样失败，说明问题出在 ZLM 拉流环节的 URL 处理；
- 日志中明确出现 `404 Stream Not Found`。

## 根因

`RtspPlayer::handleResDESCRIBE` 中以下代码去掉了 `_content_base` 的末尾斜杠：

```cpp
if (_content_base.back() == '/') {
    _content_base.pop_back();
}
```

导致 PLAY 请求使用与 `Content-Base` 不一致、去掉斜杠后的 URL。

## 修复内容

1. `src/Rtsp/RtspPlayer.cpp`
   - 移除去掉 `_content_base` 末尾斜杠的 `pop_back` 逻辑，保留 `Content-Base` 原始内容（含末尾斜杠），
     使 PLAY 请求发送与服务器 `Content-Base` 完全一致的 URL。

2. `src/Rtsp/Rtsp.cpp`
   - `SdpTrack::getControlUrl` 在拼接前先去除 `base_url` 末尾斜杠，
     避免 `_content_base` 带斜杠时 SETUP 的 track URL 被错误拼接为 `rtsp://<ip>/live//<track>` 这样的双斜杠。

## 影响范围

- 对返回不带末尾斜杠 `Content-Base` 的标准服务器：行为完全不变（原 `pop_back` 仅在末尾有 `/` 时生效）。
- 对返回带末尾斜杠 `Content-Base` 的服务器：由"去斜杠"改为"保留原始斜杠"，修复 404 问题。

## 测试

- 环境：拉流 `rtsp://192.168.16.108:8554/live`（Content-Base 带末尾斜杠）。
- 修复前：PLAY 请求报 `404 Stream Not Found`，无法拉流。
- 修复后：拉流成功，RTSP 可正常播放。

---

## 提交说明（可选，供参考）

- [x] 已本地编译通过
- [x] 已在目标服务器验证可正常拉流
```

---