### PR TITLE
fix: discard invalid RTP packets

### DIFF
--- a/src/Rtsp/RtpReceiver.cpp
+++ b/src/Rtsp/RtpReceiver.cpp
@@ -45,7 +45,8 @@ RtpPacket::Ptr RtpTrack::inputRtp(TrackType type, int sample_rate, uint8_t *ptr,
     }
     RtpHeader *header = (RtpHeader *) ptr;
     if (header->version != RtpPacket::kRtpVersion) {
-        throw BadRtpException("invalid rtp version");
+        WarnL << "invalid rtp version:" << (int) header->version;
+        return nullptr;
     }
     if (header->getPayloadSize(len) < 0) {
         // rtp有效负载小于0，非法  [AUTO-TRANSLATED:07eb3ec3]


### PR DESCRIPTION
## 问题

部分海康 RTSP 流的首个 RTP 包使用 version 1。当前 `inputRtp` 对 version 非法的 RTP 包抛出异常。

## 修改

- 对 version 非法的 RTP 包记录警告日志并返回 `nullptr` 丢弃。
- RTP 头长度不足和 payload 长度非法时仍抛出 `BadRtpException`，保留 RTP-over-TCP 的重同步机制。
- 保持后续合法 RTP 包的处理逻辑不变。